### PR TITLE
Ensure release binary exists before marking artifact available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,7 +230,7 @@ jobs:
         if: always()
         shell: bash
         run: |
-          if [[ -d build-output/target ]]; then
+          if [[ -f build-output/target/release/gnomon ]]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- ensure the workflow only marks build artifacts as available when the release binary is present
- prevent downstream Python simulation job from attempting to use a missing executable on doc-only changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1e1320344832e80ec19987de9cfc0