### PR TITLE
Replace ndarray-linalg with faer adapters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ dwldutil = "2.0.4"
 indicatif = "0.17"
 flate2 = "1.1.2"
 ndarray = { version = "0.16.1", features = ["serde", "rayon"] }
-ndarray-linalg = { version = "0.17.0", default-features = false, features = ["openblas-static"] }
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.16"
 toml = "0.8.23"
@@ -50,6 +49,7 @@ polars = { version = "0.50.0", features = ["csv", "ndarray", "fmt", "lazy"] }
 wolfe_bfgs = { git = "https://github.com/SauersML/wolfe_bfgs" }
 log = "0.4.27"
 faer = "0.22.6"
+dyn-stack = "0.13"
 
 planus = "=1.1.1" # cf. https://github.com/pola-rs/polars/issues/24208
 

--- a/build.rs
+++ b/build.rs
@@ -197,7 +197,8 @@ impl IgnoredTestCollector {
             error_msg.push_str(&format!("   {violation}\n"));
         }
 
-        error_msg.push_str("\n⚠️ #[ignore] TEST ATTRIBUTES ARE STRICTLY FORBIDDEN IN THIS PROJECT!\n");
+        error_msg
+            .push_str("\n⚠️ #[ignore] TEST ATTRIBUTES ARE STRICTLY FORBIDDEN IN THIS PROJECT!\n");
         error_msg.push_str("   IGNORING TESTS IS NEVER ALLOWED FOR ANY REASON.\n");
         error_msg.push_str("   Fix the test so it can run properly without being ignored.\n");
 
