### PR TITLE
Fix penalty nullspace dimensions for calibrator tests

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -4097,6 +4097,7 @@ mod tests {
             schema.penalty_nullspace_dims.0,
             schema.penalty_nullspace_dims.1,
             schema.penalty_nullspace_dims.2,
+            schema.penalty_nullspace_dims.3,
         ];
         let fit_result = fit_calibrator(
             y.view(),
@@ -6202,6 +6203,7 @@ mod tests {
             schema.penalty_nullspace_dims.0,
             schema.penalty_nullspace_dims.1,
             schema.penalty_nullspace_dims.2,
+            schema.penalty_nullspace_dims.3,
         ];
         let result = fit_calibrator(
             y.view(),


### PR DESCRIPTION
## Summary
- include the missing fourth penalty nullspace dimension when preparing calibrator tests

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dcaa3900c4832e8e67d22a97a60e62