### PR TITLE
Improve map progress reporting

### DIFF
--- a/map/mod.rs
+++ b/map/mod.rs
@@ -1,6 +1,7 @@
 pub mod fit;
 pub mod io;
 pub mod main;
+pub mod progress;
 pub mod project;
 pub use fit::{
     DEFAULT_BLOCK_WIDTH, DenseBlockSource, HwePcaError, HwePcaModel, HweScaler, VariantBlockSource,

--- a/map/progress.rs
+++ b/map/progress.rs
@@ -1,0 +1,69 @@
+use std::fmt;
+
+/// Stages reported during model fitting.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum FitProgressStage {
+    AlleleStatistics,
+    GramMatrix,
+    Loadings,
+}
+
+impl FitProgressStage {
+    pub fn describe(self) -> &'static str {
+        match self {
+            Self::AlleleStatistics => "allele statistics",
+            Self::GramMatrix => "Gram matrix accumulation",
+            Self::Loadings => "variant loading computation",
+        }
+    }
+}
+
+impl fmt::Display for FitProgressStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.describe())
+    }
+}
+
+/// Observer for reporting incremental progress while fitting a model.
+pub trait FitProgressObserver {
+    fn on_stage_start(&mut self, _stage: FitProgressStage, _total_variants: usize) {}
+    fn on_stage_advance(&mut self, _stage: FitProgressStage, _processed_variants: usize) {}
+    fn on_stage_finish(&mut self, _stage: FitProgressStage) {}
+}
+
+#[derive(Default)]
+pub struct NoopFitProgress;
+
+impl FitProgressObserver for NoopFitProgress {}
+
+/// Stages reported during projection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ProjectionProgressStage {
+    Projection,
+}
+
+impl ProjectionProgressStage {
+    pub fn describe(self) -> &'static str {
+        match self {
+            Self::Projection => "sample projection",
+        }
+    }
+}
+
+impl fmt::Display for ProjectionProgressStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.describe())
+    }
+}
+
+/// Observer for reporting incremental progress during projection.
+pub trait ProjectionProgressObserver {
+    fn on_stage_start(&mut self, _stage: ProjectionProgressStage, _total_variants: usize) {}
+    fn on_stage_advance(&mut self, _stage: ProjectionProgressStage, _processed_variants: usize) {}
+    fn on_stage_finish(&mut self, _stage: ProjectionProgressStage) {}
+}
+
+#[derive(Default)]
+pub struct NoopProjectionProgress;
+
+impl ProjectionProgressObserver for NoopProjectionProgress {}


### PR DESCRIPTION
## Summary
- add reusable progress observer traits for model fitting and projection stages
- update fitting and projection routines to emit detailed progress updates while processing variants
- enhance the map CLI output with descriptive messages and styled progress bars for fit and project commands

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e6dd11f084832ea6af484bc9cfbd89