@@ -385,7 +386,7 @@ fn main() {
     // Scan Rust source files for #[allow(dead_code)] attributes
     let dead_code_violations = scan_for_allow_dead_code();
     all_violations.extend(dead_code_violations);
-    
+
     // Scan Rust source files for #[ignore] test attributes
     let ignored_test_violations = scan_for_ignored_tests();
     all_violations.extend(ignored_test_violations);
@@ -394,15 +395,18 @@ fn main() {
     if !all_violations.is_empty() {
         eprintln!("\n❌ VALIDATION ERRORS");
         eprintln!("====================");
-        
+
         let violation_count = all_violations.len();
-        
+
         for violation in all_violations {
             eprintln!("{violation}");
             eprintln!("--------------------");
         }
-        
-        eprintln!("\n⚠️ Found {} total code quality violations. Fix all issues before committing.", violation_count);
+
+        eprintln!(
+            "\n⚠️ Found {} total code quality violations. Fix all issues before committing.",
+            violation_count
+        );
         std::process::exit(1);
     }
 }
@@ -472,7 +476,7 @@ fn scan_for_underscore_prefixes() -> Vec<String> {
     // especially in match statements and destructuring patterns
     let pattern = r"\b(_[a-zA-Z0-9_]+)\b";
     let mut all_violations = Vec::new();
-    
+
     match RegexMatcher::new_line_matcher(pattern) {
         Ok(matcher) => {
             let mut searcher = Searcher::new();
@@ -499,28 +503,36 @@ fn scan_for_underscore_prefixes() -> Vec<String> {
                     .to_str()
                     .is_some_and(|p| p.ends_with("calibrate/estimate.rs"));
                 if is_estimate_rs {
-                    println!("cargo:warning=Analyzing estimate.rs for underscore-prefixed variables");
+                    println!(
+                        "cargo:warning=Analyzing estimate.rs for underscore-prefixed variables"
+                    );
                 }
 
                 // Create a new collector for each file.
                 let mut collector = ViolationCollector::new(path);
 
                 // Search the file using our regex matcher and collector sink.
-                if searcher.search_path(&matcher, path, &mut collector).is_err() {
+                if searcher
+                    .search_path(&matcher, path, &mut collector)
+                    .is_err()
+                {
                     // Handle search errors gracefully
                     continue;
                 }
-                
+
                 // Process results
                 if let Some(error_message) = collector.check_and_get_error_message() {
                     // Add this error to our collection instead of returning immediately
                     all_violations.push(error_message);
                 }
             }
-        },
+        }
         Err(e) => {
             // If there's an error creating the matcher, report it but don't return early
-            all_violations.push(format!("Error creating regex matcher for underscore prefixes: {}", e));
+            all_violations.push(format!(
+                "Error creating regex matcher for underscore prefixes: {}",
+                e
+            ));
         }
     }
 
@@ -562,15 +574,18 @@ fn scan_for_forbidden_comment_patterns() -> Vec<String> {
 
                 // Use a collector that doesn't filter out doc comments for forbidden words
                 let mut collector = ForbiddenCommentCollector::new(path, true);
-                if searcher.search_path(&forbidden_matcher, path, &mut collector).is_err() {
+                if searcher
+                    .search_path(&forbidden_matcher, path, &mut collector)
+                    .is_err()
+                {
                     continue;
                 }
-                
+
                 if let Some(error_message) = collector.check_and_get_error_message() {
                     all_violations.push(error_message);
                 }
             }
-        },
+        }
         Err(e) => {
             // Record the error but continue checking other patterns
             all_violations.push(format!("Error creating forbidden words regex: {}", e));
@@ -594,15 +609,18 @@ fn scan_for_forbidden_comment_patterns() -> Vec<String> {
                 // Use a single collector with custom filtering logic
                 // false means don't check for ** in doc comments
                 let mut collector = ForbiddenCommentCollector::new(path, false);
-                if searcher.search_path(&stars_matcher, path, &mut collector).is_err() {
+                if searcher
+                    .search_path(&stars_matcher, path, &mut collector)
+                    .is_err()
+                {
                     continue;
                 }
-                
+
                 if let Some(error_message) = collector.check_and_get_error_message() {
                     all_violations.push(error_message);
                 }
             }
-        },
+        }
         Err(e) => {
             // Record the error but continue checking other patterns
             all_violations.push(format!("Error creating stars pattern regex: {}", e));
@@ -624,15 +642,18 @@ fn scan_for_forbidden_comment_patterns() -> Vec<String> {
                 let path = entry.path();
 
                 let mut custom_collector = CustomUppercaseCollector::new(path);
-                if searcher.search_path(&all_caps_matcher, path, &mut custom_collector).is_err() {
+                if searcher
+                    .search_path(&all_caps_matcher, path, &mut custom_collector)
+                    .is_err()
+                {
                     continue;
                 }
-                
+
                 if let Some(error_message) = custom_collector.check_and_get_error_message() {
                     all_violations.push(error_message);
                 }
             }
-        },
+        }
         Err(e) => {
             // Record the error but don't return early
             all_violations.push(format!("Error creating uppercase pattern regex: {}", e));
@@ -646,7 +667,7 @@ fn scan_for_allow_dead_code() -> Vec<String> {
     // Regex pattern to find #[allow(dead_code)] attributes
     let pattern = r"#\s*\[\s*allow\s*\(\s*dead_code\s*\)\s*\]";
     let mut all_violations = Vec::new();
-    
+
     match RegexMatcher::new_line_matcher(pattern) {
         Ok(matcher) => {
             let mut searcher = Searcher::new();
@@ -670,24 +691,27 @@ fn scan_for_allow_dead_code() -> Vec<String> {
                 let mut collector = DeadCodeCollector::new(path);
 
                 // Search the file using our regex matcher and collector sink
-                if searcher.search_path(&matcher, path, &mut collector).is_err() {
+                if searcher
+                    .search_path(&matcher, path, &mut collector)
+                    .is_err()
+                {
                     // Handle search errors gracefully
                     continue;
                 }
-                
+
                 // Process results
                 if let Some(error_message) = collector.check_and_get_error_message() {
                     // Add this error to our collection instead of returning immediately
                     all_violations.push(error_message);
                 }
             }
-        },
+        }
         Err(e) => {
             // If there's an error creating the matcher, report it but don't return early
             all_violations.push(format!("Error creating dead code regex matcher: {}", e));
         }
     }
-    
+
     // Return all violations found
     all_violations
 }
@@ -696,7 +720,7 @@ fn scan_for_ignored_tests() -> Vec<String> {
     // Regex pattern to find #[ignore] test attributes
     let pattern = r"#\s*\[\s*ignore\s*\]";
     let mut all_violations = Vec::new();
-    
+
     match RegexMatcher::new_line_matcher(pattern) {
         Ok(matcher) => {
             let mut searcher = Searcher::new();
@@ -720,24 +744,27 @@ fn scan_for_ignored_tests() -> Vec<String> {
                 let mut collector = IgnoredTestCollector::new(path);
 
                 // Search the file using our regex matcher and collector sink
-                if searcher.search_path(&matcher, path, &mut collector).is_err() {
+                if searcher
+                    .search_path(&matcher, path, &mut collector)
+                    .is_err()
+                {
                     // Handle search errors gracefully
                     continue;
                 }
-                
+
                 // Process results
                 if let Some(error_message) = collector.check_and_get_error_message() {
                     // Add this error to our collection instead of returning immediately
                     all_violations.push(error_message);
                 }
             }
-        },
+        }
         Err(e) => {
             // If there's an error creating the matcher, report it but don't return early
             all_violations.push(format!("Error creating ignored tests regex matcher: {}", e));
         }
     }
-    
+
     // Return all violations found
     all_violations
 }

--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -10,10 +10,10 @@ use crate::calibrate::pirls; // for PirlsResult
 
 use ndarray::{Array1, Array2, ArrayView1, ArrayView2, Axis, s};
 // no direct ndarray-linalg imports needed here
+use crate::calibrate::faer_ndarray::FaerSvd;
 use faer::Mat as FaerMat;
 use faer::Side;
 use faer::linalg::solvers::{Ldlt as FaerLdlt, Llt as FaerLlt, Solve as FaerSolve};
-use ndarray_linalg::SVD;
 use serde::{Deserialize, Serialize};
 // Use the shared optimizer facade from estimate.rs
 use crate::calibrate::estimate::{ExternalOptimOptions, optimize_external_design};

--- a/calibrate/faer_ndarray.rs
+++ b/calibrate/faer_ndarray.rs
@@ -1,0 +1,167 @@
+use dyn_stack::{MemBuffer, MemStack};
+use faer::diag::{Diag, DiagRef};
+use faer::linalg::solvers::{self, Solve};
+use faer::linalg::svd::{self, ComputeSvdVectors};
+use faer::{Mat, MatRef, Side, get_global_parallelism};
+use ndarray::{Array1, Array2, ArrayBase, Data, Ix2};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum FaerLinalgError {
+    #[error("SVD failed to converge")]
+    SvdNoConvergence,
+    #[error("Self-adjoint eigendecomposition failed: {0:?}")]
+    SelfAdjointEigen(solvers::EvdError),
+    #[error("Cholesky factorization failed: {0:?}")]
+    Cholesky(solvers::LltError),
+}
+
+fn array_to_faer<S: Data<Elem = f64>>(array: &ArrayBase<S, Ix2>) -> Mat<f64> {
+    let (rows, cols) = array.dim();
+    Mat::from_fn(rows, cols, |i, j| array[(i, j)])
+}
+
+fn mat_to_array(mat: MatRef<'_, f64>) -> Array2<f64> {
+    Array2::from_shape_fn((mat.nrows(), mat.ncols()), |(i, j)| mat[(i, j)])
+}
+
+fn diag_to_array(diag: DiagRef<'_, f64>) -> Array1<f64> {
+    let mat = diag.column_vector().as_mat();
+    Array1::from_shape_fn(mat.nrows(), |i| mat[(i, 0)])
+}
+
+pub trait FaerSvd {
+    fn svd(
+        &self,
+        compute_u: bool,
+        compute_vt: bool,
+    ) -> Result<(Option<Array2<f64>>, Array1<f64>, Option<Array2<f64>>), FaerLinalgError>;
+}
+
+impl<S: Data<Elem = f64>> FaerSvd for ArrayBase<S, Ix2> {
+    fn svd(
+        &self,
+        compute_u: bool,
+        compute_vt: bool,
+    ) -> Result<(Option<Array2<f64>>, Array1<f64>, Option<Array2<f64>>), FaerLinalgError> {
+        let faer_mat = array_to_faer(self);
+        if !compute_u && !compute_vt {
+            let singular_values = faer_mat
+                .singular_values()
+                .map_err(|_| FaerLinalgError::SvdNoConvergence)?;
+            return Ok((None, Array1::from_vec(singular_values), None));
+        }
+
+        let (rows, cols) = faer_mat.shape();
+        let compute_u_flag = if compute_u {
+            ComputeSvdVectors::Full
+        } else {
+            ComputeSvdVectors::No
+        };
+        let compute_v_flag = if compute_vt {
+            ComputeSvdVectors::Full
+        } else {
+            ComputeSvdVectors::No
+        };
+
+        let mut singular = Diag::<f64>::zeros(rows.min(cols));
+        let mut u_storage = compute_u.then(|| Mat::<f64>::zeros(rows, rows));
+        let mut v_storage = compute_vt.then(|| Mat::<f64>::zeros(cols, cols));
+
+        let par = get_global_parallelism();
+        let mut mem = MemBuffer::new(svd::svd_scratch::<f64>(
+            rows,
+            cols,
+            compute_u_flag,
+            compute_v_flag,
+            par,
+            Default::default(),
+        ));
+        let mut stack = MemStack::new(&mut mem);
+
+        svd::svd(
+            faer_mat.as_ref(),
+            singular.as_mut(),
+            u_storage.as_mut().map(|mat| mat.as_mut()),
+            v_storage.as_mut().map(|mat| mat.as_mut()),
+            par,
+            &mut stack,
+            Default::default(),
+        )
+        .map_err(|_| FaerLinalgError::SvdNoConvergence)?;
+
+        let singular_values = diag_to_array(singular.as_ref());
+        let u_opt = u_storage.map(|mat| mat_to_array(mat.as_ref()));
+        let vt_opt = v_storage.map(|mat| {
+            let mat_ref = mat.as_ref();
+            Array2::from_shape_fn((mat_ref.ncols(), mat_ref.nrows()), |(i, j)| mat_ref[(j, i)])
+        });
+
+        Ok((u_opt, singular_values, vt_opt))
+    }
+}
+
+pub trait FaerEigh {
+    fn eigh(&self, side: Side) -> Result<(Array1<f64>, Array2<f64>), FaerLinalgError>;
+}
+
+impl<S: Data<Elem = f64>> FaerEigh for ArrayBase<S, Ix2> {
+    fn eigh(&self, side: Side) -> Result<(Array1<f64>, Array2<f64>), FaerLinalgError> {
+        let faer_mat = array_to_faer(self);
+        let eigen = faer_mat
+            .self_adjoint_eigen(side)
+            .map_err(FaerLinalgError::SelfAdjointEigen)?;
+        let values = diag_to_array(eigen.S());
+        let vectors = mat_to_array(eigen.U());
+        Ok((values, vectors))
+    }
+}
+
+pub struct FaerCholeskyFactor {
+    factor: solvers::Llt<f64>,
+}
+
+impl FaerCholeskyFactor {
+    pub fn solve_vec(&self, rhs: &Array1<f64>) -> Array1<f64> {
+        let rhs_mat = Mat::from_fn(rhs.len(), 1, |i, _| rhs[i]);
+        let sol = self.factor.solve(rhs_mat.as_ref());
+        Array1::from_shape_fn(rhs.len(), |i| sol[(i, 0)])
+    }
+
+    pub fn solve_mat(&self, rhs: &Array2<f64>) -> Array2<f64> {
+        let (rows, cols) = rhs.dim();
+        let rhs_mat = Mat::from_fn(rows, cols, |i, j| rhs[(i, j)]);
+        let sol = self.factor.solve(rhs_mat.as_ref());
+        mat_to_array(sol.as_ref())
+    }
+
+    pub fn diag(&self) -> Array1<f64> {
+        diag_to_array(self.factor.L().diagonal())
+    }
+}
+
+pub trait FaerCholesky {
+    fn cholesky(&self, side: Side) -> Result<FaerCholeskyFactor, FaerLinalgError>;
+}
+
+impl<S: Data<Elem = f64>> FaerCholesky for ArrayBase<S, Ix2> {
+    fn cholesky(&self, side: Side) -> Result<FaerCholeskyFactor, FaerLinalgError> {
+        let faer_mat = array_to_faer(self);
+        let factor = faer_mat.llt(side).map_err(FaerLinalgError::Cholesky)?;
+        Ok(FaerCholeskyFactor { factor })
+    }
+}
+
+pub trait FaerQr {
+    fn qr(&self) -> Result<(Array2<f64>, Array2<f64>), FaerLinalgError>;
+}
+
+impl<S: Data<Elem = f64>> FaerQr for ArrayBase<S, Ix2> {
+    fn qr(&self) -> Result<(Array2<f64>, Array2<f64>), FaerLinalgError> {
+        let faer_mat = array_to_faer(self);
+        let qr = faer_mat.qr();
+        let q = qr.compute_Q();
+        let r = qr.R();
+        Ok((mat_to_array(q.as_ref()), mat_to_array(r)))
+    }
+}

--- a/calibrate/lib.rs
+++ b/calibrate/lib.rs
@@ -8,6 +8,7 @@ pub mod data;
 
 pub mod calibrator;
 pub mod estimate;
+pub mod faer_ndarray;
 pub mod hull;
 pub mod model;
 pub mod pirls;


### PR DESCRIPTION
## Summary
- add a `calibrate::faer_ndarray` adapter module that wraps faer’s SVD, eigendecomposition, Cholesky, and QR solvers for ndarray callers
- migrate basis, construction, calibrator, estimator, model, and PIRLS codepaths to use the new adapters and faer’s `Side` flags instead of `ndarray-linalg`
- drop the `ndarray-linalg` dependency from the workspace manifest, relying solely on `faer`
- optimize the SVD adapter to skip unnecessary singular vector work by calling the low-level faer routines directly and add `dyn-stack` to support their scratch requirements
- delete the checked-in faer documentation exports under `docs/faer/`

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d6f5177e5c832e86148835f686e1b2