### PR TITLE
Refocus calibrator gradient test on FD comparison

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -1424,6 +1424,68 @@ fn compute_fd_gradient(
     Ok(fd_grad)
 }
 
+/// Evaluate both analytic and finite-difference gradients for the external REML objective.
+pub fn evaluate_external_gradients(
+    y: ArrayView1<'_, f64>,
+    w: ArrayView1<'_, f64>,
+    x: ArrayView2<'_, f64>,
+    offset: ArrayView1<'_, f64>,
+    s_list: &[Array2<f64>],
+    opts: &ExternalOptimOptions,
+    rho: &Array1<f64>,
+) -> Result<(Array1<f64>, Array1<f64>), EstimationError> {
+    if !(y.len() == w.len() && y.len() == x.nrows() && y.len() == offset.len()) {
+        return Err(EstimationError::InvalidInput(format!(
+            "Row mismatch: y={}, w={}, X.rows={}, offset={}",
+            y.len(),
+            w.len(),
+            x.nrows(),
+            offset.len()
+        )));
+    }
+
+    let p = x.ncols();
+    for (k, s) in s_list.iter().enumerate() {
+        if s.nrows() != p || s.ncols() != p {
+            return Err(EstimationError::InvalidInput(format!(
+                "Penalty matrix {} must be {}×{}, got {}×{}",
+                k,
+                p,
+                p,
+                s.nrows(),
+                s.ncols()
+            )));
+        }
+    }
+
+    use crate::calibrate::model::ModelConfig;
+
+    let layout = ModelLayout::external(p, s_list.len());
+    let cfg = ModelConfig::external(opts.link, opts.tol, opts.max_iter);
+
+    let s_vec: Vec<Array2<f64>> = s_list.to_vec();
+    let y_o = y.to_owned();
+    let w_o = w.to_owned();
+    let x_o = x.to_owned();
+    let offset_o = offset.to_owned();
+
+    let reml_state = internal::RemlState::new_with_offset(
+        y_o.view(),
+        x_o.view(),
+        w_o.view(),
+        offset_o.view(),
+        s_vec,
+        &layout,
+        &cfg,
+        Some(opts.nullspace_dims.clone()),
+    )?;
+
+    let analytic_grad = reml_state.compute_gradient(rho)?;
+    let fd_grad = compute_fd_gradient(&reml_state, rho)?;
+
+    Ok((analytic_grad, fd_grad))
+}
+
 /// Helper to log the final model structure.
 fn log_layout_info(layout: &ModelLayout) {
     log::info!(


### PR DESCRIPTION
## Summary
- add a helper to evaluate analytic and finite-difference gradients for external REML designs
- update the external calibrator gradient agreement test to compare gradients directly instead of optimizer convergence

## Testing
- cargo test external_opt_cost_grad_agree_fd

------
https://chatgpt.com/codex/tasks/task_e_68df59198794832ebc58e86217cb50af