### PR TITLE
Upgrade dependencies and refresh downloader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ path = "cli/main.rs"
 
 [dependencies]
 ahash = "0.8.12"
-clap = { version = "4.5.46", features = ["derive"] }
+clap = { version = "4.5.48", features = ["derive"] }
 memmap2 = "0.9.8"
 rayon = "1.11.0"
 crossbeam-queue = "0.3.12"
@@ -36,20 +36,20 @@ ryu = "1.0.20"
 crossbeam-channel = "0.5.15"
 natord = "1.0.9"
 bumpalo = { version = "3.19.0", features = ["collections"] }
-dwldutil = "2.0.4"
-indicatif = "0.17"
-google-cloud-storage = "1.0.0"
-google-cloud-auth = "1.0.0"
-flate2 = "1.1.2"
+dwldutil = { version = "3.1.1", features = ["indicatif_indicator"] }
+indicatif = "0.18"
+google-cloud-storage = "1.1.0"
+google-cloud-auth = "1.0.1"
+flate2 = "1.1.4"
 ndarray = { version = "0.16.1", features = ["serde", "rayon"] }
-serde = { version = "1.0.219", features = ["derive"] }
-thiserror = "2.0.16"
-toml = "0.8.23"
-polars = { version = "0.50.0", features = ["csv", "ndarray"] }
+serde = { version = "1.0.228", features = ["derive"] }
+thiserror = "2.0.17"
+toml = "0.9.7"
+polars = { version = "0.51.0", features = ["csv", "ndarray"] }
 wolfe_bfgs = "0.1.6"
-log = "0.4.27"
+log = "0.4.28"
 faer = "0.23.2"
-dyn-stack = "0.13"
+dyn-stack = "0.13.2"
 noodles-bcf = "0.78.0"
 noodles-vcf = "0.81.0"
 noodles-bgzf = "0.43.0"


### PR DESCRIPTION
## Summary
- bump several core dependencies, including clap, polars, serde, and dwldutil
- adapt the score downloader to the updated dwldutil indicator API
- update the path benchmark helper to the latest preparation signatures

## Testing
- cargo check --all-targets

------
https://chatgpt.com/codex/tasks/task_e_68e7ff1c19dc832ebf3cba40616a3b6c