### PR TITLE
Handle VCF inputs without conversion

### DIFF
--- a/benches/path_benchmark.rs
+++ b/benches/path_benchmark.rs
@@ -22,11 +22,7 @@ use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, 
 use gnomon::batch;
 use gnomon::kernel;
 use gnomon::types::{
-    PersonSubset,
-    PipelineKind,
-    PreparationResult,
-    ReconciledVariantIndex,
-    ScoreColumnIndex,
+    PersonSubset, PipelineKind, PreparationResult, ReconciledVariantIndex, ScoreColumnIndex,
 };
 
 use crossbeam_queue::ArrayQueue;

--- a/map/main.rs
+++ b/map/main.rs
@@ -406,7 +406,7 @@ mod tests {
         save_projection_results,
     };
     use crate::map::project::ProjectionOptions;
-    use crate::shared::files::open_bcf_source;
+    use crate::shared::files::open_variant_source;
     use noodles_bcf::io::Reader as BcfReader;
     use noodles_bgzf::io::Reader as BgzfReader;
     use noodles_vcf::variant::RecordBuf;
@@ -697,7 +697,7 @@ mod tests {
 
     fn detect_compression(path: &Path) -> Result<(BcfCompression, Vec<u8>), Box<dyn Error>> {
         let mut source =
-            open_bcf_source(path).map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
+            open_variant_source(path).map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
         let mut prefix = vec![0u8; 4096];
         let mut total = 0usize;
         while total < prefix.len() {
@@ -991,7 +991,7 @@ mod tests {
         match compression {
             BcfCompression::Bgzf => {
                 eprintln!("[partial-test] compression detected: BGZF");
-                let source = open_bcf_source(path).map_err(|err| -> Box<dyn Error> {
+                let source = open_variant_source(path).map_err(|err| -> Box<dyn Error> {
                     eprintln!("[partial-test] failed to reopen remote BCF: {err}");
                     Box::new(err)
                 })?;
@@ -1034,7 +1034,7 @@ mod tests {
             }
             BcfCompression::Plain => {
                 eprintln!("[partial-test] compression detected: plain BCF");
-                let source = open_bcf_source(path).map_err(|err| -> Box<dyn Error> {
+                let source = open_variant_source(path).map_err(|err| -> Box<dyn Error> {
                     eprintln!("[partial-test] failed to reopen remote BCF: {err}");
                     Box::new(err)
                 })?;

--- a/score/download.rs
+++ b/score/download.rs
@@ -74,8 +74,7 @@ impl Indicator for DownloadIndicatorTask {
                 self.bar.finish_with_message("Done!".to_string());
             }
             IndicateSignal::Start() => {
-                self.bar
-                    .set_draw_target(ProgressDrawTarget::stdout());
+                self.bar.set_draw_target(ProgressDrawTarget::stdout());
             }
         }
     }


### PR DESCRIPTION
## Summary
- generalize shared variant file source handling to support VCF, BCF, and PLINK without VCF-to-BCF conversion
- teach map dataset loading and block source logic to use the generalized variant reader abstraction
- update supporting utilities and formatting to align with the new variant handling

## Testing
- cargo test fit_hwe_pca_from_http_vcf_stream -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68e8148e9c7c832e811ec7a69b44506e