### PR TITLE
Enable calibration by default

### DIFF
--- a/calibrate/model.rs
+++ b/calibrate/model.rs
@@ -13,12 +13,22 @@ use thiserror::Error;
 // Enabled by default. Wire this to a CLI flag like `--no-calibrate` by
 // calling `model::set_calibrator_enabled(false)` before training/prediction.
 use std::sync::atomic::{AtomicBool, Ordering};
-static CALIBRATOR_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// Default state for the post-process calibrator toggle. Calibration should be enabled unless
+/// a caller explicitly opts out.
+const CALIBRATOR_ENABLED_DEFAULT: bool = true;
+static CALIBRATOR_ENABLED: AtomicBool = AtomicBool::new(CALIBRATOR_ENABLED_DEFAULT);
 pub fn set_calibrator_enabled(enabled: bool) {
     CALIBRATOR_ENABLED.store(enabled, Ordering::SeqCst);
 }
 pub fn calibrator_enabled() -> bool {
     CALIBRATOR_ENABLED.load(Ordering::SeqCst)
+}
+
+/// Reset the calibrator toggle back to its default state. Useful for CLI entry points so each
+/// invocation starts with calibration enabled by default.
+pub fn reset_calibrator_flag() {
+    set_calibrator_enabled(CALIBRATOR_ENABLED_DEFAULT);
 }
 
 // --- Public Data Structures ---


### PR DESCRIPTION
## Summary
- add an explicit default constant and reset helper for the calibrator toggle so each run starts with calibration enabled
- extend the train and infer CLI commands with a `--no-calibration` opt-out flag and log whether calibration is active
- reset the calibrator flag when the CLI starts so calibration remains enabled by default across commands

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68df65074f64832e894435dcf7f23ffa