### PR TITLE
Detect ill-conditioned identity models before REML

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -520,9 +520,9 @@ pub fn train_model(
         layout.total_coeffs, layout.num_penalties
     );
 
-    if matches!(config.link_function, LinkFunction::Identity) && layout.num_penalties == 0 {
-        let design_condition = calculate_condition_number(&x_matrix)
-            .map_err(EstimationError::EigendecompositionFailed)?;
+    let design_condition = calculate_condition_number(&x_matrix)
+        .map_err(EstimationError::EigendecompositionFailed)?;
+    if matches!(config.link_function, LinkFunction::Identity) {
         if !design_condition.is_finite() || design_condition > DESIGN_MATRIX_CONDITION_THRESHOLD {
             let reported_condition = if design_condition.is_finite() {
                 design_condition


### PR DESCRIPTION
## Summary
- compute the design matrix condition number for all models and short-circuit ill-conditioned identity-link fits before REML optimization

## Testing
- cargo test test_detects_singular_model_gracefully -- calibrate::estimate::tests::train_model::


------
https://chatgpt.com/codex/tasks/task_e_68eb51961af0832e9dae3d2457983eda