### PR TITLE
Add manual profiling workflow for gnomon fit

### DIFF
--- a/.github/workflows/profile-fit.yml
+++ b/.github/workflows/profile-fit.yml
@@ -1,0 +1,65 @@
+name: Profiling Fit Run
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+jobs:
+  profiling-fit:
+    name: Build, Profile & Report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Ensure perf tooling is available
+        run: |
+          if ! command -v perf >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y linux-tools-common linux-tools-generic || true
+            if ! command -v perf >/dev/null 2>&1; then
+              KERNEL="$(uname -r)"
+              sudo apt-get install -y "linux-tools-$KERNEL" || true
+            fi
+          fi
+          perf --version
+
+      - name: Build release and profiling binaries
+        run: |
+          cargo +nightly build --release
+          cargo +nightly build --profile profiling --features no-inline-profiling
+
+      - name: Profile gnomon fit workload
+        env:
+          PERF_DATA: perf.data
+        run: |
+          set -euxo pipefail
+          perf record -g -o "$PERF_DATA" -- \
+            target/profiling/gnomon \
+            --fit "gs://gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chr20.filtered.SNV_INDEL.phased.shapeit5.bcf" \
+            --list "https://github.com/SauersML/genomic_pca/raw/refs/heads/main/data/GSAv2_hg38.tsv"
+
+      - name: Render perf reports
+        env:
+          PERF_DATA: perf.data
+        run: |
+          set -euo pipefail
+          if [ ! -f "$PERF_DATA" ]; then
+            echo "::error::perf.data not found"
+            exit 1
+          fi
+
+          echo "==================== PERF REPORT (flat) ===================="
+          perf report --stdio --no-children --sort=symbol --percent-limit=0.5 -i "$PERF_DATA"
+          echo "===========================================================\n"
+
+          echo "==================== PERF REPORT (call graph) =============="
+          perf report --stdio --call-graph=graph --percent-limit=2 -i "$PERF_DATA"
+          echo "==========================================================="


### PR DESCRIPTION
## Summary
- add a workflow_dispatch GitHub Actions workflow to build release and profiling binaries
- profile the gnomon fit command on the provided dataset under perf and capture perf.data
- emit flat and call-graph perf reports directly in the workflow logs for easier inspection

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68e82f02624c832e86df0b8273ede992