### PR TITLE
Fix active axis count shadowing in calibrator

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -1736,11 +1736,11 @@ pub fn fit_calibrator(
         active_penalty_count,
         link
     );
-    let active_axes = penalties
+    let active_axis_count = penalties
         .iter()
         .filter(|matrix| matrix.iter().any(|&v| v.abs() > 1e-12))
         .count();
-    let smooth_desc = match active_axes {
+    let smooth_desc = match active_axis_count {
         0 => "no calibrator smooths".to_string(),
         1 => "the calibrator smooth".to_string(),
         n => format!("all {} calibrator smooths", n),


### PR DESCRIPTION
## Summary
- rename the scalar count of active penalty axes to avoid shadowing the axes list
- ensure the active axis vector can still be iterated when filling lambdas and EDF results

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68dd41546764832e94c0517057492769