### PR TITLE
Fix over-parameterization guard for sex×PGS block

### DIFF
--- a/calibrate/construction.rs
+++ b/calibrate/construction.rs
@@ -416,8 +416,18 @@ pub fn build_design_and_penalty_matrices(
         interaction_coeffs += (pgs_basis_coeffs - 1) * (pc_basis_coeffs - 1);
     }
 
-    let num_coeffs =
-        intercept_coeffs + sex_main_coeffs + pgs_main_coeffs + pc_main_coeffs + interaction_coeffs;
+    let sex_pgs_interaction_coeffs = if sex_main_coeffs > 0 {
+        pgs_main_coeffs
+    } else {
+        0
+    };
+
+    let num_coeffs = intercept_coeffs
+        + sex_main_coeffs
+        + pgs_main_coeffs
+        + sex_pgs_interaction_coeffs
+        + pc_main_coeffs
+        + interaction_coeffs;
 
     if num_coeffs > n_samples {
         // FAIL FAST before any expensive calculations
@@ -433,6 +443,7 @@ pub fn build_design_and_penalty_matrices(
             sex_main_coeffs,
             pgs_main_coeffs,
             pc_main_coeffs,
+            sex_pgs_interaction_coeffs,
             interaction_coeffs,
         });
     }

--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -166,11 +166,12 @@ pub enum EstimationError {
     #[error(
         "Model is over-parameterized: {num_coeffs} coefficients for {num_samples} samples.\n\n\
         Coefficient Breakdown:\n\
-          - Intercept:           {intercept_coeffs}\n\
-          - Sex Main Effect:    {sex_main_coeffs}\n\
-          - PGS Main Effects:    {pgs_main_coeffs}\n\
-          - PC Main Effects:     {pc_main_coeffs}\n\
-          - Interaction Effects: {interaction_coeffs}"
+          - Intercept:               {intercept_coeffs}\n\
+          - Sex Main Effect:         {sex_main_coeffs}\n\
+          - PGS Main Effects:        {pgs_main_coeffs}\n\
+          - Sex×PGS Interaction:     {sex_pgs_interaction_coeffs}\n\
+          - PC Main Effects:         {pc_main_coeffs}\n\
+          - PC×PGS Interaction:      {interaction_coeffs}"
     )]
     ModelOverparameterized {
         num_coeffs: usize,
@@ -179,6 +180,7 @@ pub enum EstimationError {
         sex_main_coeffs: usize,
         pgs_main_coeffs: usize,
         pc_main_coeffs: usize,
+        sex_pgs_interaction_coeffs: usize,
         interaction_coeffs: usize,
     },
 


### PR DESCRIPTION
## Summary
- include the sex×PGS varying-coefficient columns in the pre-build coefficient count
- extend the ModelOverparameterized error breakdown to report the sex×PGS interaction size

## Testing
- cargo test ModelOverparameterized

------
https://chatgpt.com/codex/tasks/task_e_68e157c4ccc8832e8a6313ca66d1580c