### PR TITLE
Add PCA projection TSV to release-fit artifacts

### DIFF
--- a/.github/workflows/release-fit.yml
+++ b/.github/workflows/release-fit.yml
@@ -85,6 +85,7 @@ jobs:
           set -euo pipefail
           mv artifacts/pc1_pc2.png artifacts/pc1_pc2_no_ld.png
           mv artifacts/pc3_pc4.png artifacts/pc3_pc4_no_ld.png
+          mv artifacts/pca_projection_scores.tsv artifacts/pca_projection_scores_no_ld.tsv
 
       - name: Upload PCA plot artifacts (no --ld)
         uses: actions/upload-artifact@v4
@@ -93,6 +94,7 @@ jobs:
           path: |
             artifacts/pc1_pc2_no_ld.png
             artifacts/pc3_pc4_no_ld.png
+            artifacts/pca_projection_scores_no_ld.tsv
             gnomon-fit-no-ld.log
 
   release-fit-ld:
@@ -144,6 +146,7 @@ jobs:
           set -euo pipefail
           mv artifacts/pc1_pc2.png artifacts/pc1_pc2_ld.png
           mv artifacts/pc3_pc4.png artifacts/pc3_pc4_ld.png
+          mv artifacts/pca_projection_scores.tsv artifacts/pca_projection_scores_ld.tsv
 
       - name: Upload PCA plot artifacts (--ld)
         uses: actions/upload-artifact@v4
@@ -152,4 +155,5 @@ jobs:
           path: |
             artifacts/pc1_pc2_ld.png
             artifacts/pc3_pc4_ld.png
+            artifacts/pca_projection_scores_ld.tsv
             gnomon-fit-ld.log

--- a/scripts/generate_release_fit_plots.py
+++ b/scripts/generate_release_fit_plots.py
@@ -227,6 +227,23 @@ def main() -> None:
 
     color_map = _build_color_map(ann_pca)
 
+    score_columns = [column for column in pcs_df.columns if column.startswith("PC")]
+    export_columns = [
+        "SampleID",
+        "Population",
+        "Superpopulation",
+        *score_columns,
+    ]
+
+    available_columns = [
+        column for column in export_columns if column in ann_pca.columns
+    ]
+
+    projection_path = OUTPUT_DIR / "pca_projection_scores.tsv"
+    ann_pca.loc[:, available_columns].rename(
+        columns={"SampleID": "SampleName", "Population": "Subpopulation"}
+    ).to_csv(projection_path, sep="\t", index=False)
+
     _plot_projection(ann_pca, color_map, "PC1", "PC2", OUTPUT_DIR / "pc1_pc2.png")
     _plot_projection(ann_pca, color_map, "PC3", "PC4", OUTPUT_DIR / "pc3_pc4.png")
 


### PR DESCRIPTION
## Summary
- export annotated PCA projection scores to a TSV during release-fit plotting
- publish the TSV alongside the existing plots for both the LD and no-LD workflows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f12acd9398832eb531b2d739b5c002