### PR TITLE
Fix calibrator standardization to respect training weights

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -1105,7 +1105,7 @@ pub fn train_model(
             double_penalty_ridge: 1e-6, // Keep the tiny ridge on the nullspace
             distance_hinge: true,       // Keep the distance hinge behavior
             nullspace_shrinkage_kappa: Some(1.0), // Default equal shrinkage
-            prior_weights: None         // No custom weights
+            prior_weights: Some(reml_state.weights().to_owned()),
         };
 
         // Build design and penalties for calibrator
@@ -1143,8 +1143,11 @@ pub fn train_model(
             }
         );
 
+        let mut spec_for_model = spec.clone();
+        spec_for_model.prior_weights = None; // Do not persist training weights in the saved model
+
         let model = cal::CalibratorModel {
-            spec: spec.clone(),
+            spec: spec_for_model,
             knots_pred: schema.knots_pred,
             knots_se: schema.knots_se,
             knots_dist: schema.knots_dist,


### PR DESCRIPTION
## Summary
- ensure the calibrator design standardizes each feature with the training weights when present and validate weight length upfront
- carry training weights only through design construction and strip them before persisting the saved calibrator model

## Testing
- `cargo test calibrate::calibrator::tests::calibrator_does_no_harm_when_perfectly_calibrated -- --exact` *(fails to complete due to repeated OpenBLAS builds/linker issues even after installing gfortran)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c88f3cb8832ebd9ceda0e3995b1f