### PR TITLE
Restore remote GCS tests and anonymous client fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ bumpalo = { version = "3.19.0", features = ["collections"] }
 dwldutil = "2.0.4"
 indicatif = "0.17"
 google-cloud-storage = "1.0.0"
+google-cloud-auth = "1.0.0"
 flate2 = "1.1.2"
 ndarray = { version = "0.16.1", features = ["serde", "rayon"] }
 serde = { version = "1.0.219", features = ["derive"] }


### PR DESCRIPTION
## Summary
- require the remote I/O tests to always hit the public GCS reference
- retry Cloud Storage clients with anonymous credentials when authentication headers cannot be constructed

## Testing
- `cargo test io::tests::remote_reference_exposes_length_and_initial_bytes` *(fails: networking to GCS unavailable in CI)*
- `cargo test io::tests::remote_reference_streams_across_multiple_blocks` *(fails: networking to GCS unavailable in CI)*
- `cargo test io::tests::remote_reference_supports_boundary_reads` *(fails: networking to GCS unavailable in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a998a884832e98e1dceeb1038a5d