### PR TITLE
Fix covariance guard naming

### DIFF
--- a/map/fit.rs
+++ b/map/fit.rs
@@ -1196,10 +1196,11 @@ where
         par: Par,
         stack: &mut MemStack,
     ) {
-        let _apply_guard = self
+        let apply_guard = self
             .apply_lock
             .lock()
             .expect("covariance apply lock poisoned");
+        let _ = &apply_guard;
 
         debug_assert_eq!(out.nrows(), self.n_samples);
         debug_assert_eq!(rhs.nrows(), self.n_samples);
@@ -1621,10 +1622,11 @@ where
     S::Error: Error + Send + Sync + 'static,
     P: FitProgressObserver + Send + Sync + 'static,
 {
-    let _apply_guard = operator
+    let apply_guard = operator
         .apply_lock
         .lock()
         .expect("covariance apply lock poisoned");
+    let _ = &apply_guard;
 
     let n_samples = operator.n_samples;
     let cross_products = Mat::zeros(n_samples, n_samples);


### PR DESCRIPTION
## Summary
- rename underscore-prefixed covariance lock guards in `map/fit.rs`
- retain the guards by assigning to local variables and referencing them to avoid warnings

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68eec9f97f0c832ebbe93cfe3e0c79b8