### PR TITLE
Improve release-fit annotations and workflow downsampling control

### DIFF
--- a/.github/workflows/release-fit.yml
+++ b/.github/workflows/release-fit.yml
@@ -2,6 +2,11 @@ name: Release Fit Projection
 
 on:
   workflow_dispatch:
+    inputs:
+      downsample_factor:
+        description: 'Downsampling factor applied during PCA plot generation (>=1)'
+        required: false
+        default: '1'
   push:
     paths:
       - 'map/**/*.rs'
@@ -10,6 +15,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  RELEASE_FIT_DOWNSAMPLE: ${{ github.event.inputs.downsample_factor || '1' }}
 
 jobs:
   build-release:
@@ -78,7 +84,7 @@ jobs:
             2>&1 | tee gnomon-fit-no-ld.log
 
       - name: Generate PCA plots from projection output
-        run: python scripts/generate_release_fit_plots.py
+        run: python scripts/generate_release_fit_plots.py --downsample-factor "${{ env.RELEASE_FIT_DOWNSAMPLE }}"
 
       - name: Prepare artifacts (no --ld)
         run: |
@@ -139,7 +145,7 @@ jobs:
             2>&1 | tee gnomon-fit-ld.log
 
       - name: Generate PCA plots from projection output
-        run: python scripts/generate_release_fit_plots.py
+        run: python scripts/generate_release_fit_plots.py --downsample-factor "${{ env.RELEASE_FIT_DOWNSAMPLE }}"
 
       - name: Prepare artifacts (--ld)
         run: |


### PR DESCRIPTION
## Summary
- resolve conflicting IGSR subpopulation/superpopulation metadata before merging with fit outputs
- add a deterministic per-population downsampling option to the release-fit plotting script
- expose the downsampling factor as a workflow_dispatch input and pass it through the release-fit GitHub Actions jobs

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68f543674514832eac1fc82bdfd96fd6