### PR TITLE
Enable realtime map test output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Run map-specific tests
         if: steps.rust_changes.outputs.map == 'true'
-        run: 'cargo +nightly test --release map:: -- --show-output'
+        run: cargo +nightly test --release map:: -- --nocapture
 
       - name: Inspect Assembly for Performance Analysis
         if: steps.rust_changes.outputs.rust == 'false'


### PR DESCRIPTION
## Summary
- update the map-specific test job to use `--nocapture` so stdout streams live in CI logs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7fa8e8c1c832eaad229f8d6f6f08c