### PR TITLE
Fix CI assembly inspection path for batch module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,9 @@ jobs:
           echo "---"
           echo "--- ASSEMBLY FOR SIMD VERSION (from library) ---"
           echo "---"
-          cargo +nightly asm -C lto=off --profile profiling --features no-inline-profiling --lib --intel gnomon::batch::process_tile
+          # `score::batch` now lives under the `score` module, so keep the inspected symbol
+          # aligned with the library's public path to avoid false CI failures.
+          cargo +nightly asm -C lto=off --profile profiling --features no-inline-profiling --lib --intel gnomon::score::batch::process_tile
 
       - name: Cache getdoc binary
         id: getdoc_cache


### PR DESCRIPTION
## Summary
- update the Rust Test CI workflow to inspect `gnomon::score::batch::process_tile` with `cargo asm`
- explain the new module path so CI keeps working when only non-Rust files change

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f15bc0d1cc832eb028ce7fb6f0eec1