### PR TITLE
Fix: Add missing 'score' subcommand to gnomon calls in test scripts

### DIFF
--- a/test/bench.py
+++ b/test/bench.py
@@ -547,7 +547,8 @@ def main():
                 shutil.move(str(sf_path), str(new_path))
                 moved_gnomon_score_files.append(new_path)
             
-            gnomon_cmd = [gnomon_abs_path, "--score", gnomon_score_dir.name, data_prefix.name]
+            # The 'score' subcommand is added here.
+            gnomon_cmd = [gnomon_abs_path, "score", "--score", gnomon_score_dir.name, data_prefix.name]
             if keep_file_path:
                 gnomon_cmd.extend(["--keep", keep_file_path.name])
             gnomon_res = run_and_monitor_process("gnomon", gnomon_cmd, WORKDIR)

--- a/test/perf.py
+++ b/test/perf.py
@@ -283,8 +283,9 @@ def main():
             for sf_path in score_files:
                 shutil.move(str(sf_path), score_dir)
 
+            # The 'score' subcommand is added here as a string.
             command_str = (f'echo "--- Running workload: {name} on {PROFILING_SUBSET_PCT:.0%} subset ---" && '
-                           f'"{GNOMON_BINARY}" --score "{score_dir}" --keep "{keep_file_path}" "{data_prefix}"')
+                           f'"{GNOMON_BINARY}" score --score "{score_dir}" --keep "{keep_file_path}" "{data_prefix}"')
             commands_to_profile.append(command_str)
 
         runner_script_path = WORKDIR / "run_all_workloads.sh"

--- a/test/sim_test.py
+++ b/test/sim_test.py
@@ -336,7 +336,7 @@ def run_simple_dosage_test(workdir: Path, gnomon_path: Path, plink_path: Path, p
     _write_score_file(score_file, score_df)
 
     # --- Run all tools ---
-    gnomon_res = run_cmd_func([gnomon_path, "--score", score_file.name, prefix.name], "Simple Gnomon Test", workdir)
+    gnomon_res = run_cmd_func([gnomon_path, "score", "--score", score_file.name, prefix.name], "Simple Gnomon Test", workdir)
     gnomon_output_path = workdir / f"{prefix.name}.sscore"
     if gnomon_res and gnomon_res.returncode == 0:
         print_file_header(gnomon_output_path, "Gnomon")
@@ -451,7 +451,7 @@ def run_impossible_diploid_test(workdir: Path, gnomon_path: Path, run_cmd_func):
     _write_score_file(score_file, score_df)
 
     # 2. Invocation
-    gnomon_res = run_cmd_func([gnomon_path, "--score", score_file.name, prefix.name], "Impossible Diploid Test", workdir)
+    gnomon_res = run_cmd_func([gnomon_path, "score", "--score", score_file.name, prefix.name], "Impossible Diploid Test", workdir)
     
     # 3. Validation
     if gnomon_res is None:
@@ -527,7 +527,7 @@ def run_multi_score_file_test(workdir: Path, gnomon_path: Path, run_cmd_func):
     scores_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(score_file_A, scores_dir / score_file_A.name)
     shutil.copy(score_file_B, scores_dir / score_file_B.name)
-    cmd = [gnomon_path, "--score", str(scores_dir.resolve()), str(prefix.resolve())]
+    cmd = [gnomon_path, "score", "--score", str(scores_dir.resolve()), str(prefix.resolve())]
     gnomon_res = run_cmd_func(cmd, "Multi-Score-File Test", workdir)
 
     
@@ -683,7 +683,7 @@ def run_and_validate_tools(runtimes):
     print("="*80)
     
     if overall_success:
-        gnomon_res = run_command([GNOMON_BINARY_PATH, "--score", f"{OUTPUT_PREFIX.name}.gnomon.score", OUTPUT_PREFIX.name], "Large-Scale Gnomon", WORKDIR)
+        gnomon_res = run_command([GNOMON_BINARY_PATH, "score", "--score", f"{OUTPUT_PREFIX.name}.gnomon.score", OUTPUT_PREFIX.name], "Large-Scale Gnomon", WORKDIR)
         if not (gnomon_res and gnomon_res.returncode == 0):
             print("❌ Gnomon failed to run on the large-scale dataset.")
             overall_success = False

--- a/test/test.py
+++ b/test/test.py
@@ -298,7 +298,8 @@ def test_variant_subset(variant_df: pd.DataFrame, iteration_name: str) -> float:
     # to avoid overwriting files in parallel or sequential runs.
     g_iter_prefix = CI_WORKDIR / f"_g_iter_{iteration_name}"
     # The command does NOT take an --out flag.
-    g_cmd = [str(GNOMON_BINARY), "--score", str(temp_score_path), str(SHARED_GENOTYPE_PREFIX)]
+    # The 'score' subcommand is added here.
+    g_cmd = [str(GNOMON_BINARY), "score", "--score", str(temp_score_path), str(SHARED_GENOTYPE_PREFIX)]
     g_res = run_and_measure(g_cmd, f"Gnomon_Iter_{iteration_name}", SHARED_GENOTYPE_PREFIX)
     # After running, move the output to the unique name we expect
     if g_res['success']:
@@ -440,7 +441,8 @@ def main():
         pgs_run_results = []
         
         commands_to_run = [
-            ("gnomon", [str(GNOMON_BINARY), "--score", str(unified_score_file_path), str(SHARED_GENOTYPE_PREFIX)], SHARED_GENOTYPE_PREFIX),
+            # The 'score' subcommand is added here.
+            ("gnomon", [str(GNOMON_BINARY), "score", "--score", str(unified_score_file_path), str(SHARED_GENOTYPE_PREFIX)], SHARED_GENOTYPE_PREFIX),
             ("plink2", [str(PLINK2_BINARY), "--bfile", str(SHARED_GENOTYPE_PREFIX), "--score", str(unified_score_file_path), "1", "2", "4", "header", "no-mean-imputation", "--out", str(CI_WORKDIR / f"plink2_{pgs_id}")], CI_WORKDIR / f"plink2_{pgs_id}"),
             ("pylink", ["python3", str(PYLINK_SCRIPT), "--precise", "--bfile", str(SHARED_GENOTYPE_PREFIX), "--score", str(unified_score_file_path), "--out", str(CI_WORKDIR / f"pylink_{pgs_id}"), "1", "2", "4"], CI_WORKDIR / f"pylink_{pgs_id}"),
         ]


### PR DESCRIPTION
All test scripts that invoke the `gnomon` executable were previously omitting the required `score` subcommand. This caused command-line parsing errors, preventing the tests from running correctly.

This commit inserts the `score` subcommand immediately after the `gnomon` binary path in all affected calls across:
- test/bench.py
- test/perf.py
- test/sim_test.py
- test/test.py

This ensures the `gnomon` CLI is invoked with the correct syntax: `gnomon score --score <SCORE_FILE> <INPUT_PATH>`