### PR TITLE
Restore expected artifact layout for downstream jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,6 +232,12 @@ jobs:
         with:
           name: build-output
           path: .
+      - name: Restore expected artifact layout
+        run: |
+          rm -rf target
+          mv build-output/target target
+          if [ -f build-output/report.md ]; then mv build-output/report.md report.md; fi
+          rm -rf build-output
       - uses: actions/setup-python@v4
         with: { python-version: '3.13' }
       - uses: actions/cache@v4
@@ -253,6 +259,12 @@ jobs:
         with:
           name: build-output
           path: .
+      - name: Restore expected artifact layout
+        run: |
+          rm -rf target
+          mv build-output/target target
+          if [ -f build-output/report.md ]; then mv build-output/report.md report.md; fi
+          rm -rf build-output
       - uses: actions/setup-python@v4
         with: { python-version: '3.13' }
       - uses: actions/cache@v4
@@ -279,6 +291,12 @@ jobs:
         with:
           name: build-output
           path: .
+      - name: Restore expected artifact layout
+        run: |
+          rm -rf target
+          mv build-output/target target
+          if [ -f build-output/report.md ]; then mv build-output/report.md report.md; fi
+          rm -rf build-output
       - uses: actions/setup-python@v4
         with: { python-version: '3.13' }
       - uses: actions/cache@v4
@@ -300,6 +318,12 @@ jobs:
         with:
           name: build-output
           path: .
+      - name: Restore expected artifact layout
+        run: |
+          rm -rf target
+          mv build-output/target target
+          if [ -f build-output/report.md ]; then mv build-output/report.md report.md; fi
+          rm -rf build-output
 
       - name: Make profiling binary executable
         run: chmod +x target/profiling/gnomon


### PR DESCRIPTION
## Summary
- move downloaded artifacts from build-output back into the repository root so downstream jobs can find target/release binaries

## Testing
- not run (CI workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68df1dc999c0832e9e4f7b06e62952e9