### PR TITLE
Add len helper for VariantStatsCache tests

### DIFF
--- a/map/fit.rs
+++ b/map/fit.rs
@@ -454,7 +454,11 @@ impl VariantStatsCache {
         self.frequencies.truncate(self.write_pos);
         self.scales.truncate(self.write_pos);
         self.finalized_len = Some(self.write_pos);
+    }
 
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.finalized_len.unwrap_or(self.write_pos)
     }
 
     fn into_scaler(self) -> Option<HweScaler> {


### PR DESCRIPTION
## Summary
- add a test-only `len` helper on `VariantStatsCache` so the tests compile again

## Testing
- cargo test --no-run

------
https://chatgpt.com/codex/tasks/task_e_68ec416c4524832eb21bf82d2385eb5e