### PR TITLE
Fix calibrator tests to pass full nullspace dims

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -4724,11 +4724,7 @@ mod tests {
         let (x_cal, penalties, schema, offset) =
             build_calibrator_design(&alo_features, &spec).unwrap();
 
-        let penalty_nullspace_dims = [
-            schema.penalty_nullspace_dims.0,
-            schema.penalty_nullspace_dims.1,
-            schema.penalty_nullspace_dims.2,
-        ];
+        let penalty_nullspace_dims = dims4(schema.penalty_nullspace_dims);
         let fit_result = fit_calibrator(
             y.view(),
             w.view(),
@@ -6617,11 +6613,7 @@ mod tests {
 
         // Try to fit calibrator with large penalties
         let w = Array1::<f64>::ones(n);
-        let penalty_nullspace_dims = [
-            schema.penalty_nullspace_dims.0,
-            schema.penalty_nullspace_dims.1,
-            schema.penalty_nullspace_dims.2,
-        ];
+        let penalty_nullspace_dims = dims4(schema.penalty_nullspace_dims);
         let result = fit_calibrator(
             y.view(),
             w.view(),
@@ -6631,7 +6623,6 @@ mod tests {
             &penalty_nullspace_dims,
             LinkFunction::Logit,
         );
-
         // The fit should succeed with large lambdas
         assert!(
             result.is_ok(),


### PR DESCRIPTION
## Summary
- convert the schema nullspace tuple into a four-element array before passing it to `fit_calibrator`
- keep the large-lambda stability test on the happy path by matching the optimizer's nullspace expectations

## Testing
- cargo test calibrator_large_lambda_is_stable_low_edf -- --nocapture
- cargo test calibrator_sine_noninjective_improves_accuracy_and_not_worse -- --nocapture


------
https://chatgpt.com/codex/tasks/task_e_68de043ba0a8832e9dab9d91dfb7fbc8