### PR TITLE
Remove skip logic from map integration tests

### DIFF
--- a/map/main.rs
+++ b/map/main.rs
@@ -1186,40 +1186,9 @@ mod tests {
         Ok(keys)
     }
 
-    fn should_skip(err: &dyn Error) -> bool {
-        let mut current: Option<&dyn Error> = Some(err);
-        while let Some(e) = current {
-            let message = e.to_string().to_lowercase();
-            if message.contains("service is currently unavailable")
-                || message.contains("tcp connect error")
-                || message.contains("dns error")
-                || message.contains("timed out")
-                || message.contains("cannot create the authentication headers")
-            {
-                return true;
-            }
-            current = e.source();
-        }
-        false
-    }
-
-    fn run_or_skip(result: Result<(), Box<dyn Error>>, label: &str) -> Result<(), Box<dyn Error>> {
-        match result {
-            Ok(()) => Ok(()),
-            Err(err) => {
-                if should_skip(err.as_ref()) {
-                    eprintln!("skipping {label}: {err}");
-                    Ok(())
-                } else {
-                    Err(err)
-                }
-            }
-        }
-    }
-
     #[test]
     fn fit_and_project_full_hgdp_chr20() -> Result<(), Box<dyn Error>> {
-        run_or_skip(run_fit_and_project_hgdp_chr20(None), "HGDP chr20 PCA")
+        run_fit_and_project_hgdp_chr20(None)
     }
 
     #[test]
@@ -1227,24 +1196,12 @@ mod tests {
         let list_url = Path::new(
             "https://github.com/SauersML/genomic_pca/raw/refs/heads/main/data/GSAv2_hg38.tsv",
         );
-        run_or_skip(
-            run_fit_and_project_hgdp_chr20(Some(list_url)),
-            "HGDP chr20 PCA with remote variant list",
-        )
+        run_fit_and_project_hgdp_chr20(Some(list_url))
     }
 
     #[test]
     fn fit_and_project_full_hgdp_chr20_with_manual_variant_list() -> Result<(), Box<dyn Error>> {
-        let keys = match first_variant_keys(Path::new(HGDP_CHR20_BCF), 4_000) {
-            Ok(keys) => keys,
-            Err(err) => {
-                if should_skip(err.as_ref()) {
-                    eprintln!("skipping HGDP chr20 PCA with manual variant list: {err}");
-                    return Ok(());
-                }
-                return Err(err);
-            }
-        };
+        let keys = first_variant_keys(Path::new(HGDP_CHR20_BCF), 4_000)?;
         assert_eq!(
             keys.len(),
             4_000,
@@ -1258,9 +1215,6 @@ mod tests {
         }
         temp_file.flush()?;
 
-        run_or_skip(
-            run_fit_and_project_hgdp_chr20(Some(temp_file.path())),
-            "HGDP chr20 PCA with manual variant list",
-        )
+        run_fit_and_project_hgdp_chr20(Some(temp_file.path()))
     }
 }


### PR DESCRIPTION
## Summary
- remove conditional skip logic from HTTP PCA test
- ensure HGDP PCA integration tests always execute even on transient failures

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e9382f1580832ebb37297140a5340c