### PR TITLE
Fix spool naming for remote variant downloads

### DIFF
--- a/map/io.rs
+++ b/map/io.rs
@@ -1295,7 +1295,9 @@ impl VcfLikeVariantBlockSource {
             .unwrap_or_default()
             .as_millis();
         let mut spool_path = root.join(format!("part{}_{}", idx, unique));
-        if let Some(ext) = path.extension() {
+        if let Some(file_name) = path.file_name().and_then(|name| name.to_str()) {
+            spool_path.set_file_name(format!("part{}_{}_{}", idx, unique, file_name));
+        } else if let Some(ext) = path.extension() {
             spool_path.set_extension(ext);
         }
 


### PR DESCRIPTION
## Summary
- preserve the original remote file name when spooling variant parts so the downloaded files retain their VCF/BCF extensions and can be reopened

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e892aa9a58832ea6534faf6a30c09b