### PR TITLE
Relax perf permissions in profiling workflow

### DIFF
--- a/.github/workflows/profile-fit.yml
+++ b/.github/workflows/profile-fit.yml
@@ -31,6 +31,10 @@ jobs:
           fi
           perf --version
 
+      - name: Allow perf events recording
+        run: |
+          sudo sysctl -w kernel.perf_event_paranoid=0
+
       - name: Build release and profiling binaries
         run: |
           cargo +nightly build --release


### PR DESCRIPTION
## Summary
- lower the kernel.perf_event_paranoid value before running perf during the fit profiling workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8391585e4832ea6de18bd10072b1e