### PR TITLE
Remove redundant leverage eta computation

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -198,7 +198,6 @@ pub fn compute_alo_features(
     // Blocked solves: K S = Uᵀ; compute a_ii and var_full within the same block
     let block = 8192usize.min(n.max(1));
     let mut aii = Array1::<f64>::zeros(n);
-    let mut leverage_eta_tilde = Array1::<f64>::zeros(n); // Renamed to avoid shadowing
     let mut se_tilde = Array1::<f64>::zeros(n);
     let eta_hat = base.x_transformed.dot(&base.beta_transformed);
     let z = base.solve_working_response.clone();
@@ -306,9 +305,6 @@ pub fn compute_alo_features(
                 diag_counter += 1;
             }
 
-            // ALO predictor in the same pass (no guard needed here)
-            let denom_alo = denom_raw;
-            leverage_eta_tilde[irow] = (eta_hat[irow] - aii[irow] * z[irow]) / denom_alo;
         }
 
         col_start = col_end;


### PR DESCRIPTION
## Summary
- remove the redundant first-pass eta_tilde calculation in `compute_alo_features`
- rely on the guarded final pass to avoid potential division-by-zero when 1 - a_ii is tiny

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd5800186c832ea22915fdc2a11914