### PR TITLE
Adjust ECE drop requirement to 20 percent

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -4161,10 +4161,13 @@ mod tests {
         let cal_auc = auc(&y, &cal_probs);
 
         // Verify calibration improvements
+        let required_relative_improvement = 0.20; // 20% drop in ECE
+        let max_allowed_cal_ece = (1.0 - required_relative_improvement) * base_ece;
         assert!(
-            cal_ece <= 0.65 * base_ece + 1e-4,
-            "Calibrated ECE ({:.4}) should be meaningfully lower than base ECE ({:.4})",
+            cal_ece <= max_allowed_cal_ece,
+            "Calibrated ECE ({:.4}) should be at least {:.0}% lower than base ECE ({:.4})",
             cal_ece,
+            required_relative_improvement * 100.0,
             base_ece
         );
 


### PR DESCRIPTION
## Summary
- require calibrator ECE improvements to achieve at least a 20% relative drop
- clarify the assertion message to communicate the expected percentage improvement

## Testing
- cargo test calibrator_fixes_sinusoidal_miscalibration_binary

------
https://chatgpt.com/codex/tasks/task_e_68dcb18408f8832ea98d9b498ef421b0