### PR TITLE
Use remote variant list in full HGDP chr20 test

### DIFF
--- a/map/main.rs
+++ b/map/main.rs
@@ -1206,7 +1206,10 @@ mod tests {
 
     #[test]
     fn fit_and_project_full_hgdp_chr20() -> Result<(), Box<dyn Error>> {
-        run_fit_and_project_hgdp_chr20(None)
+        let list_url = Path::new(
+            "https://github.com/SauersML/genomic_pca/raw/refs/heads/main/data/GSAv2_hg38.tsv",
+        );
+        run_fit_and_project_hgdp_chr20(Some(list_url))
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- update the `fit_and_project_full_hgdp_chr20` map test to use the published remote variant filter list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eaf8183e9c832ea01c358170d624cd