### PR TITLE
Guard condition number computation for identity link

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -520,9 +520,9 @@ pub fn train_model(
         layout.total_coeffs, layout.num_penalties
     );
 
-    let design_condition =
-        calculate_condition_number(&x_matrix).map_err(EstimationError::EigendecompositionFailed)?;
     if matches!(config.link_function, LinkFunction::Identity) {
+        let design_condition =
+            calculate_condition_number(&x_matrix).map_err(EstimationError::EigendecompositionFailed)?;
         if !design_condition.is_finite() || design_condition > DESIGN_MATRIX_CONDITION_THRESHOLD {
             let reported_condition = if design_condition.is_finite() {
                 design_condition


### PR DESCRIPTION
## Summary
- compute the design matrix condition number only for identity link models so non-identity links skip the eigendecomposition

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68eeb64d15b4832eb82395a3b72c4086