### PR TITLE
Fix partial eigensolver scratch sizing

### DIFF
--- a/map/fit.rs
+++ b/map/fit.rs
@@ -1244,7 +1244,11 @@ where
     let mut eigvecs = Mat::zeros(n, target);
     let mut eigvals = vec![0.0f64; target];
 
-    let scratch = partial_eigen_scratch(operator, target, par, params);
+    // The partial eigensolver can increase its working subspace dimension up to
+    // `params.max_dim` during restarts. The scratch allocator must therefore be
+    // sized for the worst-case dimension rather than the requested target, or
+    // faer's internal workspace requests will overflow the provided buffer.
+    let scratch = partial_eigen_scratch(operator, params.max_dim, par, params);
     let mut mem = MemBuffer::new(scratch);
 
     let result = catch_unwind(AssertUnwindSafe(|| {


### PR DESCRIPTION
## Summary
- ensure the partial eigensolver scratch buffer is sized for the maximum working dimension
- document the reason for using the worst-case dimension when allocating scratch space

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e84d015444832eb9632f9905f75989