### PR TITLE
Stream map integration test data and fix map build

### DIFF
--- a/map/io.rs
+++ b/map/io.rs
@@ -502,15 +502,6 @@ pub struct PlinkVariantRecordIter {
     line: usize,
 }
 
-impl std::fmt::Debug for PlinkVariantRecordIter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PlinkVariantRecordIter")
-            .field("path", &self.path)
-            .field("line", &self.line)
-            .finish()
-    }
-}
-
 impl PlinkVariantRecordIter {
     fn new(path: PathBuf, reader: Box<dyn TextSource>) -> Self {
         Self {
@@ -946,7 +937,8 @@ fn compute_output_hint(path: &Path) -> OutputHint {
 
 fn create_bcf_reader(path: &Path) -> Result<BcfReader<BgzfReader<BcfSource>>, BcfIoError> {
     let source = open_bcf_source(path)?;
-    Ok(BcfReader::from(source))
+    let reader = BgzfReader::new(source);
+    Ok(BcfReader::from(reader))
 }
 
 fn verify_header(observed: &vcf::Header, expected: &vcf::Header) -> Result<(), BcfIoError> {

--- a/map/main.rs
+++ b/map/main.rs
@@ -156,226 +156,34 @@ fn open_dataset(path: &Path) -> Result<GenotypeDataset, MapDriverError> {
     Ok(GenotypeDataset::open(path)?)
 }
 
-fn persist_model(dataset: &GenotypeDataset, model: &HwePcaModel) -> Result<(), MapDriverError> {
-    let model_path = dataset_output_path(dataset, "hwe.json");
-    prepare_output_path(&model_path)?;
-
-    let file = File::create(&model_path)?;
-    let mut writer = BufWriter::new(file);
-    serde_json::to_writer_pretty(&mut writer, model)?;
-    writer.flush()?;
-
-    println!("Saved HWE PCA model to {}", model_path.display());
-    Ok(())
-}
-
-fn load_model_for_projection(dataset: &GenotypeDataset) -> Result<HwePcaModel, MapDriverError> {
-    let model_path = dataset_output_path(dataset, "hwe.json");
-    let file = File::open(&model_path)?;
-    let reader = BufReader::new(file);
-    let model: HwePcaModel = serde_json::from_reader(reader)?;
-
-    if model.n_variants() != dataset.n_variants() {
-        return Err(MapDriverError::InvalidState(format!(
-            "Model expects {} variants but dataset provides {}",
-            model.n_variants(),
-            dataset.n_variants()
-        )));
-    }
-
-    Ok(model)
-}
-
-fn persist_projection_results(
-    dataset: &GenotypeDataset,
-    result: &ProjectionResult,
-) -> Result<(), MapDriverError> {
-    let scores = result.scores.as_ref();
-    let samples = dataset.samples();
-
-    if samples.len() != scores.nrows() {
-        return Err(MapDriverError::InvalidState(format!(
-            "Projection scores contain {} rows but dataset has {} samples",
-            scores.nrows(),
-            samples.len()
-        )));
-    }
-
-    let scores_path = dataset_output_path(dataset, "projection.scores.tsv");
-    prepare_output_path(&scores_path)?;
-    let mut writer = BufWriter::new(File::create(&scores_path)?);
-
-    write!(writer, "FID\tIID")?;
-    for idx in 0..scores.ncols() {
-        write!(writer, "\tPC{}", idx + 1)?;
-    }
-    writeln!(writer)?;
-
-    for (row, sample) in samples.iter().enumerate() {
-        write!(writer, "{}\t{}", sample.family_id, sample.individual_id)?;
-        for col in 0..scores.ncols() {
-            let value = scores[(row, col)];
-            write!(writer, "\t{}", value)?;
-        }
-        writeln!(writer)?;
-    }
-
-    writer.flush()?;
-    println!("Projection scores saved to {}", scores_path.display());
-
-    if let Some(alignment) = &result.alignment {
-        let alignment_path = dataset_output_path(dataset, "projection.alignment.tsv");
-        prepare_output_path(&alignment_path)?;
-        let mut writer = BufWriter::new(File::create(&alignment_path)?);
-
-        write!(writer, "FID\tIID")?;
-        for idx in 0..alignment.ncols() {
-            write!(writer, "\tPC{}", idx + 1)?;
-        }
-        writeln!(writer)?;
-
-        for (row, sample) in samples.iter().enumerate() {
-            write!(writer, "{}\t{}", sample.family_id, sample.individual_id)?;
-            for col in 0..alignment.ncols() {
-                let value = alignment[(row, col)];
-                write!(writer, "\t{}", value)?;
-            }
-            writeln!(writer)?;
-        }
-
-        writer.flush()?;
-        println!(
-            "Projection alignment factors saved to {}",
-            alignment_path.display()
-        );
-    }
-
-    Ok(())
-}
-
-fn persist_sample_manifest(dataset: &GenotypeDataset) -> Result<(), MapDriverError> {
-    let manifest_path = dataset_output_path(dataset, "samples.tsv");
-    prepare_output_path(&manifest_path)?;
-    let mut writer = BufWriter::new(File::create(&manifest_path)?);
-
-    writeln!(writer, "FID\tIID\tPAT\tMAT\tSEX\tPHENOTYPE")?;
-
-    for record in dataset.samples() {
-        writeln!(
-            writer,
-            "{}\t{}\t{}\t{}\t{}\t{}",
-            record.family_id,
-            record.individual_id,
-            record.paternal_id,
-            record.maternal_id,
-            record.sex,
-            record.phenotype
-        )?;
-    }
-
-    writer.flush()?;
-    println!("Sample manifest saved to {}", manifest_path.display());
-    Ok(())
-}
-
-fn persist_fit_summary(
-    dataset: &GenotypeDataset,
-    model: &HwePcaModel,
-) -> Result<(), MapDriverError> {
-    let summary_path = dataset_output_path(dataset, "hwe.summary.tsv");
-    prepare_output_path(&summary_path)?;
-    let mut writer = BufWriter::new(File::create(&summary_path)?);
-
-    writeln!(writer, "metric\tvalue")?;
-    writeln!(writer, "n_samples\t{}", model.n_samples())?;
-    writeln!(writer, "n_variants\t{}", model.n_variants())?;
-
-    for (idx, variance) in model.explained_variance().iter().copied().enumerate() {
-        writeln!(writer, "explained_variance_PC{}\t{}", idx + 1, variance)?;
-    }
-
-    let ratios = model.explained_variance_ratio();
-    for (idx, ratio) in ratios.into_iter().enumerate() {
-        writeln!(writer, "explained_variance_ratio_PC{}\t{}", idx + 1, ratio)?;
-    }
-
-    writer.flush()?;
-    println!("Fit summary saved to {}", summary_path.display());
-    Ok(())
-}
-
-fn dataset_output_path(dataset: &GenotypeDataset, filename: &str) -> PathBuf {
-    dataset.output_path(filename)
-}
-
-fn prepare_output_path(path: &Path) -> Result<(), MapDriverError> {
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            fs::create_dir_all(parent)?;
-        }
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
-    use super::fit::{DEFAULT_BLOCK_WIDTH, DenseBlockSource, HwePcaModel};
-    use super::io::{DatasetBlockSource, GenotypeDataset};
+    use super::fit::HwePcaModel;
+    use super::io::GenotypeDataset;
     use super::project::ProjectionOptions;
-    use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
     use std::error::Error;
     use std::path::Path;
 
     const HGDP_CHR20_BCF: &str = "gs://gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2/\
          hgdp1kgp_chr20.filtered.SNV_INDEL.phased.shapeit5.bcf";
-    const RNG_SEED: u64 = 0xC0FFEE5EEDBADD5;
 
     #[test]
-    fn fit_and_project_split_hgdp_chr20() -> Result<(), Box<dyn Error>> {
+    fn fit_and_project_full_hgdp_chr20() -> Result<(), Box<dyn Error>> {
         let dataset = GenotypeDataset::open(Path::new(HGDP_CHR20_BCF))
             .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
-        let mut block_source = dataset
-            .block_source()
-            .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
-
-        let n_samples = block_source.n_samples();
-        let n_variants = block_source.n_variants();
+        let n_samples = dataset.n_samples();
+        let n_variants = dataset.n_variants();
         assert!(n_samples >= 3, "expected at least three samples for PCA");
         assert!(n_variants > 0, "expected at least one variant in dataset");
         assert_eq!(dataset.samples().len(), n_samples);
 
-        let dense_matrix = collect_dense_matrix(&mut block_source)?;
-
-        let mut rng = StdRng::seed_from_u64(RNG_SEED);
-        let mut sample_indices: Vec<usize> = (0..n_samples).collect();
-        sample_indices.shuffle(&mut rng);
-
-        let min_train = 2usize;
-        let min_inference = 1usize;
-        let mut train_count = ((n_samples as f64) * 0.8).round() as usize;
-        if train_count < min_train {
-            train_count = min_train;
-        }
-        if train_count > n_samples.saturating_sub(min_inference) {
-            train_count = n_samples - min_inference;
-        }
-        let inference_count = n_samples - train_count;
-        assert!(inference_count >= min_inference);
-
-        let train_indices = &sample_indices[..train_count];
-        let inference_indices = &sample_indices[train_count..];
-
-        let train_matrix =
-            slice_samples_into_dense(&dense_matrix, n_samples, n_variants, train_indices);
-        let inference_matrix =
-            slice_samples_into_dense(&dense_matrix, n_samples, n_variants, inference_indices);
-
-        let mut train_source = DenseBlockSource::new(&train_matrix, train_count, n_variants)
+        let mut train_source = dataset
+            .block_source()
             .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
         let model = HwePcaModel::fit(&mut train_source)
             .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
 
-        assert_eq!(model.n_samples(), train_count);
+        assert_eq!(model.n_samples(), n_samples);
         assert_eq!(model.n_variants(), n_variants);
         assert!(model.components() > 0);
         assert_eq!(model.explained_variance().len(), model.components());
@@ -400,15 +208,17 @@ mod tests {
             "explained variance ratios must sum to at most 1 (observed {variance_ratio_sum})"
         );
 
-        let mut inference_source =
-            DenseBlockSource::new(&inference_matrix, inference_count, n_variants)
-                .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
+        drop(train_source);
+
+        let mut inference_source = dataset
+            .block_source()
+            .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
         let projection = model
             .projector()
             .project_with_options(&mut inference_source, &ProjectionOptions::default())
             .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
 
-        assert_eq!(projection.scores.nrows(), inference_count);
+        assert_eq!(projection.scores.nrows(), n_samples);
         assert_eq!(projection.scores.ncols(), model.components());
         assert!(projection.alignment.is_none());
 
@@ -424,56 +234,5 @@ mod tests {
         }
 
         Ok(())
-    }
-
-    fn collect_dense_matrix(source: &mut DatasetBlockSource) -> Result<Vec<f64>, Box<dyn Error>> {
-        let n_samples = source.n_samples();
-        let n_variants = source.n_variants();
-        let block_capacity = DEFAULT_BLOCK_WIDTH.max(1);
-        let mut storage = vec![0.0f64; n_samples * block_capacity];
-        let mut dense = vec![0.0f64; n_samples * n_variants];
-        let mut emitted = 0usize;
-
-        while emitted < n_variants {
-            let filled = source
-                .next_block_into(block_capacity, &mut storage)
-                .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
-            if filled == 0 {
-                break;
-            }
-
-            for local_idx in 0..filled {
-                let src_offset = local_idx * n_samples;
-                let dest_offset = (emitted + local_idx) * n_samples;
-                dense[dest_offset..dest_offset + n_samples]
-                    .copy_from_slice(&storage[src_offset..src_offset + n_samples]);
-            }
-
-            emitted += filled;
-        }
-
-        assert_eq!(
-            emitted, n_variants,
-            "expected to materialize all {n_variants} variants but only processed {emitted}"
-        );
-
-        Ok(dense)
-    }
-
-    fn slice_samples_into_dense(
-        data: &[f64],
-        n_samples: usize,
-        n_variants: usize,
-        selected: &[usize],
-    ) -> Vec<f64> {
-        let mut subset = vec![0.0f64; selected.len() * n_variants];
-        for variant_idx in 0..n_variants {
-            let column = &data[variant_idx * n_samples..(variant_idx + 1) * n_samples];
-            let dest_offset = variant_idx * selected.len();
-            for (row_offset, &sample_idx) in selected.iter().enumerate() {
-                subset[dest_offset + row_offset] = column[sample_idx];
-            }
-        }
-        subset
     }
 }

--- a/shared/files.rs
+++ b/shared/files.rs
@@ -8,7 +8,6 @@ use memmap2::Mmap;
 use natord::compare;
 use std::collections::{HashMap, VecDeque};
 use std::env;
-use std::fmt;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -543,7 +542,6 @@ fn list_remote_bcf_objects(bucket: &str, prefix: &str) -> Result<Vec<String>, Pi
                 &runtime,
                 Some(AnonymousCredentials::new().build()),
             )?;
-            drop(fallback_storage);
             attempt(&fallback_control).map_err(|retry_err| {
                 convert_list_error(bucket, prefix, user_project.clone(), retry_err)
             })


### PR DESCRIPTION
## Summary
- update the map HGDP integration test to fit and project on the full dataset by streaming Google Cloud blocks twice
- remove unused persistence helpers from the map driver and clean up duplicate trait implementations in map/io
- tighten shared Google Cloud listing logic to drop an unused variable and wrap BCF sources in a BGZF reader for compatibility

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e68e47198c832eb51b8cd5aa131eff