### PR TITLE
Fix calibrator STZ column mean test nullspace dims

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -6980,11 +6980,7 @@ mod tests {
             x_uniform.view(),
             offset_uniform.view(),
             &penalties_uniform,
-            &[
-                schema_uniform.penalty_nullspace_dims.0,
-                schema_uniform.penalty_nullspace_dims.1,
-                schema_uniform.penalty_nullspace_dims.2,
-            ],
+            &dims4(schema_uniform.penalty_nullspace_dims),
             LinkFunction::Logit,
         )
         .unwrap();
@@ -6999,11 +6995,7 @@ mod tests {
             x_nonuniform.view(),
             offset_nonuniform.view(),
             &penalties_nonuniform,
-            &[
-                schema_nonuniform.penalty_nullspace_dims.0,
-                schema_nonuniform.penalty_nullspace_dims.1,
-                schema_nonuniform.penalty_nullspace_dims.2,
-            ],
+            &dims4(schema_nonuniform.penalty_nullspace_dims),
             LinkFunction::Logit,
         )
         .unwrap();


### PR DESCRIPTION
## Summary
- ensure the STZ column mean test passes all four penalty nullspace dimensions to `fit_calibrator`
- prevent nullspace dimension mismatches when SE or distance blocks are dropped under weighting

## Testing
- `cargo test calibrate::calibrator::tests::test_stz_checks_column_means_not_coef_sums -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68ddf232af00832ead6de00363f997e0