### PR TITLE
Fix RemlState documentation to reference wolfe_bfgs optimizer

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -1347,8 +1347,8 @@ pub mod internal {
         }
     }
 
-    /// Holds the state for the outer REML optimization. Implements `CostFunction`
-    /// and `Gradient` for the `argmin` library.
+    /// Holds the state for the outer REML optimization and supplies cost and
+    /// gradient evaluations to the `wolfe_bfgs` optimizer.
     ///
     /// The `cache` field uses `RefCell` to enable interior mutability. This is a crucial
     /// performance optimization. The `cost_and_grad` closure required by the BFGS


### PR DESCRIPTION
## Summary
- update the RemlState documentation comment to reference the wolfe_bfgs optimizer instead of argmin

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68dd5b911008832ebc3ea2187063ff7f