### PR TITLE
Fix sign logic for projected gradients at bounds

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -761,10 +761,10 @@ pub fn train_model(
                     // Projected/KKT handling at active bounds in rho-space
                     let tol = 1e-8;
                     for i in 0..rho.len() {
-                        if rho[i] <= -RHO_BOUND + tol && g_rho[i] < 0.0 {
+                        if rho[i] <= -RHO_BOUND + tol && g_rho[i] > 0.0 {
                             g_rho[i] = 0.0; // can't move outward below lower bound
                         }
-                        if rho[i] >= RHO_BOUND - tol && g_rho[i] > 0.0 {
+                        if rho[i] >= RHO_BOUND - tol && g_rho[i] < 0.0 {
                             g_rho[i] = 0.0; // can't move outward above upper bound
                         }
                     }
@@ -2359,10 +2359,10 @@ pub mod internal {
                             // Projected/KKT handling at active bounds in rho-space
                             let tol = 1e-8;
                             for i in 0..rho.len() {
-                                if rho[i] <= -RHO_BOUND + tol && grad[i] < 0.0 {
+                                if rho[i] <= -RHO_BOUND + tol && grad[i] > 0.0 {
                                     grad[i] = 0.0;
                                 }
-                                if rho[i] >= RHO_BOUND - tol && grad[i] > 0.0 {
+                                if rho[i] >= RHO_BOUND - tol && grad[i] < 0.0 {
                                     grad[i] = 0.0;
                                 }
                             }


### PR DESCRIPTION
## Summary
- correct the projected-gradient masking conditions at the rho bounds
- ensure feasible descent directions are preserved while outward directions are zeroed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9fc347afc832e914c3a90d2c03671