### PR TITLE
Remove unused VariantStatsCache helper

### DIFF
--- a/map/fit.rs
+++ b/map/fit.rs
@@ -369,11 +369,6 @@ impl VariantStatsCache {
         self.finalized_len.is_some()
     }
 
-    fn len(&self) -> usize {
-        self.finalized_len.unwrap_or(self.write_pos)
-    }
-
-
     fn ensure_statistics(&mut self, block: MatRef<'_, f64>, variant_range: Range<usize>, par: Par) {
         if self.is_finalized() {
             return;


### PR DESCRIPTION
## Summary
- remove the unused `VariantStatsCache::len` method to satisfy the dead code lint

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ec3db58de4832eb2c02ed4031bacac