### PR TITLE
Refine calibrator parity tests

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -25,6 +25,7 @@
 use wolfe_bfgs::{Bfgs, BfgsSolution};
 
 // Crate-level imports
+use crate::calibrate::calibrator::active_penalty_nullspace_dims;
 use crate::calibrate::construction::{
     ModelLayout, build_design_and_penalty_matrices, calculate_condition_number,
     compute_penalty_square_roots,
@@ -962,12 +963,8 @@ pub fn train_model(
             None
         } else {
             eprintln!("[CAL] Fitting post-process calibrator (shared REML/BFGS)...");
-            let penalty_nullspace_dims = [
-                schema.penalty_nullspace_dims.0,
-                schema.penalty_nullspace_dims.1,
-                schema.penalty_nullspace_dims.2,
-                schema.penalty_nullspace_dims.3,
-            ];
+            let penalty_nullspace_dims =
+                active_penalty_nullspace_dims(&schema, &penalties_cal);
             let (beta_cal, lambdas_cal, scale_cal, edf_pair, fit_meta) = cal::fit_calibrator(
                 reml_state.y(),
                 reml_state.weights(),

--- a/calibrate/model.rs
+++ b/calibrate/model.rs
@@ -847,6 +847,24 @@ mod internal {
 }
 
 #[cfg(test)]
+pub(crate) fn internal_construct_design_matrix(
+    p_new: ArrayView1<f64>,
+    pcs_new: ArrayView2<f64>,
+    config: &ModelConfig,
+    coeffs: &MappedCoefficients,
+) -> Result<Array2<f64>, ModelError> {
+    internal::construct_design_matrix(p_new, pcs_new, config, coeffs)
+}
+
+#[cfg(test)]
+pub(crate) fn internal_flatten_coefficients(
+    coeffs: &MappedCoefficients,
+    config: &ModelConfig,
+) -> Result<Array1<f64>, ModelError> {
+    internal::flatten_coefficients(coeffs, config)
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     // TrainingData is not used in tests


### PR DESCRIPTION
## Summary
- add an `active_penalty_nullspace_dims` helper and reuse it across calibrator fits in tests and estimator code
- switch the calibrator round-trip lambda assertions to a relative tolerance
- rebuild the predict-linear parity test using the same internal helpers as inference, adding test-only wrappers

## Testing
- cargo test calibrate::calibrator::tests::calibrator_persists_and_roundtrips_exactly
- cargo test calibrate::construction::tests::test_predict_linear_equals_x_beta


------
https://chatgpt.com/codex/tasks/task_e_68de7dbf24d4832e918a8da5a75be768