### PR TITLE
Remove HGDP fast test skip flag

### DIFF
--- a/map/main.rs
+++ b/map/main.rs
@@ -1216,10 +1216,6 @@ mod tests {
         }
         temp_file.flush()?;
 
-        if std::env::var("GNOMON_FAST_HGDP_TEST").unwrap_or_default() == "1" {
-            return Ok(());
-        }
-
         run_fit_and_project_hgdp_chr20(Some(temp_file.path()))
     }
 }


### PR DESCRIPTION
## Summary
- remove the GNOMON_FAST_HGDP_TEST guard so the HGDP projection test always runs

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e9a2acc074832e8a3b855e80650d37