### PR TITLE
Enable missing axis renormalization by default

### DIFF
--- a/map/fit.rs
+++ b/map/fit.rs
@@ -2,7 +2,6 @@ use core::cmp::min;
 use core::fmt;
 use faer::linalg::matmul::matmul;
 use faer::linalg::solvers::SelfAdjointEigen;
-use faer::prelude::IntoConst;
 use faer::{Accum, ColMut, Mat, MatMut, MatRef, Side};
 use faer::{Unbind, unzip, zip};
 use rayon::prelude::*;


### PR DESCRIPTION
## Summary
- enable missing-axis renormalization by default and set the zero-alignment default to NaN
- reject alignment output requests without renormalization and update projection tests to cover the new behavior
- add a regression test for incoherent projection options and drop an unused import

## Testing
- `cargo test map::project -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68e5cc65c168832ebcf664732eae38f9