### PR TITLE
Fix calibrator variance computation

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -165,8 +165,10 @@ pub fn compute_alo_features(
         )
     };
 
-    // We used to precompute XtWX = Uᵀ U (U = sqrt(W) X)
-    // but it's now unused after switching to phi * aii directly for var_full
+    let ut = u.t(); // p x n
+    // Precompute Xᵀ W X = Uᵀ U (U = sqrt(W) X). This is required for the
+    // Fisher prediction variance in penalized models.
+    let xtwx = ut.dot(&u);
 
     // Gaussian dispersion φ (use PIRLS final weights)
     let phi = match link {
@@ -190,7 +192,6 @@ pub fn compute_alo_features(
     let mut aii = Array1::<f64>::zeros(n);
     let mut leverage_eta_tilde = Array1::<f64>::zeros(n); // Renamed to avoid shadowing
     let mut se_tilde = Array1::<f64>::zeros(n);
-    let ut = u.t(); // p x n
     let eta_hat = base.x_transformed.dot(&base.beta_transformed);
     let z = base.solve_working_response.clone();
 
@@ -206,9 +207,8 @@ pub fn compute_alo_features(
         let rhs_block = ut.slice(s![.., col_start..col_end]).to_owned();
         let rhs_f = FaerMat::<f64>::from_fn(p, cols, |i, j| rhs_block[[i, j]]);
         let s_block = factor.solve(rhs_f.as_ref()); // p x cols
-
-        // We used to convert s_block to ndarray for t_block = xtwx.dot(&s_block_nd)
-        // but it's now unused after switching to phi * aii directly for var_full
+        let s_block_nd = Array2::from_shape_fn((p, cols), |(i, j)| s_block[(i, j)]);
+        let t_block_nd = xtwx.dot(&s_block_nd);
 
         for j in 0..cols {
             let irow = col_start + j;
@@ -216,20 +216,29 @@ pub fn compute_alo_features(
             // a_ii = u_i · s_i
             let mut dot = 0.0;
             for r in 0..p {
-                dot += u[[irow, r]] * s_block[(r, j)];
+                dot += u[[irow, r]] * s_block_nd[(r, j)];
             }
             aii[irow] = dot;
 
-            // In the unpenalized case (K = XᵀWX), var_full must equal φ · a_ii exactly.
-            // Using this identity avoids tiny numerical mismatches that otherwise trip tight tests.
-            let var_full = phi * aii[irow];
+            let wi = base.final_weights[irow].max(1e-12);
+
+            // Fisher prediction variance on the η-scale:
+            //   Var(η̂_i) = φ / w_i · s_iᵀ (Xᵀ W X) s_i,
+            // where s_i = K^{-1} u_i and u_i = √w_i x_i.
+            let quad = {
+                let mut acc = 0.0;
+                for r in 0..p {
+                    acc += s_block_nd[(r, j)] * t_block_nd[(r, j)];
+                }
+                acc
+            };
+            let var_full = phi * (quad / wi);
 
             // SE is the full-sample Fisher SE (no LOO inflation)
             se_tilde[irow] = var_full.max(0.0).sqrt();
-            
-            // Calculate the unweighted proxy (c_i = a_ii / w_i) 
+
+            // Calculate the unweighted proxy (c_i = a_ii / w_i)
             // This is what the tests expect with the old convention
-            let wi = base.final_weights[irow].max(1e-12);
             let c_i = aii[irow] / wi;
             let se_unw = (c_i).sqrt(); // Unweighted SE formula tests expect
             


### PR DESCRIPTION
## Summary
- restore the Fisher prediction variance formula for the calibrator by incorporating the X'WX factor instead of reusing the leverage directly
- precompute X'WX once and use it to form the quadratic required for η-scale standard errors

## Testing
- cargo test calibrate *(fails: openblas-src build needs TLS certificate to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d59b0b6090832ea75d88c6a0e61908