### PR TITLE
Clarify LOO covariance comment

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -2960,9 +2960,10 @@ mod tests {
                 ci += x_i[r] * s[(r, 0)];
             }
 
-            // Correct "true" LOO SE: uses inflation by 1/(1-aii) from the full fit
-            // We have the K from the LOO fit, which already includes the 1/(1-aii) inflation effect
-            // This matches our correct ALO formula: SE = sqrt(phi * ci / (1-aii))
+            // Correct "true" LOO SE: the covariance comes from re-estimating the fit without point i
+            // Building K from the LOO fit captures the re-estimated weights directly; it is not
+            // an explicit 1/(1 - a_ii) inflation of the full-fit covariance
+            // This matches our correct ALO formula: SE = sqrt(phi * ci / (1 - a_ii))
             loo_pred[i] = eta_i;
             loo_se[i] = ci.sqrt();
         }


### PR DESCRIPTION
## Summary
- correct the misleading comment about the LOO covariance construction and 1/(1 - a_ii) inflation

## Testing
- no tests were run (not needed for comment-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd7135b710832ea37c398127ba1968