### PR TITLE
Ensure GitHub Actions use nightly toolchain

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,6 +23,6 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-nightly-${{ hashFiles('**/Cargo.lock') }}
       - name: Build benchmark target
-        run: cargo build --release --bench path_benchmark
+        run: cargo +nightly build --release --bench path_benchmark
       - name: Run benchmark and print results
-        run: cargo bench --bench path_benchmark -- --nocapture
+        run: cargo +nightly bench --bench path_benchmark -- --nocapture

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
       # -----------------------------------------------------------------------
 
       - name: Install Rust nightly
-        if: steps.rust_changes.outputs.rust == 'true'
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Prepare cache metadata
@@ -115,7 +114,7 @@ jobs:
           echo "---"
           echo "--- ASSEMBLY FOR SIMD VERSION (from library) ---"
           echo "---"
-          cargo asm -C lto=off --profile profiling --features no-inline-profiling --lib --intel gnomon::batch::process_tile
+          cargo +nightly asm -C lto=off --profile profiling --features no-inline-profiling --lib --intel gnomon::batch::process_tile
 
       - name: Cache getdoc binary
         id: getdoc_cache
@@ -166,10 +165,10 @@ jobs:
             echo "deps_hash=${{ steps.cache_meta.outputs.deps_hash }}"
             echo ""
             echo "--- rustc ---"
-            (rustc -Vv || true)
+            (rustc +nightly -Vv || true)
             echo ""
             echo "--- cargo ---"
-            (cargo -Vv || true)
+            (cargo +nightly -Vv || true)
             echo ""
             echo "--- host uname ---"
             (uname -a || true)


### PR DESCRIPTION
## Summary
- always install the nightly toolchain in the Rust test workflow and invoke rustc/cargo through it
- run benchmark builds and benches explicitly with the nightly toolchain

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e02ca685ac832eb583191b7cad1e7e