### PR TITLE
Restore calibrator offset argument for tests

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -4025,6 +4025,7 @@ mod tests {
             y.view(),
             w.view(),
             x_cal.view(),
+            offset.view(),
             &penalties,
             LinkFunction::Identity,
             &spec,
@@ -4190,6 +4191,7 @@ mod tests {
             y.view(),
             w.view(),
             x_cal.view(),
+            offset.view(),
             &penalties,
             LinkFunction::Identity,
             &spec,
@@ -4394,6 +4396,7 @@ mod tests {
             y.view(),
             w.view(),
             x_cal.view(),
+            offset.view(),
             &penalties,
             LinkFunction::Logit,
             &spec,
@@ -5318,7 +5321,7 @@ mod tests {
 
         // Time the design matrix construction
         let design_start = Instant::now();
-        let (x_cal, penalties, _, _offset) = build_calibrator_design(&alo_features, &spec).unwrap();
+        let (x_cal, penalties, _, offset) = build_calibrator_design(&alo_features, &spec).unwrap();
         let design_time = design_start.elapsed();
 
         eprintln!(


### PR DESCRIPTION
## Summary
- restore the offset binding in the calibrator benchmarks/tests so `fit_calibrator` receives the required argument again

## Testing
- cargo test (fails)


------
https://chatgpt.com/codex/tasks/task_e_68d865409eec832eb06117595ca94995