### PR TITLE
Add Firth configuration defaults for calibrator options

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -1224,6 +1224,7 @@ pub struct ExternalOptimOptions {
     pub max_iter: usize,
     pub tol: f64,
     pub nullspace_dims: Vec<usize>,
+    pub firth: Option<crate::calibrate::calibrator::FirthSpec>,
 }
 
 pub struct ExternalOptimResult {
@@ -8104,6 +8105,7 @@ mod gradient_validation_tests {
             tol: 1e-6,
             max_iter: 100,
             nullspace_dims: vec![0, 0],
+            firth: Some(crate::calibrate::calibrator::FirthSpec::all_enabled()),
         };
 
         // Fit model and extract results for diagnostic purposes


### PR DESCRIPTION
## Summary
- add a Firth configuration (scope + toggle) to `CalibratorSpec` with logit defaults
- thread the optional Firth settings through calibrator fitting and external optimizer options
- update calibrator tests to populate the new field explicitly

## Testing
- cargo fmt
- cargo check *(aborted: dependency download storm)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b78b005c832eb3d7d3d0752585c3