### PR TITLE
Buffer BGZF-backed VCF readers and tidy diagnostics

### DIFF
--- a/map/io.rs
+++ b/map/io.rs
@@ -1503,7 +1503,7 @@ fn create_variant_reader_for_file(
         VariantFormat::Vcf => {
             let reader: Box<dyn BufRead + Send> = match compression {
                 VariantCompression::Plain => Box::new(BufReader::new(source)),
-                VariantCompression::Bgzf => Box::new(BgzfReader::new(source)),
+                VariantCompression::Bgzf => Box::new(BgzfReader::new(BufReader::new(source))),
             };
             VariantStreamReader::Vcf(VcfReader::new(reader))
         }
@@ -1520,7 +1520,7 @@ fn print_variant_diagnostics(
     err: &(dyn std::error::Error + '_),
 ) {
     let location = if is_remote_path(path) {
-        "remote (GCS)"
+        "remote (GCS/HTTP)"
     } else if path.is_dir() {
         "local directory"
     } else {
@@ -1818,7 +1818,7 @@ mod tests {
     }
 
     #[test]
-    fn bcf_source_reads_single_file_without_modification() {
+    fn variant_source_reads_single_file_without_modification() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("sample.bcf");
         let header = write_fake_bcf(&path, &[0x01, 0x02, 0x03]).unwrap();
@@ -1832,7 +1832,7 @@ mod tests {
     }
 
     #[test]
-    fn bcf_source_skips_headers_when_concatenating_directory() {
+    fn variant_source_skips_headers_when_concatenating_directory() {
         let dir = tempdir().unwrap();
         let files = [
             ("chr2.bcf", vec![0x20]),

--- a/shared/files.rs
+++ b/shared/files.rs
@@ -425,11 +425,13 @@ fn skip_vcf_header(reader: &mut dyn Read, compression: VariantCompression) -> io
             consumed
         }
         VariantCompression::Bgzf => {
-            let bgzf_reader = BgzfReader::new(counting_reader);
+            let buf_reader = BufReader::new(counting_reader);
+            let bgzf_reader = BgzfReader::new(buf_reader);
             let mut vcf_reader = VcfReader::new(bgzf_reader);
             vcf_reader.read_header()?;
             let bgzf_reader = vcf_reader.into_inner();
-            let counting_reader = bgzf_reader.into_inner();
+            let buf_reader = bgzf_reader.into_inner();
+            let counting_reader = buf_reader.into_inner();
             let (_, consumed) = counting_reader.into_inner();
             consumed
         }


### PR DESCRIPTION
## Summary
- wrap BGZF-backed VCF readers with an extra buffer so the reader type always implements `BufRead`
- update the diagnostics text to mention remote HTTP sources
- rename the variant source tests for clarity

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e8278f9950832e9b3cafc5d36ae70e