### PR TITLE
Expose shared file utilities through score::io

### DIFF
--- a/score/io.rs
+++ b/score/io.rs
@@ -10,25 +10,17 @@
 // shared buffer pool to minimize allocations and provides natural backpressure if
 // consumers cannot keep up.
 
+use crate::decide::ComputePath;
 use crate::pipeline::PipelineError;
+pub use crate::shared::files::{
+    gcs_billing_project_from_env, get_shared_runtime, load_adc_credentials, open_bed_source,
+    open_text_source, BedSource, ByteRangeSource, TextSource, PROGRESS_UPDATE_BATCH_SIZE,
+};
 use crate::types::{FilesetBoundary, PreparationResult, ReconciledVariantIndex, WorkItem};
 use crossbeam_channel::Sender;
 use crossbeam_queue::ArrayQueue;
-use google_cloud_auth::credentials::{Credentials, anonymous::Builder as AnonymousCredentials};
-use google_cloud_storage::client::{Storage, StorageControl};
-use google_cloud_storage::model_ext::ReadRange;
-use log::{debug, warn};
-use memmap2::Mmap;
-use std::collections::{HashMap, VecDeque};
-use std::env;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::Path;
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
-use tokio::runtime::Runtime;
+use std::sync::Arc;
 
 /// The generic entry point for the producer thread.
 ///

--- a/score/lib.rs
+++ b/score/lib.rs
@@ -13,6 +13,7 @@ pub mod pipeline;
 pub mod prepare;
 pub mod reformat;
 pub mod types;
+pub mod shared;
 
 // Add calibrate module
 #[path = "../calibrate/lib.rs"]

--- a/score/shared.rs
+++ b/score/shared.rs
@@ -1,0 +1,2 @@
+#[path = "../shared/files.rs"]
+pub mod files;

--- a/shared/files.rs
+++ b/shared/files.rs
@@ -1,6 +1,4 @@
 use crate::pipeline::PipelineError;
-use crossbeam_channel::Sender;
-use crossbeam_queue::ArrayQueue;
 use google_cloud_auth::credentials::{Credentials, anonymous::Builder as AnonymousCredentials};
 use google_cloud_storage::client::{Storage, StorageControl};
 use google_cloud_storage::model_ext::ReadRange;
@@ -14,12 +12,11 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::runtime::Runtime;
 
 /// The number of variants to process locally before updating the global atomic counter.
 /// A power of 2 is often efficient
-const PROGRESS_UPDATE_BATCH_SIZE: u64 = 1024;
+pub const PROGRESS_UPDATE_BATCH_SIZE: u64 = 1024;
 
 const REMOTE_BLOCK_SIZE: usize = 8 * 1024 * 1024;
 const REMOTE_CACHE_CAPACITY: usize = 8;
@@ -887,4 +884,4 @@ mod tests {
     }
 }
 
-# next test: gs://gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2  
+// next test: gs://gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2


### PR DESCRIPTION
## Summary
- re-export the shared file helpers from `score::io` so downstream modules retain the same interface
- wire the crate to include the shared file utilities module and add a shim for it
- fix the stray comment delimiter in `shared/files.rs` so it compiles as a Rust module

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e573e417f4832e832ef1527ff28746