### PR TITLE
Add GitHub workflow to benchmark release fit projection

### DIFF
--- a/.github/workflows/release-fit-projection.yml
+++ b/.github/workflows/release-fit-projection.yml
@@ -1,0 +1,97 @@
+name: Release Fit Projection Benchmark
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  benchmark:
+    name: Benchmark (${{ matrix.label }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - label: no-ld
+            runner: ubuntu-latest
+            ld: 'false'
+          - label: ld
+            runner: macos-latest
+            ld: 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build release binary
+        run: cargo build --release --bin gnomon
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install matplotlib requests
+
+      - name: Measure fit/project timing
+        env:
+          ENABLE_LD: ${{ matrix.ld }}
+        run: |
+          EXTRA_FLAG=""
+          if [ "$ENABLE_LD" = "true" ]; then
+            EXTRA_FLAG="--ld"
+          fi
+          python scripts/measure_fit_projection.py \
+            --binary target/release/gnomon \
+            --components 8 \
+            --output-dir run-artifacts/${{ matrix.label }} \
+            $EXTRA_FLAG
+        shell: bash
+
+      - name: Upload timing artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: timing-${{ matrix.label }}
+          path: run-artifacts/${{ matrix.label }}
+
+  aggregate:
+    name: Aggregate timings
+    runs-on: ubuntu-latest
+    needs: benchmark
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install matplotlib
+
+      - name: Download timing artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Combine timing results
+        run: |
+          python scripts/aggregate_timings.py \
+            artifacts/timing-no-ld/timing.json \
+            artifacts/timing-ld/timing.json \
+            --output-dir combined-results
+
+      - name: Upload combined artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: timing-combined
+          path: combined-results

--- a/scripts/aggregate_timings.py
+++ b/scripts/aggregate_timings.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Aggregate timing results from multiple benchmark runs."""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+
+
+def load_timings(paths: Iterable[pathlib.Path]) -> list[dict]:
+    results = []
+    for path in paths:
+        data = json.loads(path.read_text())
+        data["source"] = path.name
+        results.append(data)
+    if not results:
+        raise SystemExit("No timing files provided")
+    return results
+
+
+def write_combined_plot(results: list[dict], output_dir: pathlib.Path) -> pathlib.Path:
+    labels = []
+    fit = []
+    project = []
+
+    for entry in results:
+        label = "ld" if entry.get("ld_enabled") else "no-ld"
+        platform_label = entry.get("platform", "unknown")
+        labels.append(f"{label}\n{platform_label}")
+        fit.append(entry.get("fit_seconds", 0.0))
+        project.append(entry.get("project_seconds", 0.0))
+
+    x = range(len(labels))
+    width = 0.35
+
+    fig, ax = plt.subplots(figsize=(7, 4))
+    ax.bar([p - width / 2 for p in x], fit, width, label="fit", color="#1f77b4")
+    ax.bar([p + width / 2 for p in x], project, width, label="project", color="#ff7f0e")
+    ax.set_ylabel("seconds")
+    ax.set_xticks(list(x))
+    ax.set_xticklabels(labels)
+    ax.set_title("gnomon fit/project timings across runners")
+    ax.legend()
+
+    for idx, (xf, xp, fval, pval) in enumerate(zip(x, x, fit, project)):
+        ax.text(xf - width / 2, fval, f"{fval:.2f}", ha="center", va="bottom", fontsize=8)
+        ax.text(xp + width / 2, pval, f"{pval:.2f}", ha="center", va="bottom", fontsize=8)
+
+    fig.tight_layout()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    plot_path = output_dir / "timing-comparison.png"
+    fig.savefig(plot_path, dpi=200)
+    plt.close(fig)
+    return plot_path
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("timings", nargs="+", type=pathlib.Path, help="timing.json files to aggregate")
+    parser.add_argument(
+        "--output-dir",
+        default=pathlib.Path("combined-results"),
+        type=pathlib.Path,
+        help="Directory for aggregated artifacts",
+    )
+    args = parser.parse_args(argv)
+
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    results = load_timings(args.timings)
+    combined_path = output_dir / "combined.json"
+    combined_path.write_text(json.dumps(results, indent=2))
+
+    plot_path = write_combined_plot(results, output_dir)
+    print(json.dumps({"combined": str(combined_path), "plot": str(plot_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/measure_fit_projection.py
+++ b/scripts/measure_fit_projection.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Measure fit and projection timings for the gnomon CLI."""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import pathlib
+import platform
+import subprocess
+import sys
+import time
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+import requests
+import zipfile
+
+
+ARCHIVES = {
+    "chr22_subset50.fam": "https://github.com/SauersML/genomic_pca/raw/refs/heads/main/data/chr22_subset50.fam.zip",
+    "chr22_subset50.bim": "https://github.com/SauersML/genomic_pca/raw/refs/heads/main/data/chr22_subset50.bim.zip",
+    "chr22_subset50.bed": "https://github.com/SauersML/genomic_pca/raw/refs/heads/main/data/chr22_subset50.bed.zip",
+}
+
+
+class CommandError(RuntimeError):
+    """Raised when an external command fails."""
+
+
+def download_archive(url: str, expected: str, destination: pathlib.Path) -> pathlib.Path:
+    """Download a zip archive, extract the expected file, and return its path."""
+    response = requests.get(url, timeout=120)
+    response.raise_for_status()
+
+    archive = zipfile.ZipFile(io.BytesIO(response.content))
+    members = archive.namelist()
+    if expected not in members:
+        raise RuntimeError(
+            f"Archive {url} did not contain {expected!r}; found {members}"
+        )
+
+    archive.extract(expected, path=destination)
+    return destination / expected
+
+
+def download_dataset(output_dir: pathlib.Path) -> pathlib.Path:
+    """Download the PLINK dataset used for fit/project integration tests."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    bed_path: pathlib.Path | None = None
+
+    for expected, url in ARCHIVES.items():
+        extracted = download_archive(url, expected, output_dir)
+        if expected.endswith(".bed"):
+            bed_path = extracted
+
+    if bed_path is None:
+        raise RuntimeError("Failed to download PLINK dataset; .bed file missing")
+
+    return bed_path
+
+
+def run_command(cmd: Iterable[str], cwd: pathlib.Path) -> tuple[float, subprocess.CompletedProcess[str]]:
+    """Run a command, timing the elapsed wall time in seconds."""
+    start = time.perf_counter()
+    result = subprocess.run(
+        list(cmd),
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    elapsed = time.perf_counter() - start
+    if result.returncode != 0:
+        raise CommandError(
+            f"Command {' '.join(cmd)} failed with exit code {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    return elapsed, result
+
+
+def write_plot(output_dir: pathlib.Path, fit_seconds: float, project_seconds: float) -> pathlib.Path:
+    """Create a simple bar chart summarizing the timings."""
+    labels = ["fit", "project"]
+    durations = [fit_seconds, project_seconds]
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    bars = ax.bar(labels, durations, color=["#1f77b4", "#ff7f0e"])
+    ax.set_ylabel("seconds")
+    ax.set_title("gnomon fit/project timing")
+    ax.bar_label(bars, fmt="{:.2f}")
+    fig.tight_layout()
+
+    plot_path = output_dir / "timing.png"
+    fig.savefig(plot_path, dpi=200)
+    plt.close(fig)
+    return plot_path
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", required=True, type=pathlib.Path, help="Path to gnomon binary")
+    parser.add_argument(
+        "--components",
+        type=int,
+        default=8,
+        help="Number of principal components to fit",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=pathlib.Path,
+        default=pathlib.Path("timing-results"),
+        help="Directory where timing artifacts will be stored",
+    )
+    parser.add_argument(
+        "--working-dir",
+        type=pathlib.Path,
+        default=None,
+        help="Optional working directory for downloads and outputs",
+    )
+    parser.add_argument(
+        "--ld",
+        action="store_true",
+        help="Enable LD normalization during fitting",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    binary = args.binary.resolve()
+    if not binary.exists():
+        raise SystemExit(f"Binary not found at {binary}")
+
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    working_dir = args.working_dir.resolve() if args.working_dir else output_dir
+    working_dir.mkdir(parents=True, exist_ok=True)
+
+    dataset_dir = working_dir / "dataset"
+    bed_path = download_dataset(dataset_dir)
+
+    fit_cmd = [str(binary), "fit", str(bed_path), "--components", str(args.components)]
+    if args.ld:
+        fit_cmd.append("--ld")
+    fit_seconds, fit_result = run_command(fit_cmd, cwd=working_dir)
+
+    project_cmd = [str(binary), "project", str(bed_path)]
+    project_seconds, project_result = run_command(project_cmd, cwd=working_dir)
+
+    metadata = {
+        "ld_enabled": bool(args.ld),
+        "components": int(args.components),
+        "fit_seconds": fit_seconds,
+        "project_seconds": project_seconds,
+        "platform": platform.platform(),
+        "python_version": sys.version,
+        "runner_name": os.environ.get("RUNNER_NAME"),
+        "binary": str(binary),
+    }
+
+    (output_dir / "fit_stdout.txt").write_text(fit_result.stdout)
+    (output_dir / "fit_stderr.txt").write_text(fit_result.stderr)
+    (output_dir / "project_stdout.txt").write_text(project_result.stdout)
+    (output_dir / "project_stderr.txt").write_text(project_result.stderr)
+
+    timing_path = output_dir / "timing.json"
+    timing_path.write_text(json.dumps(metadata, indent=2))
+
+    plot_path = write_plot(output_dir, fit_seconds, project_seconds)
+
+    print(json.dumps({"timing": metadata, "plot": str(plot_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add a workflow that builds the release binary and runs fit/project benchmarks on separate runners with and without LD normalization
- add a measurement script that downloads the reference PLINK dataset, times the fit/project pipeline, and captures artifacts
- add an aggregation script that combines per-run timings into a comparison report and plot

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68f01d1b9968832eb48bc15e84106090