### PR TITLE
This commit introduces debug assertions and print statements to help …

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -344,6 +344,22 @@ fn pivot_and_reconcile_tile(
     reconciled_snp_start_idx: usize,
     chunk_bed_row_offset: usize,
 ) {
+    #[cfg(debug_assertions)]
+    {
+        // compute the pointer and length once
+        let ptr = tile.as_ptr() as usize;
+        let slice_len = snp_major_data.len();
+        debug_assert!(
+            ptr % bytes_per_snp as usize == 0,
+            "pivot: slice ptr {:#x} not aligned to bytes_per_snp {}",
+            ptr,
+            bytes_per_snp
+        );
+        eprintln!(
+            "[DBG] pivot_and_reconcile_tile: num_people_in_block={} snps_in_chunk={} slice.len={} bytes_per_snp={}",
+            num_people_in_block, snps_in_chunk, slice_len, bytes_per_snp
+        );
+    }
     // The number of SNPs in this chunk is the length of the tile row.
     let num_people_in_block = person_indices_in_block.len();
     let snps_in_chunk = if num_people_in_block > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,6 +235,21 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 Ok((_, _, 0, _)) => break,
                 Ok((new_reader, buffer, bytes_read, snps_in_chunk)) => {
                     reader = new_reader;
+                    #[cfg(debug_assertions)]
+                    {
+                        let bps = reader.bytes_per_snp() as usize;
+                        // if this ever trips in debug, you know you mis-aligned
+                        debug_assert!(
+                            bytes_read % bps == 0,
+                            "read_chunk: {} bytes_read is not a multiple of bytes_per_snp ({})",
+                            bytes_read, bps
+                        );
+                        // a bit more context, if you like:
+                        eprintln!(
+                            "[DBG] chunk_offset={} bytes_read={} snps_in_chunk={} bytes_per_snp={}",
+                            reader.cursor - bytes_read as u64, bytes_read, snps_in_chunk, bps
+                        );
+                    }
                     if full_buffer_tx
                         .send(IoMessage {
                             buffer,


### PR DESCRIPTION
…validate I/O buffer alignment and pivot tile alignment.

The changes are as follows:

- In `src/main.rs`, within the I/O producer task, a debug block now checks if `bytes_read` is a multiple of `bytes_per_snp` and prints relevant information.
- In `src/batch.rs`, at the beginning of the `pivot_and_reconcile_tile` function, a debug block now asserts that the tile's pointer is aligned to `bytes_per_snp` and prints information about the tile and its alignment.

These additions are guarded by `#[cfg(debug_assertions)]`, ensuring they have no performance impact in release builds.