### PR TITLE
Fix PCA SIMD imports and faer trait usage

### DIFF
--- a/map/project.rs
+++ b/map/project.rs
@@ -1,5 +1,6 @@
 use core::cmp::min;
 use faer::linalg::matmul::matmul;
+use faer::prelude::IntoConst;
 use faer::{Accum, Mat, MatMut};
 use std::error::Error;
 


### PR DESCRIPTION
## Summary
- switch the PCA SIMD utilities to `std::simd`, bringing the `SimdFloat` trait into scope so `is_finite` is available
- pull in `faer::prelude::IntoConst` and tidy mutable bindings in the PCA standardization routine
- update SIMD slice writes to use `copy_to_slice`

## Testing
- `cargo +nightly check`


------
https://chatgpt.com/codex/tasks/task_e_68e5b5fd093c832ebb27a2cca6014329