### PR TITLE
Make adapt_plink2 available to shared consumers

### DIFF
--- a/shared/lib.rs
+++ b/shared/lib.rs
@@ -10,6 +10,8 @@ pub mod shared {
     pub use super::files;
 }
 
+pub mod adapt_plink2;
+
 #[path = "../score/mod.rs"]
 pub mod score;
 


### PR DESCRIPTION
## Summary
- expose the `adapt_plink2` module outside of tests so other shared code can import it directly
- import file helpers from `crate::files` within `adapt_plink2` instead of re-exporting them from `lib.rs`
- mark the test-only PLINK block unpacker with `#[cfg(test)]` to satisfy dead-code lints

## Testing
- cargo test adapt_plink2 -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68eab76f134c832e8bd1cf60c8ec51bf