### PR TITLE
Increase sample size for real-world metrics test

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -3155,7 +3155,7 @@ pub mod internal {
         }
 
         fn build_realworld_test_fixture() -> RealWorldTestFixture {
-            let n_samples = 1176;
+            let n_samples = 1650;
             let mut rng = StdRng::seed_from_u64(42);
 
             let p = Array1::from_shape_fn(n_samples, |_| rng.gen_range(-2.0..2.0));


### PR DESCRIPTION
## Summary
- increase the synthetic dataset size in `test_model_realworld_metrics` to provide a larger sample for evaluation

## Testing
- cargo test --no-run

------
https://chatgpt.com/codex/tasks/task_e_68e3e6e3bd80832eb3d11b5b82c9a54e