### PR TITLE
Move process_tile into score batch module

### DIFF
--- a/score/batch.rs
+++ b/score/batch.rs
@@ -389,6 +389,32 @@ pub fn run_person_major_path(
 }
 
 // ========================================================================================
+//                            Public entry points
+// ========================================================================================
+
+#[cfg_attr(not(feature = "no-inline-profiling"), inline)]
+#[cfg_attr(feature = "no-inline-profiling", inline(never))]
+pub fn process_tile<'a>(
+    tile: &'a [EffectAlleleDosage],
+    prep_result: &'a PreparationResult,
+    weights_for_batch: &'a [f32],
+    flips_for_batch: &'a [u8],
+    reconciled_variant_indices_for_batch: &'a [ReconciledVariantIndex],
+    block_scores_out: &mut [f64],
+    block_missing_counts_out: &mut [u32],
+) {
+    process_tile_impl(
+        tile,
+        prep_result,
+        weights_for_batch,
+        flips_for_batch,
+        reconciled_variant_indices_for_batch,
+        block_scores_out,
+        block_missing_counts_out,
+    );
+}
+
+// ========================================================================================
 //                            Private implementation
 // ========================================================================================
 

--- a/shared/lib.rs
+++ b/shared/lib.rs
@@ -17,28 +17,6 @@ pub mod score;
 
 pub mod batch {
     pub use crate::score::batch::*;
-
-    #[cfg_attr(not(feature = "no-inline-profiling"), inline)]
-    #[cfg_attr(feature = "no-inline-profiling", inline(never))]
-    pub fn process_tile<'a>(
-        tile: &'a [crate::score::types::EffectAlleleDosage],
-        prep_result: &'a crate::score::types::PreparationResult,
-        weights_for_batch: &'a [f32],
-        flips_for_batch: &'a [u8],
-        reconciled_variant_indices_for_batch: &'a [crate::score::types::ReconciledVariantIndex],
-        block_scores_out: &mut [f64],
-        block_missing_counts_out: &mut [u32],
-    ) {
-        crate::score::batch::process_tile_impl(
-            tile,
-            prep_result,
-            weights_for_batch,
-            flips_for_batch,
-            reconciled_variant_indices_for_batch,
-            block_scores_out,
-            block_missing_counts_out,
-        );
-    }
 }
 
 pub use score::{complex, decide, download, io, kernel, pipeline, prepare, reformat, types};


### PR DESCRIPTION
## Summary
- move the process_tile wrapper from shared/lib.rs into score/batch.rs
- expose the wrapper through the score batch module so shared::batch keeps the same re-exports

## Testing
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68ee943341e8832e99ef99459ea1e357