### PR TITLE
Normalize calibrate comments to stage phrasing

### DIFF
--- a/calibrate/basis.rs
+++ b/calibrate/basis.rs
@@ -1,8 +1,6 @@
 use crate::calibrate::faer_ndarray::{FaerEigh, FaerLinalgError, FaerSvd};
 use faer::Side;
 use ndarray::{Array, Array1, Array2, ArrayView1, ArrayView2, Axis, s};
-
-// Imports removed: use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[cfg(test)]
@@ -80,8 +78,8 @@ pub enum BasisError {
 /// # Returns
 ///
 /// On success, returns a `Result` containing a tuple `(Array2<f64>, Array1<f64>)`:
-/// 1.  The **basis matrix**, with shape `[data.len(), num_basis_functions]`.
-/// 2.  A copy of the **knot vector** used.
+/// - The **basis matrix**, with shape `[data.len(), num_basis_functions]`.
+/// - A copy of the **knot vector** used.
 pub fn create_bspline_basis_with_knots(
     data: ArrayView1<f64>,
     knot_vector: ArrayView1<f64>,
@@ -156,9 +154,9 @@ pub fn create_bspline_basis_with_knots(
 /// # Returns
 ///
 /// On success, returns a `Result` containing a tuple `(Array2<f64>, Array1<f64>)`:
-/// 1.  The **basis matrix**, with shape `[data.len(), num_basis_functions]`.
-///     The number of basis functions is `num_internal_knots + degree + 1`.
-/// 2.  The **knot vector**, containing all knots including repeated boundary knots.
+/// - The **basis matrix**, with shape `[data.len(), num_basis_functions]`.
+///   The number of basis functions is `num_internal_knots + degree + 1`.
+/// - The **knot vector**, containing all knots including repeated boundary knots.
 ///
 /// # Mathematical Background
 ///
@@ -254,8 +252,8 @@ pub fn create_difference_penalty_matrix(
 ///
 /// # Returns
 /// A tuple containing:
-/// 1. The new, constrained basis matrix (with one fewer column).
-/// 2. The transformation matrix `Z` used to create it.
+/// - The new, constrained basis matrix (with one fewer column).
+/// - The transformation matrix `Z` used to create it.
 pub fn apply_sum_to_zero_constraint(
     basis_matrix: ArrayView2<f64>,
     weights: Option<ArrayView1<f64>>,
@@ -1111,16 +1109,16 @@ mod tests {
         // This test replaces a previously flawed version. The goal is to verify that
         // the prediction logic for a constrained B-spline basis is consistent and correct.
         // We perform two checks:
-        // 1. On-Grid Consistency: Ensure calculating a prediction for a single point that
+        // Stage: On-grid consistency—ensure calculating a prediction for a single point that
         //    is ON the original grid yields the same result as the batch calculation.
-        // 2. Off-Grid Interpolation: Ensure a prediction for a point OFF the grid
+        // Stage: Off-grid interpolation—ensure a prediction for a point off the grid
         //    (e.g., 0.65) produces a value that lies between its neighbors (0.6 and 0.7),
         //    validating the spline's interpolation property.
         //
         // The previous test incorrectly asserted that the value at 0.65 should equal
         // the value at 0.6, which is false for a non-flat cubic spline.
 
-        // --- 1. Setup: Same as the original test ---
+        // --- Setup: Same as the original test ---
         let data = Array::linspace(0.0, 1.0, 11);
         let degree = 3;
         let num_internal_knots = 5;
@@ -1136,10 +1134,10 @@ mod tests {
         let num_con_coeffs = main_basis_con.ncols();
         let main_coeffs = Array1::from_shape_fn(num_con_coeffs, |i| (i as f64 + 1.0) * 0.1);
 
-        // --- 2. Calculate Batch Predictions on the Grid (Our Ground Truth) ---
+        // --- Calculate batch predictions on the grid (our ground truth) ---
         let predictions_on_grid = intercept_coeff + main_basis_con.dot(&main_coeffs);
 
-        // --- 3. On-Grid Consistency Check ---
+        // --- On-grid consistency check ---
         // Let's test the point x=0.6, which corresponds to index 6 in our `data` grid.
         let test_point_on_grid_x = 0.6;
         let on_grid_idx = 6;
@@ -1164,7 +1162,7 @@ mod tests {
             epsilon = 1e-12 // Use a tight epsilon for this identity check
         );
 
-        // --- 4. Off-Grid Interpolation Check ---
+        // --- Off-grid interpolation check ---
         // Now test the off-grid point x=0.65, which lies between grid points 0.6 and 0.7.
         let test_point_off_grid_x = 0.65;
 

--- a/calibrate/construction.rs
+++ b/calibrate/construction.rs
@@ -386,7 +386,7 @@ pub fn build_design_and_penalty_matrices(
     interaction_centering_means.reserve(n_pcs);
     interaction_orth_alpha.reserve(n_pcs);
 
-    // 1. Generate basis for PGS and apply sum-to-zero constraint
+    // Stage: Generate the PGS basis and apply the sum-to-zero constraint
     let (pgs_basis_unc, pgs_knots) = create_bspline_basis(
         data.p.view(),
         config.pgs_range,
@@ -398,7 +398,6 @@ pub fn build_design_and_penalty_matrices(
     knot_vectors.insert("pgs".to_string(), pgs_knots);
 
     // Build PGS penalty on FULL basis (not arbitrarily sliced)
-    // Note: previous eigen-decomposition and range extraction were unused and removed
 
     // For PGS main effects: use non-intercept columns and apply sum-to-zero constraint
     let pgs_main_basis_unc = pgs_basis_unc.slice(s![.., 1..]);
@@ -416,7 +415,7 @@ pub fn build_design_and_penalty_matrices(
     // Save the PGS sum-to-zero constraint transformation
     sum_to_zero_constraints.insert("pgs_main".to_string(), pgs_z_transform);
 
-    // 2. Generate range-only bases for PCs (functional ANOVA decomposition)
+    // Stage: Generate range-only bases for PCs (functional ANOVA decomposition)
     let mut pc_range_bases: Vec<Array2<f64>> = Vec::with_capacity(n_pcs);
     let mut pc_null_bases: Vec<Option<Array2<f64>>> = Vec::with_capacity(n_pcs);
     let mut pc_unconstrained_bases_main: Vec<Array2<f64>> = Vec::with_capacity(n_pcs);
@@ -439,8 +438,6 @@ pub fn build_design_and_penalty_matrices(
 
         // Save PC knot vector
         knot_vectors.insert(pc_name.clone(), pc_knots);
-
-        // Note: previous eigen-decomposition and range extraction were unused and removed
 
         // For PC main effects: use non-intercept columns for whitened range basis
         let pc_main_basis_unc = pc_basis_unc.slice(s![.., 1..]);
@@ -468,7 +465,7 @@ pub fn build_design_and_penalty_matrices(
         range_transforms.insert(pc_name.clone(), z_range_pc);
     }
 
-    // 3. Calculate layout first to determine matrix dimensions
+    // Stage: Calculate the layout first to determine matrix dimensions
     let pc_range_ncols: Vec<usize> = pc_range_bases.iter().map(|b| b.ncols()).collect();
     let pc_null_ncols: Vec<usize> = pc_null_bases
         .iter()
@@ -488,7 +485,7 @@ pub fn build_design_and_penalty_matrices(
         pgs_range_ncols, // Use PGS range size for interactions
     )?;
 
-    // 4. Create individual penalty matrices - one per PC main and two per interaction
+    // Stage: Create individual penalty matrices—one per PC main and two per interaction
     // Each penalty gets its own lambda parameter for optimal smoothing control
     let p = layout.total_coeffs;
     let mut s_list = Vec::with_capacity(layout.num_penalties);
@@ -537,14 +534,14 @@ pub fn build_design_and_penalty_matrices(
 
     // Range transformations will be returned directly to the caller
 
-    // 5. Assemble the full design matrix `X` using the layout as the guide
+    // Stage: Assemble the full design matrix `X` using the layout as the guide
     // Following a strict canonical order to match the coefficient flattening logic in model.rs
     let mut x_matrix = Array2::zeros((n_samples, layout.total_coeffs));
 
-    // 1. Intercept - always the first column
+    // Stage: Populate the intercept column first
     x_matrix.column_mut(layout.intercept_col).fill(1.0);
 
-    // 2. Main PC effects: first unpenalized null-space (if any), then penalized range
+    // Stage: Fill main PC effects (null-space first, then penalized range)
     for (pc_idx, pc_config) in config.pc_configs.iter().enumerate() {
         let pc_name = &pc_config.name;
         // Fill null-space columns
@@ -600,7 +597,7 @@ pub fn build_design_and_penalty_matrices(
         }
     }
 
-    // 3. Main PGS effect - directly use the layout range
+    // Stage: Populate the main PGS effect directly from the layout range
     let pgs_range = layout.pgs_main_cols.clone();
 
     // Validate dimensions before assignment
@@ -623,7 +620,7 @@ pub fn build_design_and_penalty_matrices(
         .slice_mut(s![.., pgs_range])
         .assign(&pgs_main_basis);
 
-    // 4. Tensor product interaction effects - Range × Range only (fully penalized)
+    // Stage: Populate tensor product interaction effects using Range × Range (fully penalized)
     if pgs_range_ncols > 0 && !pc_range_bases.is_empty() {
         // Use WHITENED marginals for interactions to match main effect scaling
         let z_range_pgs = range_transforms.get("pgs").ok_or_else(|| {
@@ -1089,7 +1086,7 @@ pub fn stable_reparameterization(
             iteration, k_offset, q_current, gamma
         );
 
-        // Step 1: Find Frobenius norms of penalties in current sub-problem
+        // Stage: Find Frobenius norms of penalties in the current sub-problem
         // For penalty square roots, we need to form the full penalty matrix S_i = rS_i^T * rS_i
         let mut frob_norms = Vec::new();
         let mut max_omega: f64 = 0.0;
@@ -1122,7 +1119,7 @@ pub fn stable_reparameterization(
             break; // All remaining penalties are numerically zero
         }
 
-        // Step 2: Partition into dominant α and subdominant γ' sets
+        // Stage: Partition into dominant α and subdominant γ' sets
         // This is the most critical part of the algorithm
         // We must ensure this logic exactly matches mgcv's get_stableS function
         let threshold = eps * max_omega;
@@ -1165,7 +1162,7 @@ pub fn stable_reparameterization(
 
         // println!("DEBUG: Partitioned: alpha set = {:?}, gamma_prime set = {:?}", alpha, gamma_prime);
 
-        // Step 3a: Form SCALED sum for STABLE RANK DETECTION (lambda-INDEPENDENT)
+        // Stage: Form a scaled sum for stable rank detection (lambda-independent)
         // This creates a lambda-independent, balanced matrix for reliable rank detection
         let mut sb_for_rank = Array2::zeros((q_current, q_current));
         for &i in &alpha {
@@ -1246,7 +1243,7 @@ pub fn stable_reparameterization(
             }
         }
 
-        // Step 3b: Form WEIGHTED sum for TRANSFORMATION (lambda-weighted for eigenvectors)
+        // Stage: Form a weighted sum for the transformation (lambda-weighted for eigenvectors)
         // This matrix provides the eigenvectors for the similarity transform
         let mut sb_for_transform = Array2::zeros((q_current, q_current));
         for &i in &alpha {
@@ -1322,7 +1319,7 @@ pub fn stable_reparameterization(
         let u_reordered = ndarray::concatenate(Axis(1), &[u_range, u_null])
             .expect("Failed to reorder eigenvectors");
 
-        // Step 5B: Update global transformation matrix Qf using the REORDERED basis
+        // Stage: Update the global transformation matrix Qf using the reordered basis
         let qf_block = qf.slice(s![.., k_offset..k_offset + q_current]).to_owned();
         let qf_new = qf_block.dot(&u_reordered);
         qf.slice_mut(s![.., k_offset..k_offset + q_current])
@@ -1351,7 +1348,7 @@ pub fn stable_reparameterization(
                 .assign(&transformed_sub_block);
         }
 
-        // Step 6: Transform ALL active penalty roots by the REORDERED eigenvector matrix U.
+        // Stage: Transform all active penalty roots by the reordered eigenvector matrix U.
         // This projects them onto the new basis defined by the eigenvectors of the dominant penalties.
         for &i in &gamma {
             if rs_current[i].nrows() == 0 || q_current == 0 {
@@ -1371,7 +1368,7 @@ pub fn stable_reparameterization(
         }
 
         // ---
-        // Step 7: Partitioning logic
+        // Stage: Partitioning logic
         // After transforming with `u_reordered`, the first `r` rows correspond to the range
         // space, and the last `q_current - r` rows correspond to the null space.
         // ---
@@ -1478,10 +1475,10 @@ pub fn stable_reparameterization(
 
     // AFTER LOOP: Generate final outputs from the transformed penalty roots
 
-    // Step 1: The loop has finished - rs_current now contains the fully transformed penalty roots
+    // Stage: The loop has finished - rs_current now contains the fully transformed penalty roots
     let final_rs_transformed = rs_current;
 
-    // Step 2: Construct the final transformed total penalty matrix
+    // Stage: Construct the final transformed total penalty matrix
     let mut s_transformed = Array2::zeros((p, p));
     for i in 0..m {
         // Form full penalty from transformed root: S_k = rS_k^T * rS_k
@@ -1489,7 +1486,7 @@ pub fn stable_reparameterization(
         s_transformed.scaled_add(lambdas[i], &s_k_transformed);
     }
 
-    // Step 3: Compute eigendecomposition of S_lambda
+    // Stage: Compute the eigendecomposition of S_lambda
     let (s_eigenvalues_raw, s_eigenvectors): (Array1<f64>, Array2<f64>) = s_transformed
         .eigh(Side::Lower)
         .map_err(EstimationError::EigendecompositionFailed)?;
@@ -1527,14 +1524,14 @@ pub fn stable_reparameterization(
     // This represents the true penalty strength and changes with lambda values
     let e_transformed = e_matrix.t().to_owned();
 
-    // Step 4: Calculate log-pseudo-determinant from the positive eigenvalues
+    // Stage: Calculate the log-pseudo-determinant from the positive eigenvalues
     let log_det: f64 = s_eigenvalues_raw
         .iter()
         .filter(|&&ev| ev > tolerance)
         .map(|&ev| ev.ln())
         .sum();
 
-    // Step 5: Calculate derivatives using the correct transformed matrices
+    // Stage: Calculate derivatives using the correct transformed matrices
     let mut det1 = Array1::zeros(lambdas.len());
 
     // Compute pseudo-inverse S_lambda^+ using only eigenvalues above tolerance
@@ -1735,7 +1732,7 @@ mod tests {
 
         // The design matrix should be full-rank by construction
         // The code cleverly builds interaction terms using main effect bases that already
-        // have intercept columns removed, preventing rank deficiency from the start
+        // omit intercept columns to prevent rank deficiency from the start
         assert_eq!(
             rank,
             x.ncols(),

--- a/calibrate/data.rs
+++ b/calibrate/data.rs
@@ -22,8 +22,6 @@ use std::fs::File;
 use std::path::Path;
 use thiserror::Error;
 
-// Removed custom CSV parser in favor of using the Polars built-in functionality
-
 // --- Public Data Structures ---
 
 /// A container for validated data ready for model training.
@@ -129,7 +127,7 @@ mod internal {
             Ok(())
         }
 
-        // --- 1. Generate the exact list of required column names ---
+        // --- Generate the exact list of required column names ---
         let pc_names: Vec<String> = (1..=num_pcs).map(|i| format!("PC{i}")).collect();
         let mut required_cols: Vec<String> = Vec::with_capacity(2 + num_pcs);
         if include_phenotype {
@@ -138,7 +136,7 @@ mod internal {
         required_cols.push("score".to_string());
         required_cols.extend_from_slice(&pc_names);
 
-        // --- 2. Read and validate the DataFrame using Polars ---
+        // --- Read and validate the DataFrame using Polars ---
         println!("Loading data from '{path}'");
 
         // Use the Polars CsvReader for efficiency
@@ -179,7 +177,7 @@ mod internal {
             println!("Required 'weights' column found.");
         }
 
-        // --- 3. Convert columns efficiently to ndarray structures ---
+        // --- Convert columns efficiently to ndarray structures ---
 
         // Process phenotype column if needed
         let phenotype_opt = if include_phenotype {

--- a/calibrate/pirls.rs
+++ b/calibrate/pirls.rs
@@ -132,11 +132,11 @@ pub struct PirlsResult {
 /// This function implements the complete algorithm from mgcv's gam.fit3 function
 /// for fitting a GAM model with a fixed set of smoothing parameters:
 ///
-/// 1. Perform stable reparameterization ONCE at the beginning (mgcv's gam.reparam)
-/// 2. Transform the design matrix into this stable basis
-/// 3. Extract a single penalty square root from the transformed penalty
-/// 4. Run the P-IRLS loop entirely in the transformed basis
-/// 5. Transform the coefficients back to the original basis only when returning
+/// - Perform stable reparameterization ONCE at the beginning (mgcv's gam.reparam)
+/// - Transform the design matrix into this stable basis
+/// - Extract a single penalty square root from the transformed penalty
+/// - Run the P-IRLS loop entirely in the transformed basis
+/// - Transform the coefficients back to the original basis only when returning
 ///
 /// This architecture ensures optimal numerical stability throughout the entire
 /// fitting process by working in a well-conditioned parameter space.  
@@ -151,7 +151,7 @@ pub fn fit_model_for_fixed_rho(
     config: &ModelConfig,
 ) -> Result<PirlsResult, EstimationError> {
     // No test-specific hacks - the properly implemented algorithm should handle all cases
-    // Step 1: Convert rho (log smoothing parameters) to lambda (actual smoothing parameters)
+    // Stage: Convert rho (log smoothing parameters) to lambda (actual smoothing parameters)
     let lambdas = rho_vec.mapv(f64::exp);
 
     log::info!(
@@ -168,7 +168,7 @@ pub fn fit_model_for_fixed_rho(
         println!("Lambdas: {:?}", lambdas);
     }
 
-    // Step 2: Create lambda-INDEPENDENT balanced penalty root for stable rank detection
+    // Stage: Create the lambda-independent balanced penalty root for stable rank detection
     // This is computed ONCE from the unweighted penalty structure and never changes
     log::info!("Creating lambda-independent balanced penalty root for stable rank detection");
 
@@ -188,7 +188,7 @@ pub fn fit_model_for_fixed_rho(
         eb.shape()
     );
 
-    // Step 3: Perform stable reparameterization EXACTLY ONCE before P-IRLS loop
+    // Stage: Perform the stable reparameterization exactly once before the P-IRLS loop
     log::info!("Computing stable reparameterization for numerical stability");
     println!("[Reparam] ==> Entering stable_reparameterization...");
     let reparam_result = stable_reparameterization(rs_original, &lambdas.to_vec(), layout)?;
@@ -207,7 +207,7 @@ pub fn fit_model_for_fixed_rho(
         reparam_result.qs.shape()
     );
 
-    // Step 3: Transform the design matrix into the stable basis
+    // Stage: Transform the design matrix into the stable basis
     let x_transformed = x.dot(&reparam_result.qs);
 
     println!(
@@ -225,7 +225,7 @@ pub fn fit_model_for_fixed_rho(
         eb_transformed.sum()
     );
 
-    // Step 4: Extract penalty matrices using the TRULY lambda-independent eb
+    // Stage: Extract penalty matrices using the truly lambda-independent eb
     // Note: eb is computed from unweighted penalties and never changes with lambda
     let s_transformed = &reparam_result.s_transformed;
     // eb is already computed above as lambda-INDEPENDENT
@@ -235,7 +235,7 @@ pub fn fit_model_for_fixed_rho(
     let s_from_e_precomputed = e_transformed.t().dot(e_transformed);
     let x_transformed_t = x_transformed.t().to_owned();
 
-    // Step 5: Initialize P-IRLS state variables in the TRANSFORMED basis
+    // Stage: Initialize P-IRLS state variables in the transformed basis
     let mut beta_transformed = Array1::zeros(layout.total_coeffs);
     let mut eta = offset.to_owned();
     eta += &x_transformed.dot(&beta_transformed);
@@ -1156,15 +1156,15 @@ pub fn update_glm_vectors(
             let mut mu = eta_clamped.mapv(|e| 1.0 / (1.0 + (-e).exp()));
             mu.mapv_inplace(|v| v.clamp(PROB_EPS, 1.0 - PROB_EPS));
 
-            // 1. Calculate dμ/dη, which is μ(1-μ) for the logit link.
+            // Stage: Calculate dμ/dη, which is μ(1-μ) for the logit link.
             // This term must NOT include prior weights.
             let dmu_deta = &mu * &(1.0 - &mu);
 
-            // 2a. Weights: use true Fisher weights with a tiny floor to avoid literal zeros
+            // Stage: Form the true Fisher weights with a tiny floor to avoid literal zeros
             let fisher_w = dmu_deta.mapv(|v| v.max(MIN_WEIGHT));
             let weights = &prior_weights * &fisher_w;
 
-            // 2b. Working response denominator: allow a slightly larger floor for stability
+            // Stage: Build the working-response denominator with a slightly larger floor for stability
             let denom_z = dmu_deta.mapv(|v| v.max(MIN_D_FOR_Z));
             let z = &eta_clamped + &((&y.view().to_owned() - &mu) / &denom_z);
 
@@ -1279,21 +1279,21 @@ pub fn solve_penalized_least_squares(
         let z_eff = &z - &offset;
         let wz = &sqrt_w * &z_eff;
 
-        // 1) Use pivoted QR only to determine rank and column ordering
+        // Stage: Use pivoted QR only to determine rank and column ordering
         let (_, r_factor, pivot) = pivoted_qr_faer(&wx)?;
         let diag = r_factor.diag();
         let max_diag = diag.iter().fold(0.0f64, |a, &v| a.max(v.abs()));
         let tol = max_diag * 1e-12;
         let rank = diag.iter().filter(|&&v| v.abs() > tol).count();
 
-        // 2) Build submatrix from the first `rank` pivoted columns (in original index space)
+        // Stage: Build the submatrix from the first `rank` pivoted columns (in original index space)
         let kept_cols = &pivot[..rank];
         let mut wx_kept = Array2::<f64>::zeros((wx.nrows(), rank));
         for (j_new, &j_orig) in kept_cols.iter().enumerate() {
             wx_kept.column_mut(j_new).assign(&wx.column(j_orig));
         }
 
-        // 3) Solve LS on the kept submatrix via SVD (β_kept = V Σ⁺ Uᵀ wz)
+        // Stage: Solve least squares on the kept submatrix via SVD (β_kept = V Σ⁺ Uᵀ wz)
         use crate::calibrate::faer_ndarray::FaerSvd;
         let (u_opt, s, vt_opt) = wx_kept
             .svd(true, true)
@@ -1320,13 +1320,13 @@ pub fn solve_penalized_least_squares(
         }
         let beta_kept = vt.t().dot(&s_inv_utb); // length = rank
 
-        // 4) Construct full beta with dropped columns set to zero
+        // Stage: Construct the full beta vector with dropped columns set to zero
         let mut beta_transformed = Array1::<f64>::zeros(x_transformed.ncols());
         for (j_new, &j_orig) in kept_cols.iter().enumerate() {
             beta_transformed[j_orig] = beta_kept[j_new];
         }
 
-        // 5) Build Hessian H = Xᵀ W X (since S=0) using preallocated buffer
+        // Stage: Build the Hessian H = Xᵀ W X (since S=0) using the preallocated buffer
         use ndarray::linalg::{general_mat_mul, general_mat_vec_mul};
         let p_wx = wx.ncols();
         if workspace.xtwx_buf.dim() != (p_wx, p_wx) {
@@ -1531,9 +1531,7 @@ pub fn solve_penalized_least_squares(
 
     // EXACTLY following mgcv's pls_fit1 multi-stage approach:
 
-    //-----------------------------------------------------------------------
-    // STAGE 1: Initial QR decomposition of weighted design matrix
-    //-----------------------------------------------------------------------
+    // Stage: Initial QR decomposition of the weighted design matrix
 
     let stage1_timer = Instant::now();
     println!("[PLS Solver] Stage 1/5: Starting initial QR on weighted design matrix...");
@@ -1573,9 +1571,7 @@ pub fn solve_penalized_least_squares(
         stage1_timer.elapsed()
     );
 
-    //-----------------------------------------------------------------------
-    // STAGE 2: Rank determination using scaled augmented system
-    //-----------------------------------------------------------------------
+    // Stage: Rank determination using the scaled augmented system
 
     let stage2_timer = Instant::now();
     println!("[PLS Solver] Stage 2/5: Starting rank determination via scaled QR...");
@@ -1657,9 +1653,7 @@ pub fn solve_penalized_least_squares(
         stage2_timer.elapsed()
     );
 
-    //-----------------------------------------------------------------------
-    // STAGE 3: Create rank-reduced system using the rank pivot
-    //-----------------------------------------------------------------------
+    // Stage: Create the rank-reduced system using the rank pivot
 
     let stage3_timer = Instant::now();
     println!(
@@ -1692,9 +1686,7 @@ pub fn solve_penalized_least_squares(
         stage3_timer.elapsed()
     );
 
-    //-----------------------------------------------------------------------
-    // STAGE 4: Final QR decomposition on the unscaled, reduced system
-    //-----------------------------------------------------------------------
+    // Stage: Final QR decomposition on the unscaled, reduced system
 
     let stage4_timer = Instant::now();
     println!("[PLS Solver] Stage 4/5: Starting final QR on reduced system...");
@@ -1751,9 +1743,7 @@ pub fn solve_penalized_least_squares(
         );
     }
 
-    //-----------------------------------------------------------------------
-    // STAGE 5: Apply second transformation to the RHS and solve system
-    //-----------------------------------------------------------------------
+    // Stage: Apply the second transformation to the RHS and solve the system
 
     let stage5_timer = Instant::now();
     println!("[PLS Solver] Stage 5/5: Solving system and reconstructing results...");
@@ -1812,9 +1802,7 @@ pub fn solve_penalized_least_squares(
         beta_dropped[i] = sum / r_square[[i, i]];
     }
 
-    //-----------------------------------------------------------------------
-    // STAGE 6: Reconstruct the full coefficient vector
-    //-----------------------------------------------------------------------
+    // Stage: Reconstruct the full coefficient vector
     // Direct composition approach: orig_j = initial_pivot[ kept_positions[ final_pivot[j] ] ]
     // This maps each solved coefficient directly to its original column index
 
@@ -1854,9 +1842,7 @@ pub fn solve_penalized_least_squares(
         }
     }
 
-    //-----------------------------------------------------------------------
-    // STAGE 7: Construct the penalized Hessian
-    //-----------------------------------------------------------------------
+    // Stage: Construct the penalized Hessian
     // Build XtWX without re-touching n using Stage 1 QR result.
     // From (sqrt(W)X) * P = Q * R  =>  Xᵀ W X = P (Rᵀ R) Pᵀ
     // Compute RᵀR into a preallocated buffer
@@ -1913,9 +1899,7 @@ pub fn solve_penalized_least_squares(
         }
     }
 
-    //-----------------------------------------------------------------------
-    // STAGE 8: Calculate EDF and scale parameter
-    //-----------------------------------------------------------------------
+    // Stage: Calculate the EDF and scale parameter
 
     // Calculate effective degrees of freedom using H and XtWX directly (stable)
     let mut edf = calculate_edf(&penalized_hessian, e_transformed)?;
@@ -1989,7 +1973,7 @@ fn pivoted_qr_faer(
     let n = matrix.ncols();
     let k = m.min(n);
 
-    // Step 1: Convert ndarray to faer Mat
+    // Stage: Convert ndarray to a faer matrix
     let mut a_faer = Mat::zeros(m, n);
     for i in 0..m {
         for j in 0..n {
@@ -1997,11 +1981,11 @@ fn pivoted_qr_faer(
         }
     }
 
-    // Step 2: Perform the column-pivoted QR decomposition using the high-level API
+    // Stage: Perform the column-pivoted QR decomposition using the high-level API
     // This guarantees that Q, R, and P are all from the same consistent decomposition
     let qr = ColPivQr::new(a_faer.as_ref());
 
-    // Step 3: Extract the consistent Q factor (thin version)
+    // Stage: Extract the consistent Q factor (thin version)
     let q_faer = qr.compute_thin_Q();
     let mut q = Array2::zeros((m, k));
     for i in 0..m {
@@ -2010,7 +1994,7 @@ fn pivoted_qr_faer(
         }
     }
 
-    // Step 4: Extract the consistent R factor
+    // Stage: Extract the consistent R factor
     let r_faer = qr.R();
     let mut r = Array2::zeros((k, n));
     for i in 0..k {
@@ -2019,7 +2003,7 @@ fn pivoted_qr_faer(
         }
     }
 
-    // Step 5: Extract the consistent column permutation (pivot)
+    // Stage: Extract the consistent column permutation (pivot)
     let perm = qr.P();
     let (p0_slice, p1_slice) = perm.arrays();
     let p0: Vec<usize> = p0_slice.to_vec();
@@ -2169,14 +2153,14 @@ pub fn compute_final_penalized_hessian(
 
     let p = x.ncols();
 
-    // Step 1: Perform the QR decomposition of sqrt(W)X to get R_bar
+    // Stage: Perform the QR decomposition of sqrt(W)X to get R_bar
     let sqrt_w = weights.mapv(|w| w.sqrt()); // Weights are guaranteed non-negative with current link functions
     let wx = &x * &sqrt_w.view().insert_axis(ndarray::Axis(1));
     let (_, r_bar) = wx.qr().map_err(EstimationError::LinearSystemSolveFailed)?;
     let r_rows = r_bar.nrows().min(p);
     let r1_full = r_bar.slice(s![..r_rows, ..]);
 
-    // Step 2: Get the square root of the penalty matrix, E
+    // Stage: Get the square root of the penalty matrix, E
     // We need to use eigendecomposition as S_lambda is not necessarily from a single root
     let (eigenvalues, eigenvectors) = s_lambda
         .eigh(Side::Lower)
@@ -2204,7 +2188,7 @@ pub fn compute_final_penalized_hessian(
         }
     }
 
-    // Step 3: Form the augmented matrix [R1; E_t]
+    // Stage: Form the augmented matrix [R1; E_t]
     // Note: Here we use the full, un-truncated matrices because we are just computing
     // the Hessian for a given model, not performing rank detection.
     let e_t = e.t();
@@ -2215,12 +2199,12 @@ pub fn compute_final_penalized_hessian(
         .assign(&r1_full);
     augmented_matrix.slice_mut(s![r_rows.., ..]).assign(&e_t);
 
-    // Step 4: Perform QR decomposition on the augmented matrix
+    // Stage: Perform the QR decomposition on the augmented matrix
     let (_, r_aug) = augmented_matrix
         .qr()
         .map_err(EstimationError::LinearSystemSolveFailed)?;
 
-    // Step 5: The penalized Hessian is R_aug' * R_aug
+    // Stage: Recognize that the penalized Hessian is R_aug' * R_aug
     let h_final = r_aug.t().dot(&r_aug);
 
     Ok(h_final)
@@ -2300,7 +2284,7 @@ mod tests {
         link_function: LinkFunction,
         signal_type: SignalType,
     ) -> Result<TestScenarioResult, Box<dyn std::error::Error>> {
-        // --- 1. Data Generation ---
+        // --- Data generation ---
         let n_samples = 1000;
         let mut rng = StdRng::seed_from_u64(42);
         let p = Array1::linspace(-2.0, 2.0, n_samples);
@@ -2339,7 +2323,7 @@ mod tests {
             weights: Array1::from_elem(n_samples, 1.0),
         };
 
-        // --- 2. Model Configuration ---
+        // --- Model configuration ---
         let config = ModelConfig {
             link_function,
             penalty_order: 2,
@@ -2361,7 +2345,7 @@ mod tests {
             interaction_orth_alpha: HashMap::new(),
         };
 
-        // --- 3. Run the Fit ---
+        // --- Run the fit ---
         let (x_matrix, rs_original, layout) = setup_pirls_test_inputs(&data, &config)?;
         let rho_vec = Array1::<f64>::zeros(rs_original.len()); // Size to match penalties
 
@@ -2377,7 +2361,7 @@ mod tests {
             &config,
         )?;
 
-        // --- 4. Return all necessary components for assertion ---
+        // --- Return all necessary components for assertion ---
         Ok(TestScenarioResult {
             pirls_result,
             x_matrix,
@@ -2818,7 +2802,7 @@ mod tests {
 
         // === PHASE 6: Assert stability and correctness ===
 
-        // 1. Assert Finiteness: The result must not contain any non-finite numbers.
+        // Stage: Assert finiteness by ensuring the result contains no non-finite numbers
         assert!(
             pirls_result.deviance.is_finite(),
             "Deviance must be a finite number, but was {}",
@@ -2836,7 +2820,7 @@ mod tests {
             "The penalized Hessian must be finite."
         );
 
-        // 2. Assert Correctness (Sanity Check): The model should learn a flat function.
+        // Stage: Assert correctness by verifying the model learns a flat function
         // Transform beta back to the original, interpretable basis.
         let beta_original = pirls_result
             .reparam_result
@@ -3535,7 +3519,7 @@ mod tests {
     fn test_pivoted_qr_permutation_is_reliable() {
         use ndarray::arr2;
 
-        // 1. SETUP: Create a matrix that is tricky to pivot.
+        // Stage: Set up a matrix that is tricky to pivot
         // It's nearly rank-deficient, with highly correlated columns, forcing a non-trivial pivot.
         // This is representative of the design matrices created in the model tests.
         let a = arr2(&[
@@ -3545,10 +3529,10 @@ mod tests {
             [8.0, 9.0, 17.0, 8.0000004],
         ]);
 
-        // 2. EXECUTION: Call the function under test.
+        // Stage: Execute the function under test
         let (q, r, pivot) = pivoted_qr_faer(&a).expect("QR decomposition itself should not fail");
 
-        // 3. VERIFICATION: Check if the fundamental QR identity holds.
+        // Stage: Verify that the fundamental QR identity holds
         // First, apply the permutation to the original matrix 'a'.
         let a_pivoted = pivot_columns(a.view(), &pivot);
 
@@ -3565,7 +3549,7 @@ mod tests {
         println!("Q*R Product:\n{:?}", qr_product);
         println!("Reconstruction Error Norm: {}", reconstruction_error_norm);
 
-        // 4. ASSERTION: The reconstruction error must be small, proving the pivot is correct.
+        // Stage: Assert that the reconstruction error is small, proving the pivot is correct
         // A correct implementation should have an error norm close to machine epsilon (~1e-15).
         // An error norm greater than 1e-6 would be a definitive failure.
         assert!(

--- a/calibrate/tests/bench.py
+++ b/calibrate/tests/bench.py
@@ -77,9 +77,6 @@ def run_capture(cmd, cwd=None, env=None):
     return ret, lines
 
 
-# (Removed OpenBLAS annotate helpers and DSO priming)
-
-
 def _filter_tree(lines: list[str]) -> list[str]:
     """Filter perf tree output by stanza and drop 0-children stanzas.
 
@@ -557,8 +554,6 @@ def main():
             f.write("</pre>")
         else:
             f.write("<p>Subpath merge unavailable (install inferno-collapse-perf).</p>")
-
-        # (Removed OpenBLAS annotate section)
 
     print(f"\nHTML report -> {html_path}")
     try:

--- a/calibrate/tests/rds_view.py
+++ b/calibrate/tests/rds_view.py
@@ -13,8 +13,7 @@ TRUNCATE_KEEP = 100       # Keep this many items at the start and end
 
 def main():
     """Converts an RDS file to a rounded and truncated R script."""
-    # Step 0: Pre-flight checks for input file and Rscript
-    # ----------------------------------------------------
+    # Stage: Pre-flight checks for the input file and Rscript
     if not INPUT.exists():
         sys.stderr.write(f"Error: Input file '{INPUT}' not found in {Path('.').resolve()}\n")
         sys.exit(1)
@@ -27,21 +26,18 @@ def main():
         )
         sys.exit(2)
 
-    # Step 1: Generate the full-precision R file using Rscript.
-    # -----------------------------------------------------------
+    # Stage: Generate the full-precision R file using Rscript.
     print(f"1. Generating full-precision R code from '{INPUT}'...")
     generate_r_file()
     print(f"   Successfully generated intermediate file '{OUTPUT}'.")
 
-    # Step 2: Read the generated file and round all floating-point numbers.
-    # ----------------------------------------------------------------------
+    # Stage: Read the generated file and round all floating-point numbers.
     print(f"2. Rounding all floating-point numbers to {DECIMAL_PLACES} decimal places...")
     content = OUTPUT.read_text()
     rounded_content = round_floats_in_text(content)
     print("   Rounding complete.")
 
-    # Step 3: Find and truncate very long lists of numbers in the rounded content.
-    # --------------------------------------------------------------------------
+    # Stage: Find and truncate very long lists of numbers in the rounded content.
     print(f"3. Truncating number lists longer than {TRUNCATE_THRESHOLD} elements...")
     final_content, num_truncated = truncate_long_lists_in_text(rounded_content)
     if num_truncated > 0:
@@ -50,7 +46,6 @@ def main():
         print("   No lists were long enough to require truncation.")
 
     # Final Step: Write the processed content back to the file.
-    # ---------------------------------------------------------
     OUTPUT.write_text(final_content)
 
     print("\n--- Success! ---")


### PR DESCRIPTION
## Summary
- replace numbered step comments across calibrate modules with stage-oriented descriptions to avoid stale numbering
- convert numbered documentation lists to bullet lists for basis creation, gradient routines, and other helpers
- remove horizontal rule separators from the RDS tooling comments for cleaner guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8bbdb990c832e9a54e53b30117e1c