### PR TITLE
Fix serialization field count for HwePcaModel

### DIFF
--- a/map/fit.rs
+++ b/map/fit.rs
@@ -740,7 +740,7 @@ impl Serialize for HwePcaModel {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("HwePcaModel", 9)?;
+        let mut state = serializer.serialize_struct("HwePcaModel", 8)?;
         state.serialize_field("n_samples", &self.n_samples)?;
         state.serialize_field("n_variants", &self.n_variants)?;
         state.serialize_field("scaler", &self.scaler)?;


### PR DESCRIPTION
## Summary
- correct the field count hint used when serializing `HwePcaModel`

## Testing
- cargo test *(fails: calibrate::estimate::internal::tests::test_gradient_vs_cost_relationship)*

------
https://chatgpt.com/codex/tasks/task_e_68e6a433b42c832eabd4609950c5c93d