### PR TITLE
Increase real-world fixture sample size for CV test

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -3155,7 +3155,7 @@ pub mod internal {
         }
 
         fn build_realworld_test_fixture() -> RealWorldTestFixture {
-            let n_samples = 840;
+            let n_samples = 1176;
             let mut rng = StdRng::seed_from_u64(42);
 
             let p = Array1::from_shape_fn(n_samples, |_| rng.gen_range(-2.0..2.0));


### PR DESCRIPTION
## Summary
- increase the generated sample count in the real-world metrics fixture by 40%

## Testing
- cargo test test_model_realworld_metrics -- --nocapture *(fails: interrupted after running for a long time)*

------
https://chatgpt.com/codex/tasks/task_e_68e35bdb2f48832ebba96ed0c4ecebc2