### PR TITLE
Add guard for sex main basis dimension in ModelLayout

### DIFF
--- a/calibrate/construction.rs
+++ b/calibrate/construction.rs
@@ -216,6 +216,12 @@ impl ModelLayout {
             None
         };
 
+        if sex_main_basis_ncols > 1 {
+            return Err(EstimationError::LayoutError(
+                "sex_main_basis_ncols must be 1 with current layout encoding".into(),
+            ));
+        }
+
         // Reserve capacities to avoid reallocations
         // Estimated number of penalized blocks: one per PC main effect, plus one per interaction (if enabled)
         let estimated_penalized_blocks = config.pc_configs.len()


### PR DESCRIPTION
## Summary
- return a layout error when the sex main basis dimensionality exceeds the single-column encoding

## Testing
- `cargo test layout`


------
https://chatgpt.com/codex/tasks/task_e_68e157f588cc832ea5ab847ceb348165