### PR TITLE
Add configurable LD windows to map fit

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -21,7 +21,7 @@ Optional arguments:
 ### `fit`
 Fit an HWE PCA model from genotype data.
 
-Usage: `gnomon fit <GENOTYPE_PATH> --components <N> [--list <PATH>] [--ld]`
+Usage: `gnomon fit <GENOTYPE_PATH> --components <N> [--list <PATH>] [--ld [--sites_window <SITES> | --bp_window <BP>]]`
 
 ### `project`
 Project samples into an existing HWE PCA space.

--- a/map/README.md
+++ b/map/README.md
@@ -44,8 +44,9 @@ Optional arguments:
   1-based position—with an optional header. Any variants that cannot be found
   are reported before the command exits.
 * `--ld` – Enable linkage disequilibrium flattening. When present, LD weights
-  are estimated with a default window of 51 variants, and the resulting weights
-  are stored inside `hwe.json` so projections
+  use a default window of 51 variants unless `--sites_window <SITES>` (odd
+  number of variants) or `--bp_window <BP>` (genomic span in base pairs) is
+  supplied. The resulting weights are stored inside `hwe.json` so projections
   can apply the same normalization.
 
 ### `gnomon project`
@@ -63,9 +64,11 @@ library API when finer-grained monitoring is needed.
 2. A dense covariance build is attempted when the implied Gram matrix fits in
    memory; otherwise the partial self-adjoint eigensolver incrementally updates
    covariance from streamed blocks.
-3. `--ld` enables LD weighting with the default window of 51 variants,
-   truncated near dataset edges and validated before use.  The
-   resulting per-variant weights are saved inside the serialized model.
+3. `--ld` enables LD weighting with either the default 51-variant window, a
+   user-provided odd-sized site window, or a base-pair span that adapts to
+   variant density. Windows are truncated near dataset edges and validated
+   before use. The resulting per-variant weights are saved inside the
+   serialized model.
 4. Requested components beyond the intrinsic rank are clamped, and the driver
    reports the retained dimensionality.
 

--- a/map/mod.rs
+++ b/map/mod.rs
@@ -5,7 +5,7 @@ pub mod progress;
 pub mod project;
 pub mod variant_filter;
 pub use fit::{
-    DEFAULT_BLOCK_WIDTH, DenseBlockSource, FitOptions, HwePcaError, HwePcaModel, HweScaler,
-    LdConfig, LdWeights, VariantBlockSource,
+    DEFAULT_BLOCK_WIDTH, DEFAULT_LD_WINDOW, DenseBlockSource, FitOptions, HwePcaError, HwePcaModel,
+    HweScaler, LdConfig, LdWeights, LdWindow, VariantBlockSource,
 };
 pub use project::{HwePcaProjector, ProjectionOptions, ProjectionResult, ZeroAlignmentAction};

--- a/map/project.rs
+++ b/map/project.rs
@@ -508,7 +508,7 @@ mod tests {
     use std::convert::Infallible;
     use std::sync::Arc;
 
-    use super::super::fit::{FitOptions, LdConfig};
+    use super::super::fit::{FitOptions, LdConfig, LdWindow};
     use super::super::progress::NoopFitProgress;
 
     const N_SAMPLES: usize = 3;
@@ -536,8 +536,9 @@ mod tests {
         let mut source = DenseBlockSource::new(&data, N_SAMPLES, N_VARIANTS).expect("source");
         let options = FitOptions {
             ld: Some(LdConfig {
-                window: Some(3),
+                window: Some(LdWindow::Sites(3)),
                 ridge: Some(1.0e-3),
+                variant_keys: None,
             }),
         };
         let progress = Arc::new(NoopFitProgress::default());


### PR DESCRIPTION
## Summary
- add CLI flags `--sites_window` and `--bp_window` to configure the map fit LD window and validate user input
- extend LD weighting to support both site- and base-pair-based windows, including serialization metadata and variant key handling
- expose dataset helpers to retrieve variant keys for base-pair windows and refresh related documentation

## Testing
- cargo test map::project::tests:: -- --nocapture
- cargo test map::fit::tests:: -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68f541acb3b8832e8a9a318c0638a8de