### PR TITLE
Remove unused ModelLayout import from calibrator module

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -5,8 +5,6 @@ use crate::calibrate::estimate::EstimationError;
 use crate::calibrate::hull::PeeledHull;
 use crate::calibrate::model::{BasisConfig, LinkFunction};
 #[cfg(test)]
-use crate::calibrate::construction::ModelLayout;
-#[cfg(test)]
 use crate::calibrate::model::ModelConfig;
 use crate::calibrate::pirls; // for PirlsResult
 // no penalty root helpers needed directly here


### PR DESCRIPTION
## Summary
- remove the unused `ModelLayout` import in `calibrate::calibrator` to satisfy the crate-level lint

## Testing
- cargo +nightly build
- cargo +nightly test --no-run

------
https://chatgpt.com/codex/tasks/task_e_68dd698dd3e8832e942d0e7acd8ba2ea