### PR TITLE
Fix calibrator slicing and align interaction bases with stored coefficients

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -1579,8 +1579,9 @@ pub fn predict_calibrator(
             .assign(&b_pred.slice(s![.., ..n_pred_cols]));
     }
     if n_pred_param_cols > 0 {
+        let pred_param_block = b_pred_param.slice(s![.., ..n_pred_param_cols]);
         x.slice_mut(s![.., pred_param_range.start..pred_param_range.end])
-            .assign(&b_pred_param.slice(s![.., ..n_pred_param_cols]));
+            .assign(&pred_param_block);
     }
     if n_se_cols > 0 {
         let off = se_range.start;


### PR DESCRIPTION
## Summary
- fix the prediction-time calibrator slice for the parametric block to use a proper 2D view
- align anisotropic interaction layout and penalties with the stored range-space bases
- update prediction design reconstruction to honor the number of stored interaction coefficients

## Testing
- cargo test --lib calibrate::construction::tests::test_predict_linear_equals_x_beta -- --exact

------
https://chatgpt.com/codex/tasks/task_e_68de0d32a6dc832ea4016f73783a0934