### PR TITLE
Fix ModelLayout import for production build

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -3,7 +3,6 @@ use crate::calibrate::basis::{
 };
 use crate::calibrate::estimate::EstimationError;
 use crate::calibrate::hull::PeeledHull;
-#[cfg(test)]
 use crate::calibrate::construction::ModelLayout;
 use crate::calibrate::model::{BasisConfig, LinkFunction};
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- ensure `ModelLayout` is imported in `calibrate::calibrator` for all builds so production code can use it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd57ae594c832e9d2537369dba1727