### PR TITLE
Switch to faer self-adjoint matrix-free eigen solver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ toml = "0.8.23"
 polars = { version = "0.50.0", features = ["csv", "ndarray"] }
 wolfe_bfgs = "0.1.6"
 log = "0.4.27"
-faer = "0.22.6"
+faer = "0.23.2"
 dyn-stack = "0.13"
 noodles-bcf = "0.78.0"
 noodles-vcf = "0.81.0"


### PR DESCRIPTION
## Summary
- upgrade faer to 0.23.2 to gain access to the dedicated self-adjoint matrix-free eigensolver
- use `partial_self_adjoint_eigen` for the covariance operator so the PCA pipeline stays in real space

## Testing
- cargo check -p gnomon --lib

------
https://chatgpt.com/codex/tasks/task_e_68e6e783d2fc832e860238344aff3043