### PR TITLE
Enforce strict layout validation for trained models

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -344,7 +344,9 @@ pub fn train_model(
             calibrator: None,
         };
 
-        trained_model.assert_layout_consistency_with_layout(&layout);
+        trained_model
+            .assert_layout_consistency_with_layout(&layout)
+            .map_err(|err| EstimationError::LayoutError(err.to_string()))?;
 
         return Ok(trained_model);
     }
@@ -1100,7 +1102,9 @@ pub fn train_model(
         calibrator: calibrator_opt,
     };
 
-    trained_model.assert_layout_consistency_with_layout(&layout);
+    trained_model
+        .assert_layout_consistency_with_layout(&layout)
+        .map_err(|err| EstimationError::LayoutError(err.to_string()))?;
 
     Ok(trained_model)
 }


### PR DESCRIPTION
## Summary
- return explicit errors when required range and null transforms are missing during layout rebuilds and consistency checks
- make layout consistency validation return a `ModelError` and include a flattened coefficient count check against the layout
- propagate layout validation failures from training as `EstimationError::LayoutError`

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dea06904d8832ea5604a4a9584747c