### PR TITLE
Fix sign convention in LAML calculation

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -1815,7 +1815,10 @@ mod tests {
         let logdet_s = reparam.log_det;
 
         let penalised_ll = ll - pen;
-        let laml = penalised_ll + 0.5 * logdet_s - 0.5 * logdet_h;
+        // Laplace approximate marginal log-likelihood (Wood 2011, Eq. 14):
+        // L = ℓ_p(β̂) - 0.5 log|S_λ|_+ + 0.5 log|H_eff|.
+        // Here ℓ_p = log-likelihood minus 0.5 βᵀ S_λ β.
+        let laml = penalised_ll - 0.5 * logdet_s + 0.5 * logdet_h;
         let cost = -laml;
 
         LamlBreakdown {

--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -2034,7 +2034,7 @@ pub mod internal {
                         }
                     };
 
-                    // The LAML score is Lp + 0.5*log|S| - 0.5*log|H| + Mp/2*log(2πφ)
+                    // The LAML score is Lp - 0.5*log|S| + 0.5*log|H| + Mp/2*log(2πφ)
                     // Mp is null space dimension (number of unpenalized coefficients)
                     // For logit, scale parameter is typically fixed at 1.0, but include for completeness
                     let phi = 1.0; // Logit family typically has dispersion parameter = 1
@@ -2045,7 +2045,7 @@ pub mod internal {
                     let penalty_rank = pirls_result.reparam_result.e_transformed.nrows();
                     let mp = (self.layout.total_coeffs - penalty_rank) as f64;
 
-                    let laml = penalised_ll + 0.5 * log_det_s - 0.5 * log_det_h
+                    let laml = penalised_ll - 0.5 * log_det_s + 0.5 * log_det_h
                         + (mp / 2.0) * (2.0 * std::f64::consts::PI * phi).ln();
 
                     // Diagnostics: effective degrees of freedom via trace identity


### PR DESCRIPTION
## Summary
- correct the Laplace approximate marginal log-likelihood sign convention for the S_lambda term
- update inline documentation to match the corrected formula

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68dbdb60a524832ea6d407dc6d79d3c7