### PR TITLE
Fix artifact extraction path for release fit jobs

### DIFF
--- a/.github/workflows/release-fit.yml
+++ b/.github/workflows/release-fit.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gnomon-release-binary
-          path: target/release
+          path: .
 
       - name: Make gnomon executable
         run: chmod +x target/release/gnomon
@@ -122,7 +122,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gnomon-release-binary
-          path: target/release
+          path: .
 
       - name: Make gnomon executable
         run: chmod +x target/release/gnomon


### PR DESCRIPTION
## Summary
- adjust the artifact download location so the gnomon binary is placed in the expected target/release directory for downstream jobs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f16295ca58832ea48668c9f2c7a17f