### PR TITLE
Fix test-only import for calibrator tests

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -5,6 +5,8 @@ use crate::calibrate::estimate::EstimationError;
 use crate::calibrate::hull::PeeledHull;
 use crate::calibrate::model::{BasisConfig, LinkFunction};
 #[cfg(test)]
+use crate::calibrate::construction::ModelLayout;
+#[cfg(test)]
 use crate::calibrate::model::ModelConfig;
 use crate::calibrate::pirls; // for PirlsResult
 // no penalty root helpers needed directly here


### PR DESCRIPTION
## Summary
- import `ModelLayout` directly from the construction module for calibrator tests

## Testing
- cargo +nightly build
- cargo +nightly test --no-run

------
https://chatgpt.com/codex/tasks/task_e_68dd632933dc832eb9ab990b22534418