### PR TITLE
Fix covariance mutability for dense eigenpairs

### DIFF
--- a/map/fit.rs
+++ b/map/fit.rs
@@ -1379,7 +1379,7 @@ where
     S::Error: Error + Send + Sync + 'static,
     P: FitProgressObserver + 'static,
 {
-    let covariance = accumulate_covariance_matrix(operator, par, progress)?;
+    let mut covariance = accumulate_covariance_matrix(operator, par, progress)?;
     let n = covariance.nrows();
 
     if n == 0 || top_k == 0 {


### PR DESCRIPTION
## Summary
- make the accumulated covariance matrix mutable so it can be mirrored to the upper triangle before eigen decomposition

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68eb1081a6d0832e96cf7355b98dc08a