### PR TITLE
Remove unused runtime parameter from ADC credential loader

### DIFF
--- a/score/io.rs
+++ b/score/io.rs
@@ -74,7 +74,7 @@ pub fn gcs_billing_project_from_env() -> Option<String> {
     None
 }
 
-pub fn load_adc_credentials(runtime: &Arc<Runtime>) -> Result<Credentials, PipelineError> {
+pub fn load_adc_credentials() -> Result<Credentials, PipelineError> {
     let mut builder = google_cloud_auth::credentials::Builder::default();
     if let Some(project) = gcs_billing_project_from_env() {
         builder = builder.with_quota_project_id(project);
@@ -465,7 +465,7 @@ impl RemoteByteRangeSource {
     ) -> Result<(Storage, StorageControl), PipelineError> {
         let base_credentials = match credentials {
             Some(creds) => creds,
-            None => load_adc_credentials(runtime)?,
+            None => load_adc_credentials()?,
         };
 
         let storage_credentials = base_credentials.clone();

--- a/score/main.rs
+++ b/score/main.rs
@@ -417,7 +417,7 @@ fn resolve_gcs_filesets(uri: &str) -> Result<Vec<PathBuf>, Box<dyn Error + Send 
         |creds: Option<Credentials>| -> Result<StorageControl, Box<dyn Error + Send + Sync>> {
             let credentials = match creds {
                 Some(existing) => existing,
-                None => load_adc_credentials(&runtime)
+                None => load_adc_credentials()
                     .map_err(|e| -> Box<dyn Error + Send + Sync> { format!("{e}").into() })?,
             };
 


### PR DESCRIPTION
## Summary
- remove the unused `runtime` parameter from `load_adc_credentials`
- update call sites to use the simplified function signature

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e492a05880832ea1b3566ee9afd551