### PR TITLE
Ensure CI artifacts require release binary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,9 +230,11 @@ jobs:
         if: always()
         shell: bash
         run: |
-          if [[ -d build-output/target ]]; then
+          RELEASE_BIN="build-output/target/release/gnomon"
+          if [[ -f "$RELEASE_BIN" ]]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
+            echo "::notice::No release binary found at $RELEASE_BIN; downstream Python jobs will be skipped."
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary
- require the trimmed CI artifact to contain the release binary before marking it available
- emit a notice when the release binary is absent so downstream jobs skip gracefully

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1e1320344832e80ec19987de9cfc0