### PR TITLE
Fix calibrator smooth logging to reflect active penalties

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -1731,11 +1731,7 @@ pub fn fit_calibrator(
         active_penalty_count,
         link
     );
-    let active_axis_count = penalties
-        .iter()
-        .filter(|matrix| matrix.iter().any(|&v| v.abs() > 1e-12))
-        .count();
-    let smooth_desc = match active_axis_count {
+    let smooth_desc = match active_penalty_count {
         0 => "no calibrator smooths".to_string(),
         1 => "the calibrator smooth".to_string(),
         n => format!("all {} calibrator smooths", n),


### PR DESCRIPTION
## Summary
- base the calibrator smooth logging on the filtered active penalties so the message mirrors optimization state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5b4a7ef0832eb4aeb7c9a9ebec5d