### PR TITLE
Include offset in unpenalized scale computation

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -262,8 +262,9 @@ pub fn train_model(
             LinkFunction::Logit => 1.0,
             LinkFunction::Identity => {
                 // Weighted RSS over residuals divided by (n - edf)
-                let fitted = x_matrix.dot(&final_beta_original);
-                let residuals = data.y.clone() - &fitted;
+                let mut fitted = reml_state.offset().to_owned();
+                fitted += &x_matrix.dot(&final_beta_original);
+                let residuals = reml_state.y().to_owned() - &fitted;
                 let weighted_rss: f64 = data
                     .weights
                     .iter()


### PR DESCRIPTION
## Summary
- add the model offset when computing the unpenalized identity-link scale so it matches the regular path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd5b844100832eb9f513567adc619e