### PR TITLE
Update noodles dependencies and adjust BCF IO handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,9 @@ log = "0.4.27"
 faer = "0.22.6"
 dyn-stack = "0.13"
 noodles-bcf = "0.78.0"
-noodles-vcf = "0.78.0"
+noodles-vcf = "0.81.0"
+noodles-bgzf = "0.43.0"
+serde_json = "1.0"
 
 planus = "=1.1.1" # cf. https://github.com/pola-rs/polars/issues/24208
 
@@ -86,7 +88,6 @@ rand = "0.8"
 rand_distr = "0.4.3"
 tempfile = "3.21"
 approx = "0.5"
-serde_json = "1.0"
 
 [build-dependencies]
 walkdir = "2.5.0"

--- a/shared/files.rs
+++ b/shared/files.rs
@@ -8,6 +8,7 @@ use memmap2::Mmap;
 use natord::compare;
 use std::collections::{HashMap, VecDeque};
 use std::env;
+use std::fmt;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -133,6 +134,15 @@ impl BedSource {
 
     pub fn read_at(&self, offset: u64, dst: &mut [u8]) -> Result<(), PipelineError> {
         self.byte_source.read_at(offset, dst)
+    }
+}
+
+impl fmt::Debug for BedSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BedSource")
+            .field("len", &self.len())
+            .field("has_mmap", &self.mmap.is_some())
+            .finish()
     }
 }
 
@@ -463,7 +473,8 @@ fn fetch_bcf_object_names(
 
 fn list_remote_bcf_objects(bucket: &str, prefix: &str) -> Result<Vec<String>, PipelineError> {
     let runtime = get_shared_runtime()?;
-    let (_storage, control) = RemoteByteRangeSource::create_clients(&runtime, None)?;
+    let (storage, control) = RemoteByteRangeSource::create_clients(&runtime, None)?;
+    drop(storage);
     let bucket_path = format!("projects/_/buckets/{bucket}");
     let user_project = gcs_billing_project_from_env();
 
@@ -473,10 +484,11 @@ fn list_remote_bcf_objects(bucket: &str, prefix: &str) -> Result<Vec<String>, Pi
     match attempt(&control) {
         Ok(names) => Ok(names),
         Err(err) if RemoteByteRangeSource::is_authentication_error(&err) => {
-            let (_fallback_storage, fallback_control) = RemoteByteRangeSource::create_clients(
+            let (fallback_storage, fallback_control) = RemoteByteRangeSource::create_clients(
                 &runtime,
                 Some(AnonymousCredentials::new().build()),
             )?;
+            drop(fallback_storage);
             attempt(&fallback_control).map_err(|retry_err| {
                 convert_list_error(bucket, prefix, user_project.clone(), retry_err)
             })


### PR DESCRIPTION
## Summary
- update the noodles crates to the latest releases and promote serde_json to a runtime dependency
- adjust the BCF dataset reader to use the new noodles APIs, including manual Debug impls for iterator and block source types
- add a Debug impl for BedSource and drop unused remote storage handles to satisfy local linting

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e5f69415a4832ea8272ef1258c6e7e