### PR TITLE
Fix CV checks for anisotropic PGS-PC null penalty

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -4914,9 +4914,35 @@ pub mod internal {
                             },
                             pos_bound_ok,
                         ));
-                    } else if label == "f(PGS,PC1)[1]" || label == "f(PGS,PC1)[2]" {
+                    } else if let Some(component) = label
+                        .strip_prefix("f(PGS,PC1)[")
+                        .and_then(|suffix| suffix.strip_suffix(']'))
+                    {
                         pgs_pc1_near_rates.push(near_rate);
                         pgs_pc1_pos_rates.push(pos_rate);
+
+                        if component == "3" {
+                            // The third anisotropic component corresponds to the joint null-space
+                            // projector for f(PGS, PC1); treat it like other explicit null penalties.
+                            let pos_rate_ok = pos_rate <= 0.50;
+                            check_results.push(CheckResult::new(
+                                format!("Penalty term '{}'", label),
+                                if pos_rate_ok {
+                                    format!(
+                                        "Null-space penalty '{}' +bound rate {:.1}% within ≤50% threshold",
+                                        label,
+                                        100.0 * pos_rate
+                                    )
+                                } else {
+                                    format!(
+                                        "Null-space penalty '{}' hit +bound too often ({:.1}%)",
+                                        label,
+                                        100.0 * pos_rate
+                                    )
+                                },
+                                pos_rate_ok,
+                            ));
+                        }
                     } else if matches!(
                         label.as_str(),
                         "f(PC1)_null" | "f(PGS)_null" | "f(PGS,PC1)_null"


### PR DESCRIPTION
## Summary
- treat the third anisotropic f(PGS,PC1) component as the joint null-space penalty in the CV diagnostics
- include that component when aggregating PGS–PC penalty statistics so the expected count matches the layout

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e5849fd15c832ebfc8c2d57241536b