### PR TITLE
Only build release artifacts after successful tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
           cat report.md
 
       - name: Build Gnomon binaries (Release and Profiling)
-        if: steps.rust_changes.outputs.rust == 'true'
+        if: steps.rust_changes.outputs.rust == 'true' && steps.test_step.outcome == 'success'
         run: |
           cargo +nightly build --release
           cargo +nightly build --profile profiling --features no-inline-profiling


### PR DESCRIPTION
## Summary
- gate the release and profiling builds behind successful unit tests in CI

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d870a362a4832e8746611af947cba5