### PR TITLE
Scope score modules under score namespace

### DIFF
--- a/score/batch.rs
+++ b/score/batch.rs
@@ -12,8 +12,8 @@
 // scientific logic or reconciliation. We don't support over 100 scores.
 // It will panic / overflow if we try.
 
-use crate::kernel;
-use crate::types::{
+use crate::score::kernel;
+use crate::score::types::{
     EffectAlleleDosage, OriginalPersonIndex, PersonSubset, PreparationResult,
     ReconciledVariantIndex,
 };

--- a/score/complex.rs
+++ b/score/complex.rs
@@ -1,6 +1,6 @@
-use crate::io::BedSource;
-use crate::pipeline::{PipelineError, ScopeGuard};
-use crate::types::{BimRowIndex, FilesetBoundary, PreparationResult, ScoreInfo};
+use crate::score::io::BedSource;
+use crate::score::pipeline::{PipelineError, ScopeGuard};
+use crate::score::types::{BimRowIndex, FilesetBoundary, PreparationResult, ScoreInfo};
 use ahash::AHashSet;
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;

--- a/score/download.rs
+++ b/score/download.rs
@@ -4,7 +4,7 @@
 //
 // ========================================================================================
 
-use crate::reformat;
+use crate::score::reformat;
 use dwldutil::{DLFile, Downloader};
 use indicatif::ProgressStyle;
 use rayon::prelude::*;

--- a/score/io.rs
+++ b/score/io.rs
@@ -10,13 +10,15 @@
 // shared buffer pool to minimize allocations and provides natural backpressure if
 // consumers cannot keep up.
 
-use crate::decide::ComputePath;
-use crate::pipeline::PipelineError;
+use crate::score::decide::ComputePath;
+use crate::score::pipeline::PipelineError;
 pub use crate::shared::files::{
     gcs_billing_project_from_env, get_shared_runtime, load_adc_credentials, open_bed_source,
     open_text_source, BedSource, ByteRangeSource, TextSource, PROGRESS_UPDATE_BATCH_SIZE,
 };
-use crate::types::{FilesetBoundary, PreparationResult, ReconciledVariantIndex, WorkItem};
+use crate::score::types::{
+    FilesetBoundary, PreparationResult, ReconciledVariantIndex, WorkItem,
+};
 use crossbeam_channel::Sender;
 use crossbeam_queue::ArrayQueue;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/score/main.rs
+++ b/score/main.rs
@@ -13,14 +13,14 @@
 #![deny(unused_imports)]
 
 use clap::Parser;
-use gnomon::download;
-use gnomon::io::{
+use gnomon::score::download;
+use gnomon::score::io::{
     gcs_billing_project_from_env, get_shared_runtime, load_adc_credentials,
 };
-use gnomon::pipeline::{self, PipelineContext};
-use gnomon::prepare;
-use gnomon::reformat;
-use gnomon::types::PreparationResult;
+use gnomon::score::pipeline::{self, PipelineContext};
+use gnomon::score::prepare;
+use gnomon::score::reformat;
+use gnomon::score::types::PreparationResult;
 use natord::compare;
 use std::error::Error;
 use std::ffi::OsString;

--- a/score/pipeline.rs
+++ b/score/pipeline.rs
@@ -1,8 +1,8 @@
-use crate::batch;
-use crate::complex::{ComplexVariantResolver, resolve_complex_variants};
-use crate::decide::{self, DecisionContext, RunStrategy};
-use crate::io;
-use crate::types::{
+use crate::score::batch;
+use crate::score::complex::{ComplexVariantResolver, resolve_complex_variants};
+use crate::score::decide::{self, DecisionContext, RunStrategy};
+use crate::score::io;
+use crate::score::types::{
     EffectAlleleDosage, FilesetBoundary, PipelineKind, PreparationResult, ReconciledVariantIndex,
     WorkItem,
 };

--- a/score/prepare.rs
+++ b/score/prepare.rs
@@ -8,9 +8,9 @@
 // blueprint." It now uses a low-memory, high-throughput streaming merge-join
 // algorithm to handle genome-scale data.
 
-use crate::io::{open_text_source, TextSource};
-use crate::pipeline::PipelineError;
-use crate::types::{
+use crate::score::io::{open_text_source, TextSource};
+use crate::score::pipeline::PipelineError;
+use crate::score::types::{
     BimRowIndex, FilesetBoundary, GroupedComplexRule, PersonSubset, PipelineKind,
     PreparationResult, ScoreColumnIndex, ScoreInfo,
 };

--- a/shared/files.rs
+++ b/shared/files.rs
@@ -1,4 +1,4 @@
-use crate::pipeline::PipelineError;
+use crate::score::pipeline::PipelineError;
 use google_cloud_auth::credentials::{Credentials, anonymous::Builder as AnonymousCredentials};
 use google_cloud_storage::client::{Storage, StorageControl};
 use google_cloud_storage::model_ext::ReadRange;

--- a/shared/lib.rs
+++ b/shared/lib.rs
@@ -11,7 +11,7 @@ pub mod shared {
 }
 
 #[path = "../score/mod.rs"]
-mod score;
+pub mod score;
 
 #[path = "../map/mod.rs"]
 pub mod map;


### PR DESCRIPTION
## Summary
- remove the shared crate re-export of score-specific modules so they remain under the `score` namespace
- update score modules and shared helpers to import through `crate::score::...`
- adjust the score CLI entrypoint to use the new module paths

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e5a8b58980832ea1f290956c5372cd