### PR TITLE
Guard against singular penalized Hessians in REML fits

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -2012,21 +2012,30 @@ pub mod internal {
             let (_, ridge_used) = self.effective_hessian(pirls_result.as_ref());
 
             // Only check eigenvalues if we needed to add a ridge
+            const MIN_ACCEPTABLE_HESSIAN_EIGENVALUE: f64 = 1e-12;
             if ridge_used > 0.0 {
                 if let Ok((eigs, _)) = pirls_result.penalized_hessian_transformed.eigh(Side::Lower)
                 {
-                    let all_nonpos = eigs.iter().all(|&x| x <= 0.0);
-                    if all_nonpos {
-                        // Truly pathological: everything ≤ 0
-                        return Err(EstimationError::HessianNotPositiveDefinite {
-                            min_eigenvalue: eigs.iter().cloned().fold(f64::INFINITY, f64::min),
-                        });
-                    }
-                    log::warn!(
-                        "Penalized Hessian not PD (min eig <= 0). Proceeding with stabilized logdet."
-                    );
                     if let Some(min_eig) = eigs.iter().cloned().reduce(f64::min) {
                         eprintln!("[Diag] H min_eig={:.3e}", min_eig);
+
+                        if min_eig <= 0.0 {
+                            log::warn!(
+                                "Penalized Hessian not PD (min eig <= 0). Treating as a fatal singularity."
+                            );
+                        }
+
+                        if !min_eig.is_finite() || min_eig <= MIN_ACCEPTABLE_HESSIAN_EIGENVALUE {
+                            let condition_number = calculate_condition_number(
+                                &pirls_result.penalized_hessian_transformed,
+                            )
+                            .ok()
+                            .unwrap_or(f64::INFINITY);
+
+                            return Err(EstimationError::ModelIsIllConditioned {
+                                condition_number,
+                            });
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add a minimum eigenvalue threshold when ridge stabilization is triggered during REML fits
- return a `ModelIsIllConditioned` error when the penalized Hessian collapses instead of continuing with a degenerate solution

## Testing
- cargo test test_detects_singular_model_gracefully

------
https://chatgpt.com/codex/tasks/task_e_68d8bca10388832e94f5404182b49095