### PR TITLE
Adjust tests to avoid ndarray approx feature

### DIFF
--- a/calibrate/basis.rs
+++ b/calibrate/basis.rs
@@ -538,9 +538,10 @@ mod tests {
         let knots = internal::generate_full_knot_vector((0.0, 10.0), 3, 2).unwrap();
         // 3 internal + 2 * (2+1) boundary = 9 knots
         assert_eq!(knots.len(), 9);
+        let expected_knots = array![0.0, 0.0, 0.0, 2.5, 5.0, 7.5, 10.0, 10.0, 10.0];
         assert_abs_diff_eq!(
-            knots,
-            array![0.0, 0.0, 0.0, 2.5, 5.0, 7.5, 10.0, 10.0, 10.0],
+            knots.as_slice().unwrap(),
+            expected_knots.as_slice().unwrap(),
             epsilon = 1e-9
         );
     }
@@ -553,9 +554,10 @@ mod tests {
         // Since quantile knots are disabled, this should generate uniform knots
         // 3 internal knots + 2 * (2+1) boundary = 9 knots
         assert_eq!(knots.len(), 9);
+        let expected_knots = array![0.0, 0.0, 0.0, 2.5, 5.0, 7.5, 10.0, 10.0, 10.0];
         assert_abs_diff_eq!(
-            knots,
-            array![0.0, 0.0, 0.0, 2.5, 5.0, 7.5, 10.0, 10.0, 10.0],
+            knots.as_slice().unwrap(),
+            expected_knots.as_slice().unwrap(),
             epsilon = 1e-9
         );
     }
@@ -573,7 +575,12 @@ mod tests {
             [0., 1., -4., 5., -2.],
             [0., 0., 1., -2., 1.]
         ];
-        assert_abs_diff_eq!(s, expected_s, epsilon = 1e-9);
+        assert_eq!(s.shape(), expected_s.shape());
+        assert_abs_diff_eq!(
+            s.as_slice().unwrap(),
+            expected_s.as_slice().unwrap(),
+            epsilon = 1e-9
+        );
     }
 
     #[test]
@@ -1151,9 +1158,10 @@ mod tests {
         .unwrap();
 
         // Uniform fallback: boundary repeated degree+1=2 times => 2 + 3 + 2 = 7 knots
+        let expected_knots = array![0.0, 0.0, 2.5, 5.0, 7.5, 10.0, 10.0];
         assert_abs_diff_eq!(
-            knots_uniform,
-            array![0.0, 0.0, 2.5, 5.0, 7.5, 10.0, 10.0],
+            knots_uniform.as_slice().unwrap(),
+            expected_knots.as_slice().unwrap(),
             epsilon = 1e-9
         );
 

--- a/calibrate/model.rs
+++ b/calibrate/model.rs
@@ -892,7 +892,11 @@ mod tests {
 
         // Verify the results match our correctly calculated ground truth
         assert_eq!(predictions.len(), 2);
-        assert_abs_diff_eq!(predictions, expected_values, epsilon = 1e-10);
+        assert_abs_diff_eq!(
+            predictions.as_slice().unwrap(),
+            expected_values.as_slice().unwrap(),
+            epsilon = 1e-10
+        );
     }
 
     /// Tests that the prediction fails appropriately with invalid input dimensions.


### PR DESCRIPTION
## Summary
- keep the main ndarray dependency lean by removing the `approx` feature
- compare ndarray arrays in tests by operating on their contiguous slices so `assert_abs_diff_eq!` still works

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d749db7f0c832eaed019d5a36aa51f