### PR TITLE
Fix release fit workflow artifact path

### DIFF
--- a/.github/workflows/release-fit.yml
+++ b/.github/workflows/release-fit.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gnomon-release-binary
-          path: .
+          path: target/release
 
       - name: Make gnomon executable
         run: chmod +x target/release/gnomon
@@ -120,7 +120,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gnomon-release-binary
-          path: .
+          path: target/release
 
       - name: Make gnomon executable
         run: chmod +x target/release/gnomon


### PR DESCRIPTION
## Summary
- update the release fit workflow to extract the release binary into target/release
- allow subsequent chmod and execution steps to find the binary correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f075bf582c832e99f1e8429bfa62a4