### PR TITLE
Expose batch process_tile for cargo asm

### DIFF
--- a/score/batch.rs
+++ b/score/batch.rs
@@ -421,7 +421,7 @@ fn process_block<'a>(
         prep_result,
     );
 
-    process_tile(
+    process_tile_impl(
         &tile,
         prep_result,
         weights,
@@ -475,7 +475,7 @@ fn accumulate_simd_lane(
 /// calculating a baseline score and pre-computing sparse indices.
 #[cfg_attr(not(feature = "no-inline-profiling"), inline)]
 #[cfg_attr(feature = "no-inline-profiling", inline(never))]
-fn process_tile<'a>(
+pub(crate) fn process_tile_impl<'a>(
     tile: &'a [EffectAlleleDosage],
     prep_result: &'a PreparationResult,
     weights_for_batch: &'a [f32],

--- a/shared/adapt_plink2.rs
+++ b/shared/adapt_plink2.rs
@@ -1044,7 +1044,7 @@ impl ByteRangeSource for VirtualBed {
         }
 
         // 2) Serve the body: contiguous blocks of size self.block_bytes per variant.
-        let mut body_off = offset - 3;
+        let body_off = offset - 3;
         let mut out_idx = (body_off / (self.block_bytes as u64)) as usize;
         let mut within_block = (body_off % (self.block_bytes as u64)) as usize;
 
@@ -1121,7 +1121,6 @@ impl ByteRangeSource for VirtualBed {
             }
 
             written += to_copy;
-            body_off += to_copy as u64;
             within_block = 0;
             out_idx += 1;
         }

--- a/shared/lib.rs
+++ b/shared/lib.rs
@@ -15,7 +15,34 @@ pub mod adapt_plink2;
 #[path = "../score/mod.rs"]
 pub mod score;
 
-pub use score::{batch, complex, decide, download, io, kernel, pipeline, prepare, reformat, types};
+pub mod batch {
+    pub use crate::score::batch::*;
+
+    #[cfg_attr(not(feature = "no-inline-profiling"), inline)]
+    #[cfg_attr(feature = "no-inline-profiling", inline(never))]
+    pub fn process_tile<'a>(
+        tile: &'a [crate::score::types::EffectAlleleDosage],
+        prep_result: &'a crate::score::types::PreparationResult,
+        weights_for_batch: &'a [f32],
+        flips_for_batch: &'a [u8],
+        reconciled_variant_indices_for_batch:
+            &'a [crate::score::types::ReconciledVariantIndex],
+        block_scores_out: &mut [f64],
+        block_missing_counts_out: &mut [u32],
+    ) {
+        crate::score::batch::process_tile_impl(
+            tile,
+            prep_result,
+            weights_for_batch,
+            flips_for_batch,
+            reconciled_variant_indices_for_batch,
+            block_scores_out,
+            block_missing_counts_out,
+        );
+    }
+}
+
+pub use score::{complex, decide, download, io, kernel, pipeline, prepare, reformat, types};
 
 #[path = "../map/mod.rs"]
 pub mod map;


### PR DESCRIPTION
## Summary
- expose a stable `gnomon::batch::process_tile` entry point that forwards to the existing scoring kernel so cargo-asm can find it
- rename the internal implementation to `process_tile_impl` and reuse it from the batching pipeline

## Testing
- cargo check
- cargo +nightly asm -C lto=off --profile profiling --features no-inline-profiling --lib --intel gnomon::batch::process_tile | head


------
https://chatgpt.com/codex/tasks/task_e_68ed62a2196c832eb3908b12a57578a9