### PR TITLE
Add streaming BCF dataset support to map pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ wolfe_bfgs = "0.1.6"
 log = "0.4.27"
 faer = "0.22.6"
 dyn-stack = "0.13"
+noodles-bcf = "0.78.0"
+noodles-vcf = "0.78.0"
 
 planus = "=1.1.1" # cf. https://github.com/pola-rs/polars/issues/24208
 

--- a/map/mod.rs
+++ b/map/mod.rs
@@ -1,4 +1,5 @@
 pub mod fit;
+pub mod io;
 pub mod main;
 pub mod project;
 


### PR DESCRIPTION
## Summary
- add noodles-based BCF/VCF dependencies needed for decoding binary variant streams
- introduce a unified `GenotypeDataset` abstraction with PLINK and BCF block sources and hook it into the map fit/project drivers
- rely on the shared BCF readers so both local directories and GCS prefixes stream variants into PCA

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e5ead598d0832e977247e2a73d5bbe