### PR TITLE
Simplify calibrator Firth spec

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -28,22 +28,14 @@ pub struct CalibratorFeatures {
 
 /// Configuration of the calibrator smooths and penalties
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum FirthScope {
-    All,
-    BackboneOnly,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FirthSpec {
     pub enabled: bool,
-    pub scope: FirthScope,
 }
 
 impl FirthSpec {
     pub fn all_enabled() -> Self {
         Self {
             enabled: true,
-            scope: FirthScope::All,
         }
     }
 }
@@ -1831,8 +1823,7 @@ pub fn fit_calibrator(
         if let Some(ref firth_spec) = firth {
             if firth_spec.enabled {
                 eprintln!(
-                    "[CAL] Firth penalization active for calibrator fit (scope={:?})",
-                    firth_spec.scope
+                    "[CAL] Firth penalization active for calibrator fit",
                 );
             } else {
                 eprintln!("[CAL] Firth penalization disabled for calibrator fit");

--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -1061,6 +1061,7 @@ pub fn train_model(
             penalty_order_dist: base_penalty_order,
             distance_hinge: true,
             prior_weights: Some(reml_state.weights().to_owned()),
+            firth: cal::CalibratorSpec::firth_default_for_link(config.link_function),
         };
 
         // Build design and penalties for calibrator


### PR DESCRIPTION
## Summary
- remove the unused FirthScope enum and simplify FirthSpec to a boolean toggle
- update calibrator logging that mentioned the deleted scope field
- ensure calibrator specs built in estimate.rs still populate firth defaults

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e5bb5688a4832e9d887c1d8001e140