### PR TITLE
Add BCF streaming support to IO layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ log = "0.4.27"
 faer = "0.22.6"
 dyn-stack = "0.13"
 noodles-bcf = "0.78.0"
-noodles-vcf = "0.78.0"
+noodles-vcf = "0.81.0"
 
 planus = "=1.1.1" # cf. https://github.com/pola-rs/polars/issues/24208
 

--- a/map/io.rs
+++ b/map/io.rs
@@ -13,9 +13,10 @@ use noodles_bcf::io::Reader as BcfReader;
 use noodles_vcf::{
     self as vcf,
     variant::RecordBuf,
-    variant::record_buf::samples::{
-        keys::key,
-        sample::{self, Value, value::Array, value::genotype::Genotype as SampleGenotype},
+    variant::record::samples::keys::key,
+    variant::record_buf::samples::sample::{
+        self, Value,
+        value::{Array, genotype::Genotype as SampleGenotype},
     },
 };
 use thiserror::Error;
@@ -317,11 +318,19 @@ impl PlinkDataset {
     }
 }
 
-#[derive(Debug)]
 pub struct PlinkVariantRecordIter {
     path: PathBuf,
     reader: Box<dyn TextSource>,
     line: usize,
+}
+
+impl std::fmt::Debug for PlinkVariantRecordIter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PlinkVariantRecordIter")
+            .field("path", &self.path)
+            .field("line", &self.line)
+            .finish()
+    }
 }
 
 impl PlinkVariantRecordIter {
@@ -616,6 +625,17 @@ pub struct BcfVariantBlockSource {
     emitted: usize,
 }
 
+impl std::fmt::Debug for BcfVariantBlockSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BcfVariantBlockSource")
+            .field("path", &self.path)
+            .field("n_samples", &self.n_samples)
+            .field("n_variants", &self.n_variants)
+            .field("emitted", &self.emitted)
+            .finish()
+    }
+}
+
 impl BcfVariantBlockSource {
     fn new(
         path: PathBuf,
@@ -743,7 +763,7 @@ fn compute_output_hint(path: &Path) -> OutputHint {
 
 fn create_bcf_reader(path: &Path) -> Result<BcfReader<BcfSource>, BcfIoError> {
     let source = open_bcf_source(path)?;
-    Ok(BcfReader::new(source))
+    Ok(BcfReader::from(source))
 }
 
 fn verify_header(observed: &vcf::Header, expected: &vcf::Header) -> Result<(), BcfIoError> {
@@ -841,10 +861,10 @@ fn numeric_from_value(value: &Value) -> Result<Option<f64>, BcfIoError> {
             }
         }
         Value::Array(Array::Integer(values)) => {
-            Ok(values.get(0).and_then(|opt| opt.map(|n| n as f64)))
+            Ok(values.get(0).copied().flatten().map(|n| n as f64))
         }
         Value::Array(Array::Float(values)) => {
-            Ok(values.get(0).and_then(|opt| opt.map(|n| n as f64)))
+            Ok(values.get(0).copied().flatten().map(|n| n as f64))
         }
         Value::Array(_) => Ok(None),
         Value::Genotype(genotype) => dosage_from_genotype(genotype.as_ref()),
@@ -979,4 +999,78 @@ fn is_remote_path(path: &Path) -> bool {
     path.to_str()
         .map(|s| s.starts_with("gs://"))
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::{Read, Write};
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    fn fake_bcf_header() -> Vec<u8> {
+        let header_text =
+            b"##fileformat=VCFv4.3\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\n\0";
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"BCF");
+        bytes.push(2);
+        bytes.push(2);
+        bytes.extend_from_slice(&(header_text.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(header_text);
+        bytes
+    }
+
+    fn write_fake_bcf<P: AsRef<Path>>(path: P, payload: &[u8]) -> std::io::Result<Vec<u8>> {
+        let mut file = File::create(path)?;
+        let header = fake_bcf_header();
+        file.write_all(&header)?;
+        file.write_all(payload)?;
+        Ok(header)
+    }
+
+    fn read_all(mut source: BcfSource) -> Vec<u8> {
+        let mut data = Vec::new();
+        source.read_to_end(&mut data).unwrap();
+        data
+    }
+
+    #[test]
+    fn bcf_source_reads_single_file_without_modification() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sample.bcf");
+        let header = write_fake_bcf(&path, &[0x01, 0x02, 0x03]).unwrap();
+
+        let source = open_bcf_source(&path).unwrap();
+        let bytes = read_all(source);
+
+        let mut expected = header;
+        expected.extend_from_slice(&[0x01, 0x02, 0x03]);
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn bcf_source_skips_headers_when_concatenating_directory() {
+        let dir = tempdir().unwrap();
+        let files = [
+            ("chr2.bcf", vec![0x20]),
+            ("chr10.bcf", vec![0x10]),
+            ("chr1.bcf", vec![0x01]),
+        ];
+
+        for (name, payload) in &files {
+            let path = dir.path().join(name);
+            write_fake_bcf(&path, payload).unwrap();
+        }
+
+        let mut expected = fake_bcf_header();
+        expected.extend_from_slice(&[0x01]);
+        expected.extend_from_slice(&[0x20]);
+        expected.extend_from_slice(&[0x10]);
+
+        let source = open_bcf_source(dir.path()).unwrap();
+        let bytes = read_all(source);
+
+        assert_eq!(bytes, expected);
+    }
 }

--- a/shared/files.rs
+++ b/shared/files.rs
@@ -136,6 +136,15 @@ impl BedSource {
     }
 }
 
+impl std::fmt::Debug for BedSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BedSource")
+            .field("len", &self.len())
+            .field("has_mmap", &self.mmap.is_some())
+            .finish()
+    }
+}
+
 /// Creates a `BedSource` for the provided `.bed` path. Local paths are
 /// memory-mapped, while `gs://` locations stream data directly from Cloud
 /// Storage.
@@ -162,18 +171,19 @@ pub fn open_bed_source(path: &Path) -> Result<BedSource, PipelineError> {
 struct PreparedBcfReader {
     reader: Box<dyn Read + Send>,
     len: u64,
+    skip_header: bool,
 }
 
 /// Provides sequential access to one or more BCF streams. The data is
 /// transparently decompressed when the underlying files are BGZF-compressed.
 pub struct BcfSource {
-    readers: VecDeque<Box<dyn Read + Send>>,
+    readers: VecDeque<PreparedBcfReader>,
     current: Option<Box<dyn Read + Send>>,
     total_len: Option<u64>,
 }
 
 impl BcfSource {
-    fn from_readers(readers: Vec<PreparedBcfReader>) -> Result<Self, PipelineError> {
+    fn from_readers(mut readers: Vec<PreparedBcfReader>) -> Result<Self, PipelineError> {
         if readers.is_empty() {
             return Err(PipelineError::Io(
                 "No BCF files were discovered for the requested input".to_string(),
@@ -187,8 +197,9 @@ impl BcfSource {
         })?;
 
         let mut queue = VecDeque::with_capacity(readers.len());
-        for reader in readers {
-            queue.push_back(reader.reader);
+        for (idx, mut reader) in readers.drain(..).enumerate() {
+            reader.skip_header = idx > 0;
+            queue.push_back(reader);
         }
 
         Ok(Self {
@@ -204,11 +215,8 @@ impl BcfSource {
         }
 
         loop {
-            if self.current.is_none() {
-                self.current = self.readers.pop_front();
-                if self.current.is_none() {
-                    return Ok(0);
-                }
+            if !self.ensure_current_reader()? {
+                return Ok(0);
             }
 
             if let Some(reader) = self.current.as_mut() {
@@ -221,6 +229,25 @@ impl BcfSource {
                 }
             }
         }
+    }
+
+    fn ensure_current_reader(&mut self) -> io::Result<bool> {
+        while self.current.is_none() {
+            let prepared = match self.readers.pop_front() {
+                Some(reader) => reader,
+                None => return Ok(false),
+            };
+
+            let mut reader = prepared.reader;
+            if prepared.skip_header {
+                skip_bcf_header(reader.as_mut())?;
+                self.total_len = None;
+            }
+
+            self.current = Some(reader);
+        }
+
+        Ok(true)
     }
 
     /// Returns the combined compressed length of the underlying BCF objects
@@ -240,6 +267,38 @@ impl Read for BcfSource {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.read_internal(buf)
     }
+}
+
+fn skip_bcf_header(reader: &mut dyn Read) -> io::Result<u64> {
+    const MAGIC_LEN: usize = 3;
+    const VERSION_LEN: usize = 2;
+    const HEADER_FIELD_LEN: usize = 4;
+
+    let mut magic = [0u8; MAGIC_LEN];
+    reader.read_exact(&mut magic)?;
+    if magic != *b"BCF" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Encountered non-BCF data while concatenating streams",
+        ));
+    }
+
+    let mut version = [0u8; VERSION_LEN];
+    reader.read_exact(&mut version)?;
+
+    let mut len_buf = [0u8; HEADER_FIELD_LEN];
+    reader.read_exact(&mut len_buf)?;
+    let header_len = u32::from_le_bytes(len_buf) as u64;
+
+    let consumed = io::copy(&mut reader.take(header_len), &mut io::sink())?;
+    if consumed != header_len {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "BCF header ended unexpectedly while skipping concatenated input",
+        ));
+    }
+
+    Ok((MAGIC_LEN + VERSION_LEN + HEADER_FIELD_LEN) as u64 + header_len)
 }
 
 pub fn open_text_source(path: &Path) -> Result<Box<dyn TextSource>, PipelineError> {
@@ -358,7 +417,11 @@ fn open_local_bcf_reader(path: &Path) -> Result<PreparedBcfReader, PipelineError
         Box::new(BufReader::new(file))
     };
 
-    Ok(PreparedBcfReader { reader, len })
+    Ok(PreparedBcfReader {
+        reader,
+        len,
+        skip_header: false,
+    })
 }
 
 fn is_gzip_magic(magic: &[u8; 2]) -> bool {
@@ -463,7 +526,7 @@ fn fetch_bcf_object_names(
 
 fn list_remote_bcf_objects(bucket: &str, prefix: &str) -> Result<Vec<String>, PipelineError> {
     let runtime = get_shared_runtime()?;
-    let (_storage, control) = RemoteByteRangeSource::create_clients(&runtime, None)?;
+    let (_, control) = RemoteByteRangeSource::create_clients(&runtime, None)?;
     let bucket_path = format!("projects/_/buckets/{bucket}");
     let user_project = gcs_billing_project_from_env();
 
@@ -473,7 +536,7 @@ fn list_remote_bcf_objects(bucket: &str, prefix: &str) -> Result<Vec<String>, Pi
     match attempt(&control) {
         Ok(names) => Ok(names),
         Err(err) if RemoteByteRangeSource::is_authentication_error(&err) => {
-            let (_fallback_storage, fallback_control) = RemoteByteRangeSource::create_clients(
+            let (_, fallback_control) = RemoteByteRangeSource::create_clients(
                 &runtime,
                 Some(AnonymousCredentials::new().build()),
             )?;
@@ -1125,7 +1188,11 @@ fn prepare_remote_bcf_reader(
     } else {
         Box::new(reader)
     };
-    Ok(PreparedBcfReader { reader, len })
+    Ok(PreparedBcfReader {
+        reader,
+        len,
+        skip_header: false,
+    })
 }
 
 struct RemoteCache {


### PR DESCRIPTION
## Summary
- stream BCF data from single files or directories by tracking PreparedBcfReaders and skipping duplicate headers
- hook the new BCF source into map IO utilities, add Debug helpers, and add regression tests for concatenated streams
- bump noodles-vcf to 0.81.0 for the updated samples API

## Testing
- cargo test --lib map::io::tests::bcf_source_reads_single_file_without_modification
- cargo test --lib map::io::tests::bcf_source_skips_headers_when_concatenating_directory


------
https://chatgpt.com/codex/tasks/task_e_68e5f173d9d8832e8f1e3135caeca368