### PR TITLE
Inline shared files module

### DIFF
--- a/score/lib.rs
+++ b/score/lib.rs
@@ -13,7 +13,11 @@ pub mod pipeline;
 pub mod prepare;
 pub mod reformat;
 pub mod types;
-pub mod shared;
+#[path = "../shared/files.rs"]
+pub mod shared_files;
+pub mod shared {
+    pub use super::shared_files as files;
+}
 
 // Add calibrate module
 #[path = "../calibrate/lib.rs"]

--- a/score/shared.rs
+++ b/score/shared.rs
@@ -1,2 +1,0 @@
-#[path = "../shared/files.rs"]
-pub mod files;


### PR DESCRIPTION
## Summary
- inline the shared files module definition directly in `score/lib.rs`
- remove the redundant `score/shared.rs` wrapper module

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e579909164832eaf30554aa58fa1fc