### PR TITLE
Add row shape guards to calibrator fitting paths

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -1077,6 +1077,16 @@ pub fn optimize_external_design(
     s_list: &[Array2<f64>],
     opts: &ExternalOptimOptions,
 ) -> Result<ExternalOptimResult, EstimationError> {
+    if !(y.len() == w.len() && y.len() == x.nrows() && y.len() == offset.len()) {
+        return Err(EstimationError::InvalidInput(format!(
+            "Row mismatch: y={}, w={}, X.rows={}, offset={}",
+            y.len(),
+            w.len(),
+            x.nrows(),
+            offset.len()
+        )));
+    }
+
     use crate::calibrate::construction::compute_penalty_square_roots;
     use crate::calibrate::model::ModelConfig;
 


### PR DESCRIPTION
## Summary
- add upfront row-shape validation to `fit_calibrator`
- guard the external REML optimizer against mismatched tall inputs
- adjust the PIRLS non-convergence test to exercise the new shape guard

## Testing
- `cargo test pirls_nonconvergence_is_caught_and_propagated`


------
https://chatgpt.com/codex/tasks/task_e_68db4aa7a7f8832ea887c6e53d7b4d48