### PR TITLE
Fix(batch): Correct scope for debug print variables

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -353,6 +353,23 @@ fn pivot_and_reconcile_tile(
     };
     let bytes_per_snp = (prep_result.total_people_in_fam as u64 + 3) / 4;
 
+    #[cfg(debug_assertions)]
+    {
+        // compute the pointer and length once
+        let ptr = tile.as_ptr() as usize;
+        let slice_len = snp_major_data.len();
+        debug_assert!(
+            ptr % bytes_per_snp as usize == 0,
+            "pivot: slice ptr {:#x} not aligned to bytes_per_snp {}",
+            ptr,
+            bytes_per_snp
+        );
+        eprintln!(
+            "[DBG] pivot_and_reconcile_tile: num_people_in_block={} snps_in_chunk={} slice.len={} bytes_per_snp={}",
+            num_people_in_block, snps_in_chunk, slice_len, bytes_per_snp
+        );
+    }
+
     let two_splat = U8xN::splat(2);
     let missing_sentinel_splat = U8xN::splat(3);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,6 +235,21 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 Ok((_, _, 0, _)) => break,
                 Ok((new_reader, buffer, bytes_read, snps_in_chunk)) => {
                     reader = new_reader;
+                    #[cfg(debug_assertions)]
+                    {
+                        let bps = reader.bytes_per_snp() as usize;
+                        // if this ever trips in debug, you know you mis-aligned
+                        debug_assert!(
+                            bytes_read % bps == 0,
+                            "read_chunk: {} bytes_read is not a multiple of bytes_per_snp ({})",
+                            bytes_read, bps
+                        );
+                        // a bit more context, if you like:
+                        eprintln!(
+                            "[DBG] chunk_offset={} bytes_read={} snps_in_chunk={} bytes_per_snp={}",
+                            reader.cursor - bytes_read as u64, bytes_read, snps_in_chunk, bps
+                        );
+                    }
                     if full_buffer_tx
                         .send(IoMessage {
                             buffer,


### PR DESCRIPTION
This commit fixes a bug in the previous commit where the debug print statements in `src/batch.rs` were added before the necessary variables (`bytes_per_snp`, `num_people_in_block`, and `snps_in_chunk`) were defined.

The debug print block has been moved to after these variable definitions to ensure they are in scope.

The debug assertions and print statements help validate I/O buffer alignment and pivot tile alignment:

- In `src/main.rs`, a debug block now checks if `bytes_read` is a multiple of `bytes_per_snp` and prints relevant information.
- In `src/batch.rs`, at the beginning of the `pivot_and_reconcile_tile` function, after relevant variables are defined, a debug block now asserts that the tile's pointer is aligned to `bytes_per_snp` and prints information about the tile and its alignment.

These additions are guarded by `#[cfg(debug_assertions)]`, ensuring they have no performance impact in release builds.