### PR TITLE
Use mask popcount for SIMD finite count

### DIFF
--- a/map/fit.rs
+++ b/map/fit.rs
@@ -518,11 +518,7 @@ where
         let mask = lane.is_finite();
         let finite = mask.select(lane, zero);
         sum += finite.reduce_sum();
-        count += mask
-            .to_array()
-            .into_iter()
-            .map(|flag| flag as usize)
-            .sum::<usize>();
+        count += mask.to_bitmask().count_ones() as usize;
     }
 
     for &value in remainder {


### PR DESCRIPTION
## Summary
- replace the boolean-array based count with a bitmask popcount in `sum_and_count_finite_impl`
- keep scalar remainder handling untouched while relying on the more efficient SIMD path

## Testing
- not run (per instruction)


------
https://chatgpt.com/codex/tasks/task_e_68eafcad6b58832e829f24a0b381d0ed