### PR TITLE
Refactor map IO orchestration

### DIFF
--- a/map/io.rs
+++ b/map/io.rs
@@ -1,10 +1,13 @@
 use std::ffi::OsString;
+use std::fs::{self, File};
 use std::io;
+use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::str::{self, FromStr};
 use std::sync::{Arc, OnceLock};
 
-use crate::map::fit::VariantBlockSource;
+use crate::map::fit::{HwePcaModel, VariantBlockSource};
+use crate::map::project::ProjectionResult;
 use crate::score::pipeline::PipelineError;
 use crate::shared::files::{
     BcfSource, BedSource, TextSource, open_bcf_source, open_bed_source, open_text_source,
@@ -68,6 +71,16 @@ pub enum GenotypeIoError {
     Plink(#[from] PlinkIoError),
     #[error(transparent)]
     Bcf(#[from] BcfIoError),
+}
+
+#[derive(Debug, Error)]
+pub enum DatasetOutputError {
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("{0}")]
+    InvalidState(String),
 }
 
 #[derive(Clone, Debug)]
@@ -137,6 +150,169 @@ impl GenotypeDataset {
             Self::Bcf(dataset) => dataset.output_path(filename),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectionOutputPaths {
+    pub scores: PathBuf,
+    pub alignment: Option<PathBuf>,
+}
+
+pub fn save_hwe_model(
+    dataset: &GenotypeDataset,
+    model: &HwePcaModel,
+) -> Result<PathBuf, DatasetOutputError> {
+    let model_path = dataset.output_path("hwe.json");
+    prepare_output_path(&model_path)?;
+
+    let file = File::create(&model_path)?;
+    let mut writer = BufWriter::new(file);
+    serde_json::to_writer_pretty(&mut writer, model)?;
+    writer.flush()?;
+
+    Ok(model_path)
+}
+
+pub fn load_hwe_model(dataset: &GenotypeDataset) -> Result<HwePcaModel, DatasetOutputError> {
+    let model_path = dataset.output_path("hwe.json");
+    let file = File::open(&model_path)?;
+    let reader = BufReader::new(file);
+    let model: HwePcaModel = serde_json::from_reader(reader)?;
+
+    if model.n_variants() != dataset.n_variants() {
+        return Err(DatasetOutputError::InvalidState(format!(
+            "Model expects {} variants but dataset provides {}",
+            model.n_variants(),
+            dataset.n_variants()
+        )));
+    }
+
+    Ok(model)
+}
+
+pub fn save_projection_results(
+    dataset: &GenotypeDataset,
+    result: &ProjectionResult,
+) -> Result<ProjectionOutputPaths, DatasetOutputError> {
+    let scores = result.scores.as_ref();
+    let samples = dataset.samples();
+
+    if samples.len() != scores.nrows() {
+        return Err(DatasetOutputError::InvalidState(format!(
+            "Projection scores contain {} rows but dataset has {} samples",
+            scores.nrows(),
+            samples.len()
+        )));
+    }
+
+    let scores_path = dataset.output_path("projection.scores.tsv");
+    prepare_output_path(&scores_path)?;
+    let mut writer = BufWriter::new(File::create(&scores_path)?);
+
+    write!(writer, "FID\tIID")?;
+    for idx in 0..scores.ncols() {
+        write!(writer, "\tPC{}", idx + 1)?;
+    }
+    writeln!(writer)?;
+
+    for (row, sample) in samples.iter().enumerate() {
+        write!(writer, "{}\t{}", sample.family_id, sample.individual_id)?;
+        for col in 0..scores.ncols() {
+            let value = scores[(row, col)];
+            write!(writer, "\t{}", value)?;
+        }
+        writeln!(writer)?;
+    }
+
+    writer.flush()?;
+
+    let mut alignment_path = None;
+    if let Some(alignment) = result.alignment.as_ref() {
+        let path = dataset.output_path("projection.alignment.tsv");
+        prepare_output_path(&path)?;
+        let mut writer = BufWriter::new(File::create(&path)?);
+
+        write!(writer, "FID\tIID")?;
+        for idx in 0..alignment.ncols() {
+            write!(writer, "\tPC{}", idx + 1)?;
+        }
+        writeln!(writer)?;
+
+        for (row, sample) in samples.iter().enumerate() {
+            write!(writer, "{}\t{}", sample.family_id, sample.individual_id)?;
+            for col in 0..alignment.ncols() {
+                let value = alignment[(row, col)];
+                write!(writer, "\t{}", value)?;
+            }
+            writeln!(writer)?;
+        }
+
+        writer.flush()?;
+        alignment_path = Some(path);
+    }
+
+    Ok(ProjectionOutputPaths {
+        scores: scores_path,
+        alignment: alignment_path,
+    })
+}
+
+pub fn save_sample_manifest(dataset: &GenotypeDataset) -> Result<PathBuf, DatasetOutputError> {
+    let manifest_path = dataset.output_path("samples.tsv");
+    prepare_output_path(&manifest_path)?;
+    let mut writer = BufWriter::new(File::create(&manifest_path)?);
+
+    writeln!(writer, "FID\tIID\tPAT\tMAT\tSEX\tPHENOTYPE")?;
+
+    for record in dataset.samples() {
+        writeln!(
+            writer,
+            "{}\t{}\t{}\t{}\t{}\t{}",
+            record.family_id,
+            record.individual_id,
+            record.paternal_id,
+            record.maternal_id,
+            record.sex,
+            record.phenotype
+        )?;
+    }
+
+    writer.flush()?;
+    Ok(manifest_path)
+}
+
+pub fn save_fit_summary(
+    dataset: &GenotypeDataset,
+    model: &HwePcaModel,
+) -> Result<PathBuf, DatasetOutputError> {
+    let summary_path = dataset.output_path("hwe.summary.tsv");
+    prepare_output_path(&summary_path)?;
+    let mut writer = BufWriter::new(File::create(&summary_path)?);
+
+    writeln!(writer, "metric\tvalue")?;
+    writeln!(writer, "n_samples\t{}", model.n_samples())?;
+    writeln!(writer, "n_variants\t{}", model.n_variants())?;
+
+    for (idx, variance) in model.explained_variance().iter().copied().enumerate() {
+        writeln!(writer, "explained_variance_PC{}\t{}", idx + 1, variance)?;
+    }
+
+    let ratios = model.explained_variance_ratio();
+    for (idx, ratio) in ratios.into_iter().enumerate() {
+        writeln!(writer, "explained_variance_ratio_PC{}\t{}", idx + 1, ratio)?;
+    }
+
+    writer.flush()?;
+    Ok(summary_path)
+}
+
+fn prepare_output_path(path: &Path) -> Result<(), io::Error> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug)]

--- a/map/main.rs
+++ b/map/main.rs
@@ -1,11 +1,12 @@
 use std::fmt;
-use std::fs::{self, File};
-use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use super::fit::{HwePcaError, HwePcaModel};
-use super::io::{GenotypeDataset, GenotypeIoError};
-use super::project::{ProjectionOptions, ProjectionResult};
+use super::io::{
+    DatasetOutputError, GenotypeDataset, GenotypeIoError, ProjectionOutputPaths, load_hwe_model,
+    save_fit_summary, save_hwe_model, save_projection_results, save_sample_manifest,
+};
+use super::project::ProjectionOptions;
 
 /// High-level commands that can be executed within the `map` module.
 #[derive(Debug)]
@@ -72,6 +73,16 @@ impl From<serde_json::Error> for MapDriverError {
     }
 }
 
