### PR TITLE
Remove unnecessary mut from s_se assignment

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -1077,7 +1077,7 @@ pub fn build_calibrator_design(
     // the ordinary roughness penalties are sufficient.  The linear nullspaces are
     // no longer present, so no extra shrinkage or fixed ridges are required.
     let s_pred = s_pred_raw_sc;
-    let mut s_se = s_se_raw_sc;
+    let s_se = s_se_raw_sc;
     let s_dist = s_dist_raw_sc;
 
     if se_linear_fallback {


### PR DESCRIPTION
## Summary
- remove the unused `mut` binding from the `s_se` penalty matrix assignment to clear the compiler warning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8b99bc508832e82ba76f3a2753c1a