### PR TITLE
Fix variant block source trait implementation

### DIFF
--- a/map/fit.rs
+++ b/map/fit.rs
@@ -826,18 +826,6 @@ where
         unsafe { *self.observed_variants.get() }
     }
 
-    fn effective_n_variants(&self) -> usize {
-        self.observed_n_variants()
-            .or_else(|| {
-                if self.n_variants_hint > 0 {
-                    Some(self.n_variants_hint)
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(0)
-    }
-
     fn stats_computed(&self) -> bool {
         unsafe { (*self.stats.get()).is_finalized() }
     }

--- a/map/progress.rs
+++ b/map/progress.rs
@@ -1,5 +1,4 @@
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::io::IsTerminal;
@@ -207,10 +206,14 @@ impl ManagedStageBar {
     }
 
     fn set_estimate(&mut self, estimated_total: usize) {
-        if let StageBarMode::Spinner { approximate } = &mut self.mode {
-            *approximate = Some(estimated_total as u64);
-            self.refresh_spinner_message(*approximate);
-        }
+        let new_value = match &mut self.mode {
+            StageBarMode::Spinner { approximate } => {
+                *approximate = Some(estimated_total as u64);
+                *approximate
+            }
+            StageBarMode::Determinate { .. } => return,
+        };
+        self.refresh_spinner_message(new_value);
     }
 
     fn refresh_spinner_message(&self, approximate: Option<u64>) {


### PR DESCRIPTION
## Summary
- ensure `DatasetBlockSource` only forwards to backend implementations to fix trait visibility errors
- move selection bookkeeping onto `VcfLikeVariantBlockSource` with safe borrowing
- clean up unused helpers and ensure progress spinners update without borrow conflicts

## Testing
- not run (per request)