+impl From<DatasetOutputError> for MapDriverError {
+    fn from(value: DatasetOutputError) -> Self {
+        match value {
+            DatasetOutputError::Io(err) => Self::Io(err),
+            DatasetOutputError::Serialization(err) => Self::Serialization(err),
+            DatasetOutputError::InvalidState(msg) => Self::InvalidState(msg),
+        }
+    }
+}
+
 /// Execute the provided [`MapCommand`].
 pub fn run(command: MapCommand) -> Result<(), MapDriverError> {
     match command {
@@ -99,9 +110,14 @@ fn run_fit(genotype_path: &Path) -> Result<(), MapDriverError> {
         model.n_variants()
     );
 
-    persist_model(&dataset, &model)?;
-    persist_sample_manifest(&dataset)?;
-    persist_fit_summary(&dataset, &model)?;
+    let model_path = save_hwe_model(&dataset, &model)?;
+    println!("Saved HWE PCA model to {}", model_path.display());
+
+    let manifest_path = save_sample_manifest(&dataset)?;
+    println!("Sample manifest saved to {}", manifest_path.display());
+
+    let summary_path = save_fit_summary(&dataset, &model)?;
+    println!("Fit summary saved to {}", summary_path.display());
 
     Ok(())
 }
@@ -116,7 +132,7 @@ fn run_project(genotype_path: &Path) -> Result<(), MapDriverError> {
         dataset.n_variants()
     );
 
-    let model = load_model_for_projection(&dataset)?;
+    let model = load_hwe_model(&dataset)?;
     println!("Model provides {} principal components", model.components());
 
     let mut source = dataset.block_source()?;
@@ -124,7 +140,12 @@ fn run_project(genotype_path: &Path) -> Result<(), MapDriverError> {
     let projector = model.projector();
     let result = projector.project_with_options(&mut source, &options)?;
 
-    persist_projection_results(&dataset, &result)?;
+    let ProjectionOutputPaths { scores, alignment } = save_projection_results(&dataset, &result)?;
+
+    println!("Projection scores saved to {}", scores.display());
+    if let Some(path) = alignment {
+        println!("Projection alignment factors saved to {}", path.display());
+    }
 
     println!("Projection complete for {} samples", result.scores.nrows());
 
@@ -133,165 +154,4 @@ fn run_project(genotype_path: &Path) -> Result<(), MapDriverError> {
 
 fn open_dataset(path: &Path) -> Result<GenotypeDataset, MapDriverError> {
     Ok(GenotypeDataset::open(path)?)
-}
-
-fn persist_model(dataset: &GenotypeDataset, model: &HwePcaModel) -> Result<(), MapDriverError> {
-    let model_path = dataset_output_path(dataset, "hwe.json");
-    prepare_output_path(&model_path)?;
-
-    let file = File::create(&model_path)?;
-    let mut writer = BufWriter::new(file);
-    serde_json::to_writer_pretty(&mut writer, model)?;
-    writer.flush()?;
-
-    println!("Saved HWE PCA model to {}", model_path.display());
-    Ok(())
-}
-
-fn load_model_for_projection(dataset: &GenotypeDataset) -> Result<HwePcaModel, MapDriverError> {
-    let model_path = dataset_output_path(dataset, "hwe.json");
-    let file = File::open(&model_path)?;
-    let reader = BufReader::new(file);
-    let model: HwePcaModel = serde_json::from_reader(reader)?;
-
-    if model.n_variants() != dataset.n_variants() {
-        return Err(MapDriverError::InvalidState(format!(
-            "Model expects {} variants but dataset provides {}",
-            model.n_variants(),
-            dataset.n_variants()
-        )));
-    }
-
-    Ok(model)
-}
-
-fn persist_projection_results(
-    dataset: &GenotypeDataset,
-    result: &ProjectionResult,
-) -> Result<(), MapDriverError> {
-    let scores = result.scores.as_ref();
-    let samples = dataset.samples();
-
-    if samples.len() != scores.nrows() {
-        return Err(MapDriverError::InvalidState(format!(
-            "Projection scores contain {} rows but dataset has {} samples",
-            scores.nrows(),
-            samples.len()
-        )));
-    }
-
-    let scores_path = dataset_output_path(dataset, "projection.scores.tsv");
-    prepare_output_path(&scores_path)?;
-    let mut writer = BufWriter::new(File::create(&scores_path)?);
-
-    write!(writer, "FID\tIID")?;
-    for idx in 0..scores.ncols() {
-        write!(writer, "\tPC{}", idx + 1)?;
-    }
-    writeln!(writer)?;
-
-    for (row, sample) in samples.iter().enumerate() {
-        write!(writer, "{}\t{}", sample.family_id, sample.individual_id)?;
-        for col in 0..scores.ncols() {
-            let value = scores[(row, col)];
-            write!(writer, "\t{}", value)?;
-        }
-        writeln!(writer)?;
-    }
-
-    writer.flush()?;
-    println!("Projection scores saved to {}", scores_path.display());
-
-    if let Some(alignment) = &result.alignment {
-        let alignment_path = dataset_output_path(dataset, "projection.alignment.tsv");
-        prepare_output_path(&alignment_path)?;
-        let mut writer = BufWriter::new(File::create(&alignment_path)?);
-
-        write!(writer, "FID\tIID")?;
-        for idx in 0..alignment.ncols() {
-            write!(writer, "\tPC{}", idx + 1)?;
-        }
-        writeln!(writer)?;
-
-        for (row, sample) in samples.iter().enumerate() {
-            write!(writer, "{}\t{}", sample.family_id, sample.individual_id)?;
-            for col in 0..alignment.ncols() {
-                let value = alignment[(row, col)];
-                write!(writer, "\t{}", value)?;
-            }
-            writeln!(writer)?;
-        }
-
-        writer.flush()?;
-        println!(
-            "Projection alignment factors saved to {}",
-            alignment_path.display()
-        );
-    }
-
-    Ok(())
-}
-
-fn persist_sample_manifest(dataset: &GenotypeDataset) -> Result<(), MapDriverError> {
-    let manifest_path = dataset_output_path(dataset, "samples.tsv");
-    prepare_output_path(&manifest_path)?;
-    let mut writer = BufWriter::new(File::create(&manifest_path)?);
-
-    writeln!(writer, "FID\tIID\tPAT\tMAT\tSEX\tPHENOTYPE")?;
-
-    for record in dataset.samples() {
-        writeln!(
-            writer,
-            "{}\t{}\t{}\t{}\t{}\t{}",
-            record.family_id,
-            record.individual_id,
-            record.paternal_id,
-            record.maternal_id,
-            record.sex,
-            record.phenotype
-        )?;
-    }
-
-    writer.flush()?;
-    println!("Sample manifest saved to {}", manifest_path.display());
-    Ok(())
-}
-
-fn persist_fit_summary(
-    dataset: &GenotypeDataset,
-    model: &HwePcaModel,
-) -> Result<(), MapDriverError> {
-    let summary_path = dataset_output_path(dataset, "hwe.summary.tsv");
-    prepare_output_path(&summary_path)?;
-    let mut writer = BufWriter::new(File::create(&summary_path)?);
-
-    writeln!(writer, "metric\tvalue")?;
-    writeln!(writer, "n_samples\t{}", model.n_samples())?;
-    writeln!(writer, "n_variants\t{}", model.n_variants())?;
-
-    for (idx, variance) in model.explained_variance().iter().copied().enumerate() {
-        writeln!(writer, "explained_variance_PC{}\t{}", idx + 1, variance)?;
-    }
-
-    let ratios = model.explained_variance_ratio();
-    for (idx, ratio) in ratios.into_iter().enumerate() {
-        writeln!(writer, "explained_variance_ratio_PC{}\t{}", idx + 1, ratio)?;
-    }
-
-    writer.flush()?;
-    println!("Fit summary saved to {}", summary_path.display());
-    Ok(())
-}
-
-fn dataset_output_path(dataset: &GenotypeDataset, filename: &str) -> PathBuf {
-    dataset.output_path(filename)
-}
-
-fn prepare_output_path(path: &Path) -> Result<(), MapDriverError> {
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            fs::create_dir_all(parent)?;
-        }
-    }
-    Ok(())
 }


### PR DESCRIPTION
## Summary
- move format-specific persistence and loading helpers from `map::main` into `map::io`
- add output error handling helpers and reusable projection output paths structure
- simplify the map driver to orchestrate operations using the IO helpers and keep status logging

## Testing
- `cargo fmt`
- `cargo check -p gnomon` *(fails: build script rejects underscore-prefixed variables in shared/files.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f3853948832eb80a2e311361afc3