### PR TITLE
Support streaming BIM and FAM metadata

### DIFF
--- a/score/types.rs
+++ b/score/types.rs
@@ -19,6 +19,8 @@ pub struct WorkItem {
 #[derive(Debug, Clone)]
 pub struct FilesetBoundary {
     pub bed_path: PathBuf,
+    pub bim_path: PathBuf,
+    pub fam_path: PathBuf,
     pub starting_global_index: u64,
 }
 


### PR DESCRIPTION
## Summary
- Introduce a shared Tokio runtime and a text-streaming abstraction for BIM/FAM files with both local and remote implementations
- Refactor the preparation pipeline to derive explicit per-fileset paths, stream BIM data once, validate/merge multi-FAM inputs, and compute variant totals without reopening files
- Extend FilesetBoundary metadata so downstream stages receive explicit BED/BIM/FAM paths

## Testing
- Not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e0a28ab7b0832ebec28efab3b65038