### PR TITLE
Fix ADC credential error conversion for GCS client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ dwldutil = "2.0.4"
 indicatif = "0.17"
 google-cloud-storage = "1.0.0"
 google-cloud-auth = "1.0.0"
+google-cloud-gax = "1.0.0"
 flate2 = "1.1.2"
 ndarray = { version = "0.16.1", features = ["serde", "rayon"] }
 serde = { version = "1.0.219", features = ["derive"] }


### PR DESCRIPTION
## Summary
- convert ADC credential loading failures into `google_cloud_gax::client_builder::Error` so `?` propagation compiles
- wrap Cloud Storage control client build failures in a boxed `io::Error` with context
- add the `google-cloud-gax` crate dependency to access the shared client builder error type

## Testing
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68e4231f1380832ea311694d5fc10560