### PR TITLE
Guard Python workflows when no build artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ env:
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    outputs:
+      rust_changes: ${{ steps.rust_changes.outputs.rust }}
+      artifact_available: ${{ steps.artifact_status.outputs.available }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -223,9 +226,21 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
+      - name: Determine artifact availability (always)
+        id: artifact_status
+        if: always()
+        shell: bash
+        run: |
+          if [[ -d build-output/target ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
   python_test_integration:
-    runs-on: ubuntu-latest
     needs: build_and_test
+    if: needs.build_and_test.outputs.artifact_available == 'true'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -251,8 +266,9 @@ jobs:
       - run: python -u test/test.py
 
   python_test_simulation:
-    runs-on: ubuntu-latest
     needs: build_and_test
+    if: needs.build_and_test.outputs.artifact_available == 'true'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -283,8 +299,9 @@ jobs:
           sudo dmesg | grep -i -E 'killed process|out of memory' || echo "No OOM messages found."
 
   python_test_benchmark:
-    runs-on: ubuntu-latest
     needs: build_and_test
+    if: needs.build_and_test.outputs.artifact_available == 'true'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -310,8 +327,9 @@ jobs:
       - run: python -u test/bench.py
 
   performance_reports:
-    runs-on: ubuntu-latest
     needs: build_and_test
+    if: needs.build_and_test.outputs.artifact_available == 'true'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- expose whether the Rust build produced artifacts as an output of the build job
- skip downstream Python and profiling jobs when build artifacts are unavailable to avoid failing moves

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68df615f8aa0832eac5d8e57c175e531