### PR TITLE
Fix calibrator test helpers after offset refactor

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -4025,6 +4025,7 @@ mod tests {
             y.view(),
             w.view(),
             x_cal.view(),
+            offset.view(),
             &penalties,
             LinkFunction::Identity,
             &spec,
@@ -4190,6 +4191,7 @@ mod tests {
             y.view(),
             w.view(),
             x_cal.view(),
+            offset.view(),
             &penalties,
             LinkFunction::Identity,
             &spec,
@@ -4394,6 +4396,7 @@ mod tests {
             y.view(),
             w.view(),
             x_cal.view(),
+            offset.view(),
             &penalties,
             LinkFunction::Logit,
             &spec,
@@ -5318,7 +5321,7 @@ mod tests {
 
         // Time the design matrix construction
         let design_start = Instant::now();
-        let (x_cal, penalties, _, _) = build_calibrator_design(&alo_features, &spec).unwrap();
+        let (x_cal, penalties, _, offset) = build_calibrator_design(&alo_features, &spec).unwrap();
         let design_time = design_start.elapsed();
 
         eprintln!(


### PR DESCRIPTION
## Summary
- pass the offset view to `fit_calibrator` in the calibrator tests after the API change
- retain the offset from `build_calibrator_design` in the calibration performance test

## Testing
- `cargo test calibrate::calibrator::tests::calibrator_does_no_harm_when_perfectly_calibrated -- --exact --nocapture` *(fails: known test failure)*
- `cargo test calibrate::calibrator::tests::calibrator_fixes_sinusoidal_miscalibration_binary -- --exact` *(fails: known test failure)*
- `cargo test calibrate::calibrator::tests::external_opt_cost_grad_agree_fd -- --exact` *(fails: known test failure)*
- `cargo test calibrate::calibrator::tests::se_smooth_learns_heteroscedastic_shrinkage -- --exact` *(fails: known test failure)*

------
https://chatgpt.com/codex/tasks/task_e_68d8693b6be8832e93ac5c7451249c8b