### PR TITLE
Add binary sex main effect to calibrate models

### DIFF
--- a/calibrate/data.rs
+++ b/calibrate/data.rs
@@ -31,6 +31,8 @@ pub struct TrainingData {
     /// The Principal Components matrix (`PC`), from 'PC1', 'PC2', ... columns.
     /// Shape: [n_samples, num_pcs].
     pub pcs: Array2<f64>,
+    /// The binary sex indicator column (coded as 0/1), from the required 'sex' column.
+    pub sex: Array1<f64>,
     /// The prior weights vector, from the required 'weights' column.
     pub weights: Array1<f64>,
 }
@@ -43,6 +45,8 @@ pub struct PredictionData {
     /// The Principal Components matrix (`PC`), from 'PC1', 'PC2', ... columns.
     /// Shape: [n_samples, num_pcs].
     pub pcs: Array2<f64>,
+    /// The binary sex indicator column (coded as 0/1), from the required 'sex' column.
+    pub sex: Array1<f64>,
     /// Optional sample identifiers. If an input column `sample_id` exists, it is used;
     /// otherwise sequential IDs (1-based) are generated as strings.
     pub sample_ids: Vec<String>,
@@ -90,16 +94,28 @@ pub enum DataError {
 /// Loads and validates data specifically for model training.
 pub fn load_training_data(path: &str, num_pcs: usize) -> Result<TrainingData, DataError> {
     // Do not require an explicit 'weights' column. If missing, default to 1.0.
-    let (p, pcs, y_opt, weights) = internal::load_data(path, num_pcs, true, false)?;
+    let (p, pcs, sex, y_opt, weights) = internal::load_data(path, num_pcs, true, false)?;
     // This unwrap is safe because we passed `include_phenotype: true`.
     let y = y_opt.unwrap();
-    Ok(TrainingData { y, p, pcs, weights })
+    Ok(TrainingData {
+        y,
+        p,
+        pcs,
+        sex,
+        weights,
+    })
 }
 
 /// Loads and validates data specifically for prediction.
 pub fn load_prediction_data(path: &str, num_pcs: usize) -> Result<PredictionData, DataError> {
-    let (p, pcs, _, _, sample_ids) = internal::load_data_with_ids(path, num_pcs, false, false)?;
-    Ok(PredictionData { p, pcs, sample_ids })
+    let (p, pcs, sex, _, _, sample_ids) =
+        internal::load_data_with_ids(path, num_pcs, false, false)?;
+    Ok(PredictionData {
+        p,
+        pcs,
+        sex,
+        sample_ids,
+    })
 }
 
 /// Internal module for shared data loading logic.
@@ -115,7 +131,16 @@ mod internal {
         num_pcs: usize,
         include_phenotype: bool,
         require_weights: bool,
-    ) -> Result<(Array1<f64>, Array2<f64>, Option<Array1<f64>>, Array1<f64>), DataError> {
+    ) -> Result<
+        (
+            Array1<f64>,
+            Array2<f64>,
+            Array1<f64>,
+            Option<Array1<f64>>,
+            Array1<f64>,
+        ),
+        DataError,
+    > {
         // Small helper: validate that an array contains only finite values
         fn validate_is_finite(arr: &Array1<f64>, column_name: &str) -> Result<(), DataError> {
             if arr.iter().any(|&v| !v.is_finite()) {
@@ -126,11 +151,12 @@ mod internal {
 
         // --- Generate the exact list of required column names ---
         let pc_names: Vec<String> = (1..=num_pcs).map(|i| format!("PC{i}")).collect();
-        let mut required_cols: Vec<String> = Vec::with_capacity(2 + num_pcs);
+        let mut required_cols: Vec<String> = Vec::with_capacity(3 + num_pcs);
         if include_phenotype {
             required_cols.push("phenotype".to_string());
         }
         required_cols.push("score".to_string());
+        required_cols.push("sex".to_string());
         required_cols.extend_from_slice(&pc_names);
 
         // --- Read and validate the DataFrame using Polars ---
@@ -243,6 +269,34 @@ mod internal {
         // Now convert to ndarray
         let pgs = score_casted.rechunk().f64()?.to_ndarray()?.to_owned();
         validate_is_finite(&pgs, "score")?;
+
+        // Process sex column
+        let sex_series = df.column("sex")?;
+        if sex_series.null_count() > 0 {
+            return Err(DataError::MissingValuesFound("sex".to_string()));
+        }
+
+        let sex_casted = match sex_series.cast(&DataType::Float64) {
+            Ok(casted) => casted,
+            Err(_) => {
+                return Err(DataError::ColumnWrongType {
+                    column_name: "sex".to_string(),
+                    expected_type: "f64 (numeric)",
+                    found_type: format!("{:?}", sex_series.dtype()),
+                });
+            }
+        };
+
+        if sex_casted.null_count() > 0 {
+            return Err(DataError::ColumnWrongType {
+                column_name: "sex".to_string(),
+                expected_type: "f64 (numeric)",
+                found_type: format!("{:?}", sex_series.dtype()),
+            });
+        }
+
+        let sex = sex_casted.rechunk().f64()?.to_ndarray()?.to_owned();
+        validate_is_finite(&sex, "sex")?;
 
         // Process PC columns efficiently
         let mut pc_arrays = Vec::with_capacity(num_pcs);
@@ -388,7 +442,7 @@ mod internal {
         println!(
             "Data validation successful: all required columns have numeric data with no missing values."
         );
-        Ok((pgs, pcs, phenotype_opt, weights))
+        Ok((pgs, pcs, sex, phenotype_opt, weights))
     }
 
     /// Variant of `load_data` that also extracts or synthesizes sample IDs.
@@ -401,6 +455,7 @@ mod internal {
         (
             Array1<f64>,
             Array2<f64>,
+            Array1<f64>,
             Option<Array1<f64>>,
             Array1<f64>,
             Vec<String>,
@@ -408,7 +463,7 @@ mod internal {
         DataError,
     > {
         // Load using the existing path
-        let (p, pcs, y_opt, w) = load_data(path, num_pcs, include_phenotype, require_weights)?;
+        let (p, pcs, sex, y_opt, w) = load_data(path, num_pcs, include_phenotype, require_weights)?;
 
         // Reload a lightweight frame to try to get sample_id without duplicating conversions
         let df = CsvReader::new(File::open(Path::new(path))?)
@@ -447,7 +502,7 @@ mod internal {
             (1..=n).map(|i| i.to_string()).collect()
         };
 
-        Ok((p, pcs, y_opt, w, sample_ids))
+        Ok((p, pcs, sex, y_opt, w, sample_ids))
     }
 }
 
@@ -469,8 +524,8 @@ mod tests {
 
     #[test]
     fn test_non_finite_values_rejected_in_score() {
-        let header = "phenotype\tscore\tPC1";
-        let data_row = "1.0\tNaN\t0.1"; // NaN should be parsed as f64::NAN
+        let header = "phenotype\tscore\tsex\tPC1";
+        let data_row = "1.0\tNaN\t0\t0.1"; // NaN should be parsed as f64::NAN
         let content = generate_csv_content(header, data_row, 30);
         let file = create_test_csv(&content).unwrap();
         let err = load_training_data(file.path().to_str().unwrap(), 1).unwrap_err();
@@ -482,8 +537,8 @@ mod tests {
 
     #[test]
     fn test_non_finite_values_rejected_in_pc() {
-        let header = "phenotype\tscore\tPC1";
-        let data_row = "1.0\t2.0\tNaN"; // NaN in PC1
+        let header = "phenotype\tscore\tsex\tPC1";
+        let data_row = "1.0\t2.0\t1\tNaN"; // NaN in PC1
         let content = generate_csv_content(header, data_row, 30);
         let file = create_test_csv(&content).unwrap();
         let err = load_training_data(file.path().to_str().unwrap(), 1).unwrap_err();
@@ -502,13 +557,13 @@ mod tests {
         format!("{}\n{}", header, data_rows)
     }
 
-    const TEST_HEADER: &str = "phenotype\tscore\tPC1\tPC2\textra_col";
-    const TEST_DATA_ROW: &str = "1.0\t1.5\t0.1\t0.2\t1.0";
+    const TEST_HEADER: &str = "phenotype\tscore\tsex\tPC1\tPC2\textra_col";
+    const TEST_DATA_ROW: &str = "1.0\t1.5\t0\t0.1\t0.2\t1.0";
 
     #[test]
     fn test_load_training_data_success() {
         // Create test data that includes required columns including weights
-        let header = "phenotype\tscore\tPC1\tPC2\tweights";
+        let header = "phenotype\tscore\tsex\tPC1\tPC2\tweights";
 
         // Generate varied test data with different values in each row
         let mut rows = Vec::with_capacity(31);
@@ -516,9 +571,10 @@ mod tests {
 
         for i in 0..30 {
             let row = format!(
-                "{:.2}\t{:.2}\t{:.3}\t{:.3}\t{:.1}",
+                "{:.2}\t{:.2}\t{}\t{:.3}\t{:.3}\t{:.1}",
                 i as f64 / 10.0,
                 (i as f64 + 5.0) / 10.0,
+                i % 2,
                 (i as f64 - 2.0) / 20.0,
                 (i as f64 + 3.0) / 15.0,
                 1.0 // Add weight of 1.0 for each row
@@ -538,18 +594,21 @@ mod tests {
         // Test specific values in the first row
         assert_abs_diff_eq!(data.y[0], 0.00, epsilon = 1e-6);
         assert_abs_diff_eq!(data.p[0], 0.50, epsilon = 1e-6);
+        assert_abs_diff_eq!(data.sex[0], 0.0, epsilon = 1e-6);
         assert_abs_diff_eq!(data.pcs[[0, 0]], -0.100, epsilon = 1e-6);
         assert_abs_diff_eq!(data.pcs[[0, 1]], 0.200, epsilon = 1e-6);
 
         // Test specific values in a middle row
         assert_abs_diff_eq!(data.y[15], 1.50, epsilon = 1e-6);
         assert_abs_diff_eq!(data.p[15], 2.00, epsilon = 1e-6);
+        assert_abs_diff_eq!(data.sex[15], (15 % 2) as f64, epsilon = 1e-6);
         assert_abs_diff_eq!(data.pcs[[15, 0]], 0.650, epsilon = 1e-6);
         assert_abs_diff_eq!(data.pcs[[15, 1]], 1.200, epsilon = 1e-6);
 
         // Test specific values in the last row
         assert_abs_diff_eq!(data.y[29], 2.90, epsilon = 1e-6);
         assert_abs_diff_eq!(data.p[29], 3.40, epsilon = 1e-6);
+        assert_abs_diff_eq!(data.sex[29], (29 % 2) as f64, epsilon = 1e-6);
         assert_abs_diff_eq!(data.pcs[[29, 0]], 1.350, epsilon = 1e-6);
         assert_abs_diff_eq!(data.pcs[[29, 1]], 2.133, epsilon = 1e-6);
     }
@@ -557,7 +616,7 @@ mod tests {
     #[test]
     fn test_pcs_matrix_structure_with_custom_data() {
         // Create test data with different values for each row including weights
-        let custom_header = "phenotype\tscore\tPC1\tPC2\tweights";
+        let custom_header = "phenotype\tscore\tsex\tPC1\tPC2\tweights";
 
         // Generate 20 rows with a clear pattern to meet the minimum row requirement
         let mut custom_rows = Vec::with_capacity(21);
@@ -565,9 +624,10 @@ mod tests {
 
         for i in 0..20 {
             let row = format!(
-                "{:.1}\t{:.1}\t{:.1}\t{:.1}\t{:.1}",
+                "{:.1}\t{:.1}\t{}\t{:.1}\t{:.1}\t{:.1}",
                 i as f64 / 10.0,
                 (i as f64 + 1.0) / 10.0,
+                i % 2,
                 (i as f64 + 2.0) / 10.0,
                 (i as f64 + 3.0) / 10.0,
                 1.0 // Add weight of 1.0 for each row
@@ -581,6 +641,7 @@ mod tests {
 
         // Verify dimensions
         assert_eq!(data.pcs.shape(), &[20, 2]);
+        assert_eq!(data.sex.len(), 20);
 
         // Verify the matrix contents for a few key elements
         assert_abs_diff_eq!(data.pcs[[0, 0]], 0.2, epsilon = 1e-6);
@@ -594,8 +655,8 @@ mod tests {
     #[test]
     fn test_load_prediction_data_success() {
         // Create test data that includes required columns including weights
-        let header = "score\tPC1\tweights";
-        let data_row = "1.5\t0.1\t1.0"; // Added dummy weight
+        let header = "score\tsex\tPC1\tweights";
+        let data_row = "1.5\t1\t0.1\t1.0"; // Added dummy weight
         let content = generate_csv_content(header, data_row, 30);
         let file = create_test_csv(&content).unwrap();
         let data = load_prediction_data(file.path().to_str().unwrap(), 1).unwrap();
@@ -603,12 +664,13 @@ mod tests {
         assert_eq!(data.p.len(), 30);
         assert_eq!(data.pcs.shape(), &[30, 1]);
         assert_abs_diff_eq!(data.p[0], 1.5, epsilon = 1e-6);
+        assert_abs_diff_eq!(data.sex[0], 1.0, epsilon = 1e-6);
         assert_abs_diff_eq!(data.pcs[[0, 0]], 0.1, epsilon = 1e-6);
     }
 
     #[test]
     fn test_error_column_not_found() {
-        let content = generate_csv_content("phenotype\tscore\tPC1", "1.0\t1.5\t0.1", 30);
+        let content = generate_csv_content("phenotype\tscore\tsex\tPC1", "1.0\t1.5\t0\t0.1", 30);
         let file = create_test_csv(&content).unwrap();
         let err = load_training_data(file.path().to_str().unwrap(), 2).unwrap_err();
         match err {
@@ -620,7 +682,7 @@ mod tests {
     #[test]
     fn test_error_missing_values() {
         // Create test data with missing values in the score column
-        let content = generate_csv_content("phenotype\tscore\tPC1", "1.0\t\t0.1", 30);
+        let content = generate_csv_content("phenotype\tscore\tsex\tPC1", "1.0\t\t0\t0.1", 30);
         let file = create_test_csv(&content).unwrap();
 
         // Call the function that should detect the error
@@ -641,7 +703,11 @@ mod tests {
     #[test]
     fn test_error_wrong_type() {
         // Create test data with a non-numeric value in the score column
-        let content = generate_csv_content("phenotype\tscore\tPC1", "1.0\tnot_a_number\t0.1", 30);
+        let content = generate_csv_content(
+            "phenotype\tscore\tsex\tPC1",
+            "1.0\tnot_a_number\t0\t0.1",
+            30,
+        );
         let file = create_test_csv(&content).unwrap();
 
         // Call the function that should detect the error

--- a/calibrate/pirls.rs
+++ b/calibrate/pirls.rs
@@ -1506,105 +1506,105 @@ pub fn solve_penalized_least_squares(
         let h_faer = FaerMat::<f64>::from_fn(p_dim, p_dim, |i, j| penalized_hessian[[i, j]]);
         match FaerLlt::new(h_faer.as_ref(), Side::Lower) {
             Ok(chol) => {
-            // Guard: estimate conditioning of H; if too ill-conditioned, fall back to QR path
-            let cond_bad = match penalized_hessian.eigh(Side::Lower) {
-                Ok((eigs, _)) => {
-                    let mut min_ev = f64::INFINITY;
-                    let mut max_ev = 0.0f64;
-                    for &ev in eigs.iter() {
-                        if ev.is_finite() {
-                            if ev > max_ev {
-                                max_ev = ev;
-                            }
-                            if ev < min_ev {
-                                min_ev = ev;
+                // Guard: estimate conditioning of H; if too ill-conditioned, fall back to QR path
+                let cond_bad = match penalized_hessian.eigh(Side::Lower) {
+                    Ok((eigs, _)) => {
+                        let mut min_ev = f64::INFINITY;
+                        let mut max_ev = 0.0f64;
+                        for &ev in eigs.iter() {
+                            if ev.is_finite() {
+                                if ev > max_ev {
+                                    max_ev = ev;
+                                }
+                                if ev < min_ev {
+                                    min_ev = ev;
+                                }
                             }
                         }
+                        // Treat non-positive or extremely small min eigenvalues as bad conditioning
+                        if !(min_ev.is_finite()) || min_ev <= 0.0 {
+                            true
+                        } else {
+                            let cond = max_ev / min_ev.max(std::f64::MIN_POSITIVE);
+                            cond > 1e8
+                        }
                     }
-                    // Treat non-positive or extremely small min eigenvalues as bad conditioning
-                    if !(min_ev.is_finite()) || min_ev <= 0.0 {
-                        true
-                    } else {
-                        let cond = max_ev / min_ev.max(std::f64::MIN_POSITIVE);
-                        cond > 1e8
+                    Err(_) => {
+                        // If we can't estimate, be conservative and proceed with SPD path
+                        false
                     }
-                }
-                Err(_) => {
-                    // If we can't estimate, be conservative and proceed with SPD path
-                    false
-                }
-            };
-            if cond_bad {
-                diagnostics.record_fallback(PlsFallbackReason::IllConditioned);
-            } else {
-                // Single multi-RHS solve: [ XtWz | Eᵀ ]
-                let rk_rows = e_transformed.nrows();
-                let nrhs = 1 + rk_rows;
-                let rhs = FaerMat::<f64>::from_fn(p_dim, nrhs, |i, j| {
-                    if j == 0 {
-                        xtwz[i]
-                    } else {
-                        e_transformed[(j - 1, i)]
-                    }
-                });
-                let sol = chol.solve(rhs.as_ref());
-
-                // β̂ from first column
-                let mut beta_transformed = Array1::zeros(p_dim);
-                for i in 0..p_dim {
-                    beta_transformed[i] = sol[(i, 0)];
-                }
-                if !beta_transformed.iter().all(|v| v.is_finite()) {
-                    return Err(EstimationError::ModelIsIllConditioned {
-                        condition_number: f64::INFINITY,
+                };
+                if cond_bad {
+                    diagnostics.record_fallback(PlsFallbackReason::IllConditioned);
+                } else {
+                    // Single multi-RHS solve: [ XtWz | Eᵀ ]
+                    let rk_rows = e_transformed.nrows();
+                    let nrhs = 1 + rk_rows;
+                    let rhs = FaerMat::<f64>::from_fn(p_dim, nrhs, |i, j| {
+                        if j == 0 {
+                            xtwz[i]
+                        } else {
+                            e_transformed[(j - 1, i)]
+                        }
                     });
-                }
+                    let sol = chol.solve(rhs.as_ref());
 
-                // EDF = p - ⟨H⁻¹Eᵀ, Eᵀ⟩_F using remaining columns
-                let mut frob = 0.0f64;
-                for j in 0..rk_rows {
+                    // β̂ from first column
+                    let mut beta_transformed = Array1::zeros(p_dim);
                     for i in 0..p_dim {
-                        frob += sol[(i, 1 + j)] * e_transformed[(j, i)];
+                        beta_transformed[i] = sol[(i, 0)];
                     }
-                }
-                let mp = (p_dim as f64 - rk_rows as f64).max(0.0);
-                let edf = (p_dim as f64 - frob).clamp(mp, p_dim as f64);
-                if !edf.is_finite() {
-                    return Err(EstimationError::ModelIsIllConditioned {
-                        condition_number: f64::INFINITY,
-                    });
-                }
+                    if !beta_transformed.iter().all(|v| v.is_finite()) {
+                        return Err(EstimationError::ModelIsIllConditioned {
+                            condition_number: f64::INFINITY,
+                        });
+                    }
 
-                // Scale parameter
-                let scale = calculate_scale(
-                    &beta_transformed,
-                    x_transformed,
-                    y,
-                    weights,
-                    edf,
-                    link_function,
-                );
-                if !scale.is_finite() {
-                    return Err(EstimationError::ModelIsIllConditioned {
-                        condition_number: f64::INFINITY,
-                    });
-                }
+                    // EDF = p - ⟨H⁻¹Eᵀ, Eᵀ⟩_F using remaining columns
+                    let mut frob = 0.0f64;
+                    for j in 0..rk_rows {
+                        for i in 0..p_dim {
+                            frob += sol[(i, 1 + j)] * e_transformed[(j, i)];
+                        }
+                    }
+                    let mp = (p_dim as f64 - rk_rows as f64).max(0.0);
+                    let edf = (p_dim as f64 - frob).clamp(mp, p_dim as f64);
+                    if !edf.is_finite() {
+                        return Err(EstimationError::ModelIsIllConditioned {
+                            condition_number: f64::INFINITY,
+                        });
+                    }
 
-                println!(
-                    "[PLS Solver] (SPD/LLᵀ) Completed with edf={:.2}, scale={:.4e}",
-                    edf, scale
-                );
-
-                return Ok((
-                    StablePLSResult {
-                        beta: beta_transformed,
-                        penalized_hessian,
+                    // Scale parameter
+                    let scale = calculate_scale(
+                        &beta_transformed,
+                        x_transformed,
+                        y,
+                        weights,
                         edf,
-                        scale,
-                    },
-                    p_dim,
-                ));
-            }
+                        link_function,
+                    );
+                    if !scale.is_finite() {
+                        return Err(EstimationError::ModelIsIllConditioned {
+                            condition_number: f64::INFINITY,
+                        });
+                    }
+
+                    println!(
+                        "[PLS Solver] (SPD/LLᵀ) Completed with edf={:.2}, scale={:.4e}",
+                        edf, scale
+                    );
+
+                    return Ok((
+                        StablePLSResult {
+                            beta: beta_transformed,
+                            penalized_hessian,
+                            edf,
+                            scale,
+                        },
+                        p_dim,
+                    ));
+                }
             }
             Err(_) => diagnostics.record_fallback(PlsFallbackReason::FactorizationFailed),
         }
@@ -1984,7 +1984,13 @@ pub fn solve_penalized_least_squares(
     // - Forming the penalized Hessian matrix (X'WX + S) for uncertainty quantification
     // - Calculating effective degrees of freedom (model complexity measure)
     // - Estimating the scale parameter (variance component for Gaussian models)
-    diagnostics.emit_qr_summary(edf, scale, rank, x_transformed.ncols(), function_timer.elapsed());
+    diagnostics.emit_qr_summary(
+        edf,
+        scale,
+        rank,
+        x_transformed.ncols(),
+        function_timer.elapsed(),
+    );
 
     // Return the result
     Ok((
@@ -2260,13 +2266,13 @@ pub fn compute_final_penalized_hessian(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use approx::assert_abs_diff_eq;
     use crate::calibrate::basis::create_difference_penalty_matrix;
     use crate::calibrate::construction::{
         build_design_and_penalty_matrices, compute_penalty_square_roots,
     };
     use crate::calibrate::data::TrainingData;
     use crate::calibrate::model::{BasisConfig, InteractionPenaltyKind, map_coefficients};
+    use approx::assert_abs_diff_eq;
     use ndarray::{Array1, Array2, arr1, arr2};
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
@@ -2369,6 +2375,7 @@ mod tests {
             y,
             p,
             pcs: Array2::zeros((n_samples, 0)),
+            sex: Array1::zeros(n_samples),
             weights: Array1::from_elem(n_samples, 1.0),
         };
 
@@ -2562,6 +2569,7 @@ mod tests {
         // Create a model layout
         let layout = ModelLayout {
             intercept_col: 0,
+            sex_col: None,
             pgs_main_cols: 0..0,
             pc_null_cols: vec![],
             pc_null_block_idx: vec![],
@@ -2609,7 +2617,7 @@ mod tests {
     #[test]
     fn test_stable_reparameterization_preserves_nullspace_rank() {
         use crate::calibrate::construction::{
-            compute_penalty_square_roots, stable_reparameterization, ModelLayout,
+            ModelLayout, compute_penalty_square_roots, stable_reparameterization,
         };
 
         // Create a canonical cubic spline penalty (second-order differences)
@@ -2643,8 +2651,8 @@ mod tests {
         // Run stable reparameterization and confirm the null space dimension is preserved.
         let layout = ModelLayout::external(num_basis_functions, 1);
         let lambdas = vec![1.0];
-        let reparam =
-            stable_reparameterization(&rs_list, &lambdas, &layout).expect("stable reparameterization");
+        let reparam = stable_reparameterization(&rs_list, &lambdas, &layout)
+            .expect("stable reparameterization");
 
         assert_eq!(
             reparam.e_transformed.nrows(),
@@ -2658,10 +2666,7 @@ mod tests {
             .copied()
             .filter(|&ev| ev > tolerance)
             .collect();
-        let expected_log_det: f64 = positive_eigs
-            .iter()
-            .map(|&ev| ev.ln())
-            .sum::<f64>();
+        let expected_log_det: f64 = positive_eigs.iter().map(|&ev| ev.ln()).sum::<f64>();
         assert_abs_diff_eq!(reparam.log_det, expected_log_det, epsilon = 1e-9);
 
         // The transformed penalty should expose the same null-space dimension.
@@ -2755,6 +2760,7 @@ mod tests {
         // Create a model layout
         let layout = ModelLayout {
             intercept_col: 0,
+            sex_col: None,
             pgs_main_cols: 0..0,
             pc_null_cols: vec![],
             pc_null_block_idx: vec![],
@@ -2889,6 +2895,7 @@ mod tests {
             y,
             p,
             pcs: Array2::zeros((n_samples, 0)),
+            sex: Array1::zeros(n_samples),
             weights: Array1::from_elem(n_samples, 1.0),
         };
 
@@ -3018,6 +3025,7 @@ mod tests {
             y,
             p,
             pcs: Array2::zeros((n_samples, 0)),
+            sex: Array1::zeros(n_samples),
             weights: Array1::from_elem(n_samples, 1.0),
         };
 
@@ -3622,6 +3630,7 @@ mod tests {
 
         let layout = ModelLayout {
             intercept_col: 0,
+            sex_col: None,
             pgs_main_cols: 0..0,
             pc_null_cols: vec![],
             pc_null_block_idx: vec![],

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,11 @@
 #![deny(unused_imports)]
 #![deny(clippy::no_effect_underscore_binding)]
 
+use clap::{Args, Parser, Subcommand};
+use ndarray::{Array1, ArrayView1};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process;
-use std::collections::HashSet;
-use ndarray::{Array1, ArrayView1};
-use clap::{Parser, Subcommand, Args};
 
 use gnomon::calibrate::data::{load_prediction_data, load_training_data};
 use gnomon::calibrate::estimate::train_model;
@@ -187,7 +187,7 @@ pub fn infer(args: InferArgs) -> Result<(), Box<dyn std::error::Error>> {
     // Make detailed predictions
     println!("Generating predictions with diagnostics...");
     let (eta, mean, signed_dist, se_eta_opt) =
-        model.predict_detailed(data.p.view(), data.pcs.view())?;
+        model.predict_detailed(data.p.view(), data.sex.view(), data.pcs.view())?;
 
     // Check if calibrator is available
     let calibrated_mean_opt = if args.no_calibration {
@@ -196,7 +196,7 @@ pub fn infer(args: InferArgs) -> Result<(), Box<dyn std::error::Error>> {
     } else if model.calibrator.is_some() {
         println!("Calibrator detected. Generating calibrated predictions.");
         // Get calibrated predictions but don't error if calibrator is missing
-        match model.predict_calibrated(data.p.view(), data.pcs.view()) {
+        match model.predict_calibrated(data.p.view(), data.sex.view(), data.pcs.view()) {
             Ok(calibrated) => Some(calibrated),
             Err(_) => None,
         }


### PR DESCRIPTION
## Summary
- add a binary sex column to the training and prediction data structures and loaders
- extend design, layout, and coefficient mapping to include an unpenalized sex main effect
- update model prediction APIs, tests, and supporting utilities to handle the new covariate

## Testing
- cargo test calibrate::data::tests::test_load_training_data_success *(fails to complete in this environment due to long dependency compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68e02bdbaa60832ebb0a0a9d4c1b6e9a