### PR TITLE
Fix calibrator tuple binding to avoid underscore variables

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -5318,7 +5318,7 @@ mod tests {
 
         // Time the design matrix construction
         let design_start = Instant::now();
-        let (x_cal, penalties, _, _offset) = build_calibrator_design(&alo_features, &spec).unwrap();
+        let (x_cal, penalties, _, _) = build_calibrator_design(&alo_features, &spec).unwrap();
         let design_time = design_start.elapsed();
 
         eprintln!(


### PR DESCRIPTION
## Summary
- remove the underscore-prefixed binding in the calibrator design tuple so only wildcards remain

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d865409eec832eb06117595ca94995