### PR TITLE
Use nightly toolchain for release fit workflow

### DIFF
--- a/.github/workflows/release-fit.yml
+++ b/.github/workflows/release-fit.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Cache cargo build artifacts
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary
- switch the release fit workflow to install the nightly Rust toolchain so portable SIMD builds succeed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0142ed13c832e98aa863726fde99c