### PR TITLE
Expose score modules at crate root

### DIFF
--- a/shared/lib.rs
+++ b/shared/lib.rs
@@ -13,6 +13,10 @@ pub mod shared {
 #[path = "../score/mod.rs"]
 mod score;
 
+pub use score::{
+    batch, complex, decide, download, io, kernel, pipeline, prepare, reformat, types,
+};
+
 #[path = "../map/mod.rs"]
 pub mod map;
 


### PR DESCRIPTION
## Summary
- re-export the score modules from the shared crate root so existing module paths resolve

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e5a8b58980832ea1f290956c5372cd