### PR TITLE
Add debug assertions for chunk processing and genotype data

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -326,6 +326,27 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
         let mut partial_scores_buffer = partial_scores_pool_clone.pop().unwrap();
 
+#[cfg(debug_assertions)]
+{
+    eprintln!(
+        "[debug] CHUNK ➤ offset={} bytes={} snps_in_chunk={} \
+         recon_range=[{}..{}) ({} snps) \
+         weights=[{}..{})({} floats) \
+         partial_scores_buf.len={} people_to_score={} scores_per_person={}",
+        bed_row_offset,
+        bytes_read,
+        snps_in_chunk,
+        reconciled_indices_start,
+        reconciled_indices_end,
+        num_reconciled_in_chunk,
+        weights_start,
+        weights_end,
+        weights_end - weights_start,
+        partial_scores_buffer.len(),
+        prep_clone.num_people_to_score,
+        prep_clone.score_names.len(),
+    );
+}
         // Dispatch the computation. We pass the raw buffer slice as before, but now also
         // include the specific sub-problem parameters for the compute engine.
         let compute_handle = task::spawn_blocking(move || {


### PR DESCRIPTION
This commit introduces two sets of debug logging capabilities to aid in diagnosing data processing issues:

1. Chunk-level snapshot in `main.rs`:
   - An `eprintln!` macro has been added before spawning the compute task.
   - It logs key information about each chunk, including offsets, byte counts, SNP counts, reconciled index ranges, weight array slices, and buffer sizes.
   - This log is prefixed with `[debug]` and is only compiled when `debug_assertions` are enabled, ensuring no performance impact in release builds.

2. Genotype data probes in `src/batch.rs`:
   - Added `use std::sync::atomic::{AtomicBool, Ordering};` for thread-safe one-time printing.
   - Probe #1 (Genotype Unpacking Trace):
     - Located in `pivot_and_reconcile_tile` after `initial_dosages` calculation.
     - Traces the unpacking of the first genotype processed by any thread, showing packed byte, bit shift, isolated 2-bit genotype, intermediate terms, and initial dosage. - Prefixed with `[debug]` and conditional on `debug_assertions`. Uses `AtomicBool` to print only once per execution.
   - Probe #2 (Kernel Input Summary): - Located in `process_tile` before calling `kernel::accumulate_scores_for_person`. - Summarizes `g1_indices` and `g2_indices` lengths for the first person processed by any thread, showing the number of SNPs with dosage 1 and 2. - Prefixed with `[debug]` and conditional on `debug_assertions`. Uses `AtomicBool` to print only once per execution.

These probes provide detailed, zero-cost (in release) insights into critical stages of the data pipeline.