### PR TITLE
Fix CalibratorModel initialization with penalty nullspace dims

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -4003,6 +4003,7 @@ mod tests {
             pred_constraint_transform: schema.pred_constraint_transform,
             stz_se: schema.stz_se,
             stz_dist: schema.stz_dist,
+            penalty_nullspace_dims: schema.penalty_nullspace_dims,
             standardize_pred: schema.standardize_pred,
             standardize_se: schema.standardize_se,
             standardize_dist: schema.standardize_dist,


### PR DESCRIPTION
## Summary
- populate the CalibratorModel initialization with the schema-derived penalty_nullspace_dims to match the struct definition

## Testing
- cargo check
- cargo test --no-run

------
https://chatgpt.com/codex/tasks/task_e_68d9f961b13c832e91d6792732afc316