### PR TITLE
Remove unused ModelLayout import from calibrator

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -1907,7 +1907,6 @@ pub fn fit_calibrator(
 
 #[cfg(test)]
 mod tests {
-    use crate::calibrate::construction::ModelLayout;
     use super::*;
     use crate::calibrate::basis::null_range_whiten;
     use ndarray::{Array1, Array2, Axis};


### PR DESCRIPTION
## Summary
- remove an unused ModelLayout import from `calibrate::calibrator`

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68dd60c73bc8832ea4890f5511c3b29d