### PR TITLE
Add HGDP chr20 variant list regression tests

### DIFF
--- a/map/main.rs
+++ b/map/main.rs
@@ -406,7 +406,8 @@ mod tests {
         save_projection_results,
     };
     use crate::map::project::ProjectionOptions;
-    use crate::shared::files::open_variant_source;
+    use crate::map::variant_filter::{VariantFilter, VariantKey, VariantSelection};
+    use crate::shared::files::{VariantCompression, VariantFormat, open_variant_source};
     use noodles_bcf::io::Reader as BcfReader;
     use noodles_bgzf::io::Reader as BgzfReader;
     use noodles_vcf::variant::RecordBuf;
@@ -420,12 +421,12 @@ mod tests {
     use std::error::Error;
     use std::fmt::Write as _;
     use std::fs::{self, File};
-    use std::io::Read;
+    use std::io::{Read, Write};
     use std::path::{Path, PathBuf};
     use std::process::Command;
     use std::str::FromStr;
     use std::time::Duration;
-    use tempfile::tempdir;
+    use tempfile::{NamedTempFile, tempdir};
     use zip::read::ZipArchive;
 
     use reqwest::blocking::Client;
@@ -1077,24 +1078,56 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn fit_and_project_full_hgdp_chr20() -> Result<(), Box<dyn Error>> {
+    fn run_fit_and_project_hgdp_chr20(variant_list: Option<&Path>) -> Result<(), Box<dyn Error>> {
         let dataset = GenotypeDataset::open(Path::new(HGDP_CHR20_BCF))
             .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
         let n_samples = dataset.n_samples();
-        let n_variants = dataset.n_variants();
         assert!(n_samples >= 3, "expected at least three samples for PCA");
-        assert!(n_variants > 0, "expected at least one variant in dataset");
         assert_eq!(dataset.samples().len(), n_samples);
 
+        let mut selection: Option<VariantSelection> = None;
+        let expected_variants = if let Some(list_path) = variant_list {
+            let filter = VariantFilter::from_file(list_path).map_err(|err| {
+                let message = format!(
+                    "failed to load variant list {}: {err:?}",
+                    list_path.display()
+                );
+                Box::<dyn Error>::from(message)
+            })?;
+            let chosen = dataset
+                .select_variants(&filter)
+                .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
+            assert!(
+                !chosen.indices.is_empty(),
+                "variant list {} did not match any variants in the dataset",
+                list_path.display()
+            );
+            selection = Some(chosen);
+            selection
+                .as_ref()
+                .map(|sel| sel.indices.len())
+                .expect("selection should be present")
+        } else {
+            dataset.n_variants()
+        };
+
+        assert!(
+            expected_variants > 0,
+            "expected at least one variant in dataset"
+        );
+
         let mut train_source = dataset
-            .block_source()
+            .block_source_with_selection(selection.as_ref().map(|sel| sel.indices.as_slice()))
             .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
-        let model = HwePcaModel::fit(&mut train_source)
+        let mut model = HwePcaModel::fit(&mut train_source)
             .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
 
+        if let Some(sel) = &selection {
+            model.set_variant_keys(Some(sel.keys.clone()));
+        }
+
         assert_eq!(model.n_samples(), n_samples);
-        assert_eq!(model.n_variants(), n_variants);
+        assert_eq!(model.n_variants(), expected_variants);
         assert!(model.components() > 0);
         assert_eq!(model.explained_variance().len(), model.components());
         assert!(
@@ -1121,7 +1154,7 @@ mod tests {
         drop(train_source);
 
         let mut inference_source = dataset
-            .block_source()
+            .block_source_with_selection(selection.as_ref().map(|sel| sel.indices.as_slice()))
             .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
         let projection = model
             .projector()
@@ -1143,6 +1176,89 @@ mod tests {
             }
         }
 
+        if let Some(sel) = &selection {
+            if let Some(keys) = model.variant_keys() {
+                assert_eq!(keys.len(), sel.indices.len());
+            }
+        }
+
         Ok(())
+    }
+
+    fn first_variant_keys(path: &Path, limit: usize) -> Result<Vec<VariantKey>, Box<dyn Error>> {
+        let source =
+            open_variant_source(path).map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
+        match (source.format(), source.compression()) {
+            (VariantFormat::Bcf, VariantCompression::Plain) => {
+                collect_bcf_variant_keys(BcfReader::from(source), limit)
+            }
+            (VariantFormat::Bcf, VariantCompression::Bgzf) => {
+                collect_bcf_variant_keys(BcfReader::from(BgzfReader::new(source)), limit)
+            }
+            (other_format, other_compression) => Err(format!(
+                "unsupported variant source combination: format={other_format:?} compression={other_compression:?}"
+            )
+            .into()),
+        }
+    }
+
+    fn collect_bcf_variant_keys<R: Read>(
+        mut reader: BcfReader<R>,
+        limit: usize,
+    ) -> Result<Vec<VariantKey>, Box<dyn Error>> {
+        let header = reader
+            .read_header()
+            .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
+        let mut record = RecordBuf::default();
+        let mut keys = Vec::new();
+
+        while keys.len() < limit {
+            let bytes = reader
+                .read_record_buf(&header, &mut record)
+                .map_err(|err| -> Box<dyn Error> { Box::new(err) })?;
+            if bytes == 0 {
+                break;
+            }
+
+            if let Some(position) = record.variant_start() {
+                let chrom = record.reference_sequence_name().to_string();
+                let key = VariantKey::new(&chrom, position.get() as u64);
+                keys.push(key);
+            }
+        }
+
+        Ok(keys)
+    }
+
+    #[test]
+    fn fit_and_project_full_hgdp_chr20() -> Result<(), Box<dyn Error>> {
+        run_fit_and_project_hgdp_chr20(None)
+    }
+
+    #[test]
+    fn fit_and_project_full_hgdp_chr20_with_remote_variant_list() -> Result<(), Box<dyn Error>> {
+        let list_url = Path::new(
+            "https://github.com/SauersML/genomic_pca/raw/refs/heads/main/data/GSAv2_hg38.tsv",
+        );
+        run_fit_and_project_hgdp_chr20(Some(list_url))
+    }
+
+    #[test]
+    fn fit_and_project_full_hgdp_chr20_with_manual_variant_list() -> Result<(), Box<dyn Error>> {
+        let keys = first_variant_keys(Path::new(HGDP_CHR20_BCF), 4_000)?;
+        assert_eq!(
+            keys.len(),
+            4_000,
+            "expected to collect exactly 4,000 variants from HGDP chr20 dataset"
+        );
+
+        let mut temp_file = NamedTempFile::new()?;
+        writeln!(temp_file, "chrom\tpos")?;
+        for key in keys.into_iter().take(4_000) {
+            writeln!(temp_file, "{}\t{}", key.chromosome, key.position)?;
+        }
+        temp_file.flush()?;
+
+        run_fit_and_project_hgdp_chr20(Some(temp_file.path()))
     }
 }


### PR DESCRIPTION
## Summary
- factor reusable helper for fitting and projecting the HGDP chr20 dataset with optional variant selections
- add regression tests for using a remote variant list URL and a generated subset of 4,000 variants
- include utilities to harvest variant keys from the chr20 BCF for constructing the manual list

## Testing
- cargo test --no-run

------
https://chatgpt.com/codex/tasks/task_e_68e82e0a7174832ea9fa023fd9d83b06