### PR TITLE
Fix LD-weight handling during PCA projection

### DIFF
--- a/map/fit.rs
+++ b/map/fit.rs
@@ -415,7 +415,11 @@ fn standardize_block_impl(block: MatMut<'_, f64>, freqs: &[f64], scales: &[f64],
     }
 }
 
-fn apply_ld_weights(block: MatMut<'_, f64>, variant_range: Range<usize>, weights: &[f64]) {
+pub(crate) fn apply_ld_weights(
+    block: MatMut<'_, f64>,
+    variant_range: Range<usize>,
+    weights: &[f64],
+) {
     let start = variant_range.start.min(weights.len());
     let end = variant_range.end.min(weights.len());
     if end <= start {


### PR DESCRIPTION
## Summary
- expose the LD weighting helper for reuse outside of fitting
- apply LD weights to standardized projection blocks before multiplying by loadings
- incorporate squared LD weights when accumulating alignment mass during renormalization

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68eeb990a284832e87f14eb1eaadaaf0