### PR TITLE
Adjust gram budget to use system memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ noodles-vcf = "0.81.0"
 noodles-bgzf = "0.43.0"
 reqwest = { version = "0.12.9", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
 serde_json = "1.0.145"
+sysinfo = "0.30.12"
 
 planus = "=1.1.1" # cf. https://github.com/pola-rs/polars/issues/24208
 


### PR DESCRIPTION
## Summary
- replace the hard-coded Gram matrix memory budget with a value derived from the host's RAM
- cache the computed budget while keeping existing environment variable overrides and fallbacks
- add the `sysinfo` crate dependency to detect total system memory

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68f06c6028d8832ead5231df4297322c