### PR TITLE
Fix: Use nightly toolchain for all cargo commands in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,8 +128,8 @@ jobs:
       - name: Build Gnomon binaries (Release and Profiling)
         if: steps.rust_changes.outputs.rust == 'true'
         run: |
-          cargo build --release
-          cargo build --profile profiling --features no-inline-profiling
+          cargo +nightly build --release
+          cargo +nightly build --profile profiling --features no-inline-profiling
       
       - name: Fail job if unit tests failed
         if: steps.rust_changes.outputs.rust == 'true' && steps.test_step.outcome == 'failure'


### PR DESCRIPTION
The CI was failing because some cargo commands were not using the nightly toolchain, which is required for the `portable_simd` feature. I've updated the `test.yml` workflow to use `cargo +nightly` for all build commands.