### PR TITLE
Set release workflow CPU target flag

### DIFF
--- a/.github/workflows/release-fit.yml
+++ b/.github/workflows/release-fit.yml
@@ -10,6 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  RUSTFLAGS: "-C target-cpu=x86-64-v3"
 
 jobs:
   build-release:


### PR DESCRIPTION
## Summary
- restore the workspace cargo config to its prior native-target settings
- configure the release-fit workflow to build the release binary with `-C target-cpu=x86-64-v3`

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f1601b5508832e92240856f2e24d3a