### PR TITLE
Fix tuple bindings to satisfy underscore validation

### DIFF
--- a/calibrate/construction.rs
+++ b/calibrate/construction.rs
@@ -2212,7 +2212,7 @@ mod tests {
         let data = make_toy_data(n);
         let config = cfg_with_interaction(InteractionPenaltyKind::Anisotropic);
 
-        let (x, s_list, layout, _stz, _knots, _range, _pc_null, _centers, _alpha) =
+        let (x, s_list, layout, _, _, _, _, _, _) =
             build_design_and_penalty_matrices(&data, &config)
                 .expect("anisotropic interaction construction should not panic");
 
@@ -2267,7 +2267,7 @@ mod tests {
         let data = make_toy_data(n);
         let config = cfg_with_interaction(InteractionPenaltyKind::Isotropic);
 
-        let (_x, s_list, layout, _stz, _knots, _range, _pc_null, _centers, _alpha) =
+        let (_, s_list, layout, _, _, _, _, _, _) =
             build_design_and_penalty_matrices(&data, &config)
                 .expect("isotropic interaction construction should not panic");
 


### PR DESCRIPTION
## Summary
- replace underscore-prefixed tuple bindings in calibrate construction tests with ignored placeholders to satisfy the build script validation

## Testing
- cargo +nightly build

------
https://chatgpt.com/codex/tasks/task_e_68debb5452b4832ea949cda11bb5ddec