### PR TITLE
Promote calibration debug assertions to runtime checks

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -361,7 +361,7 @@ pub fn compute_alo_features(
     for i in 0..n {
         // Compute denominator without guard for accurate ALO prediction
         let denom = 1.0 - aii[i];
-        debug_assert!(denom > 0.0, "Unexpected a_ii >= 1.0 in ALO");
+        assert!(denom > 0.0, "Unexpected a_ii >= 1.0 in ALO");
 
         // CORRECT ALO predictor formula using the Sherman-Morrison identity:
         //   η̂^{(-i)} = (η̂_i - a_ii * z_i) / (1 - a_ii)
@@ -1511,7 +1511,7 @@ pub fn build_calibrator_design(
     };
 
     // Early self-check to ensure built penalties match X width
-    debug_assert!(
+    assert!(
         penalties
             .iter()
             .all(|s| s.nrows() == x.ncols() && s.ncols() == x.ncols()),
@@ -3009,7 +3009,7 @@ mod tests {
             }
 
             let denom = 1.0 - aii;
-            debug_assert!(
+            assert!(
                 denom > 0.0,
                 "Unexpected a_ii >= 1.0 in fixed-weight LOO baseline: a_ii = {:.6e}",
                 aii

--- a/calibrate/construction.rs
+++ b/calibrate/construction.rs
@@ -515,9 +515,9 @@ pub fn build_design_and_penalty_matrices(
         };
 
     if matches!(config.interaction_penalty, InteractionPenaltyKind::Anisotropic) {
-        debug_assert_eq!(pgs_int_ncols, pgs_main_basis_unc.ncols());
+        assert_eq!(pgs_int_ncols, pgs_main_basis_unc.ncols());
         for (idx, basis) in pc_unconstrained_bases_main.iter().enumerate() {
-            debug_assert_eq!(pc_int_ncols[idx], basis.ncols());
+            assert_eq!(pc_int_ncols[idx], basis.ncols());
         }
     }
 
@@ -580,7 +580,7 @@ pub fn build_design_and_penalty_matrices(
 
         match config.interaction_penalty {
             InteractionPenaltyKind::Isotropic => {
-                debug_assert_eq!(block.penalty_indices.len(), 1);
+                assert_eq!(block.penalty_indices.len(), 1);
                 let penalty_idx = block.penalty_indices[0];
                 let m = col_range.len() as f64;
                 let alpha = if m > 0.0 { 1.0 / m.sqrt() } else { 1.0 };


### PR DESCRIPTION
## Summary
- promote critical interaction penalty invariants in `calibrate::construction` to release-mode assertions
- enforce calibrator invariants for ALO denominators, penalty dimensions, and fixed-weight LOO checks in release builds

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68dea8811274832ea1652c5f3ce938c7