### PR TITLE
Add map test that downloads and processes PLINK dataset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ rand = "0.8"
 rand_distr = "0.4.3"
 tempfile = "3.21"
 approx = "0.5"
+reqwest = { version = "0.12.8", features = ["blocking", "rustls-tls"] }
+zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 
 [build-dependencies]
 walkdir = "2.5.0"


### PR DESCRIPTION
## Summary
- add reqwest and zip as dev-dependencies for downloading and extracting PLINK archives in tests
- add a map test that downloads a small PLINK dataset, runs HWE PCA fitting, reloads the saved model, and projects the same data

## Testing
- cargo test --no-run

------
https://chatgpt.com/codex/tasks/task_e_68e7fa65ad94832e9119fe1847dd7c74