### PR TITLE
Fix logistic regression penalty parameter

### DIFF
--- a/scripts/compare_release_fit_projections.py
+++ b/scripts/compare_release_fit_projections.py
@@ -370,7 +370,7 @@ def _build_models() -> list[tuple[str, Callable[[], BaseEstimator]]]:
         (
             "LogisticRegression",
             lambda: LogisticRegression(
-                penalty="none",
+                penalty=None,
                 solver="lbfgs",
                 max_iter=1000,
                 multi_class="auto",


### PR DESCRIPTION
## Summary
- update the logistic regression model configuration to use a valid penalty value for recent scikit-learn versions

## Testing
- not run (requires projection comparison data not available in CI)


------
https://chatgpt.com/codex/tasks/task_e_68f69e2e131c832ea495732bac6d3aa3