### PR TITLE
Fix reuse of PGS sum-to-zero transform

### DIFF
--- a/calibrate/construction.rs
+++ b/calibrate/construction.rs
@@ -494,7 +494,7 @@ pub fn build_design_and_penalty_matrices(
     range_transforms.insert("pgs".to_string(), z_range_pgs);
 
     // Save the PGS sum-to-zero constraint transformation
-    sum_to_zero_constraints.insert("pgs_main".to_string(), pgs_z_transform);
+    sum_to_zero_constraints.insert("pgs_main".to_string(), pgs_z_transform.clone());
 
     // Stage: Generate range-only bases for PCs (functional ANOVA decomposition)
     let mut pc_range_bases: Vec<Array2<f64>> = Vec::with_capacity(n_pcs);


### PR DESCRIPTION
## Summary
- clone the PGS sum-to-zero transform before storing it in the constraints map so later penalty construction can reuse the original matrix

## Testing
- cargo test --no-run

------
https://chatgpt.com/codex/tasks/task_e_68e095e81120832ea18e1fbec76e83db