### PR TITLE
Fix calibrate model tests for sex main effect

### DIFF
--- a/calibrate/model.rs
+++ b/calibrate/model.rs
@@ -1151,7 +1151,9 @@ mod tests {
         let coeffs = Array1::from(model.coefficients.main_effects.pgs.clone());
 
         // Stage: Calculate the final expected linear predictor as intercept + constrained_basis * coeffs
-        let expected_values = model.coefficients.intercept + pgs_main_basis_con.dot(&coeffs);
+        let mut expected_values = pgs_main_basis_con.dot(&coeffs);
+        expected_values += &sex_points.mapv(|v| v * model.coefficients.main_effects.sex);
+        expected_values += model.coefficients.intercept;
 
         // Get the model's prediction using the actual `predict` method
         let predictions = model
@@ -1390,8 +1392,10 @@ mod tests {
         };
 
         // Create a dummy dataset for generating the correct model structure
-        // Using n_samples=100 to avoid over-parameterization
-        let n_samples = 100;
+        // Choose a sample size that comfortably exceeds the total number of coefficients in this
+        // configuration (currently 101) so that the design matrix construction succeeds even as
+        // new unpenalized effects such as sex are introduced.
+        let n_samples = 150;
         let dummy_data = TrainingData {
             y: Array1::linspace(0.0, 1.0, n_samples),
             p: Array1::linspace(-1.0, 1.0, n_samples),


### PR DESCRIPTION
## Summary
- update the calibrate model prediction unit test to include the sex main effect in the expected linear predictor
- grow the dummy dataset in the save/load round-trip test so that it remains over-determined after adding the sex coefficient

## Testing
- cargo test calibrate::model::tests::test_trained_model_predict -- --nocapture
- cargo test calibrate::model::tests::test_save_load_functionality -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68e068cf7458832ea9be49d9b1b8f4f6