### PR TITLE
Restore PGS×PC null penalties

### DIFF
--- a/calibrate/README.md
+++ b/calibrate/README.md
@@ -36,8 +36,10 @@ stored for prediction-time standard errors.
 Each smooth term is represented with B-spline bases generated in
 [`basis.rs`](basis.rs). Difference penalties of configurable order control the
 wiggliness of the univariate smooths, tensor-product penalties regularize the
-interactions with PCs, and a double-penalty construction (null-space plus
-wiggle penalty) tempers the sex×PGS varying coefficient. These penalties
+interactions with PCs using directional smoothness along the PGS and PC axes
+plus an explicit null⊗null shrinkage, and a wiggle-only penalty tempers the
+sex×PGS varying coefficient while its null space is handled by the purity
+projection. These penalties
 respect the null spaces implied by the ANOVA constraints so that intercepts,
 sex main effects, and other lower-order components remain unpenalized by
 construction.

--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -3370,17 +3370,25 @@ pub mod internal {
             let mut types = vec![TermType::PcMainEffect; layout.num_penalties];
             for block in &layout.penalty_map {
                 for (component_idx, &pen_idx) in block.penalty_indices.iter().enumerate() {
-                    let label = if block.penalty_indices.len() > 1 {
-                        match block.term_type {
-                            TermType::SexPgsInteraction => match component_idx {
-                                0 => "f(PGS,sex)[PGS]".to_string(),
-                                1 => "f(PGS,sex)[sex]".to_string(),
-                                _ => format!("{}[{}]", block.term_name, component_idx + 1),
-                            },
-                            _ => format!("{}[{}]", block.term_name, component_idx + 1),
+                    let label = match block.term_type {
+                        TermType::SexPgsInteraction => "f(PGS,sex)[PGS]".to_string(),
+                        TermType::Interaction if block.penalty_indices.len() == 3 => {
+                            match component_idx {
+                                0 => format!("{}[PGS]", block.term_name),
+                                1 => format!("{}[PC]", block.term_name),
+                                2 => format!("{}[null]", block.term_name),
+                                _ => unreachable!(
+                                    "Unexpected component index for interaction penalties"
+                                ),
+                            }
                         }
-                    } else {
-                        block.term_name.clone()
+                        _ => {
+                            if block.penalty_indices.len() > 1 {
+                                format!("{}[{}]", block.term_name, component_idx + 1)
+                            } else {
+                                block.term_name.clone()
+                            }
+                        }
                     };
                     labels[pen_idx] = label;
                     types[pen_idx] = block.term_type.clone();


### PR DESCRIPTION
## Summary
- restore the anisotropic PGS×PC interaction layout to carry three penalties and rebuild the null⊗null projector plumbing alongside the sex×PGS wiggle-only block
- update the penalty labeling, regression test, and README text so the reinstated null penalty is documented and validated

## Testing
- `cargo test --lib calibrate::construction::tests::test_interaction_term_has_correct_penalty_structure -- --nocapture` *(fails: map::main still references a missing io module in the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e87a58a8832ebcb2d4b7599cd8da