### PR TITLE
Remove unused runtime dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,7 @@ crossbeam-queue = "0.3.12"
 tokio = { version = "1.47.1", features = ["sync", "rt-multi-thread", "macros"] }
 num_cpus = "1.17.0"
 ryu = "1.0.20"
-futures = "0.3.31"
-itertools = "0.14.0"
 crossbeam-channel = "0.5.15"
-memchr = "2.7.5"
 natord = "1.0.9"
 bumpalo = { version = "3.19.0", features = ["collections"] }
 dwldutil = "2.0.4"


### PR DESCRIPTION
## Summary
- remove unused direct dependencies (futures, itertools, and memchr) from the workspace manifest to shrink the compile-time dependency graph

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d86af8d914832e9b881e512798ebf4