### PR TITLE
Rebuild release fit jobs locally with native target

### DIFF
--- a/.github/workflows/release-fit.yml
+++ b/.github/workflows/release-fit.yml
@@ -18,10 +18,10 @@ env:
   RELEASE_FIT_DOWNSAMPLE: ${{ github.event.inputs.downsample_factor || '1' }}
 
 jobs:
-  build-release:
-    name: Build gnomon binary
+  release-fit-no-ld:
+    name: Timed fit and plots (no --ld)
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 360
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -29,28 +29,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Cache cargo build artifacts
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build gnomon (release)
+      - name: Rebuild gnomon (release, native cpu)
         run: |
           set -euxo pipefail
-          cargo build --release --bin gnomon
-
-      - name: Upload gnomon binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: gnomon-release-binary
-          path: target/release/gnomon
-
-  release-fit-no-ld:
-    name: Timed fit and plots (no --ld)
-    runs-on: ubuntu-22.04
-    needs: build-release
-    timeout-minutes: 360
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+          cargo clean
+          RUSTFLAGS="-C target-cpu=native" cargo build --release --bin gnomon
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -63,22 +46,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r scripts/requirements-release-fit.txt
-
-      - name: Download gnomon binary
-        uses: actions/download-artifact@v4
-        with:
-          name: gnomon-release-binary
-          path: gnomon-artifact
-
-      - name: Install gnomon binary
-        run: |
-          set -euo pipefail
-          binary_path="$(find gnomon-artifact -type f -name gnomon -print -quit)"
-          if [ -z "${binary_path}" ]; then
-            echo "Unable to locate downloaded gnomon binary" >&2
-            exit 1
-          fi
-          install -Dm755 "${binary_path}" target/release/gnomon
 
       - name: Timed gnomon fit run (no --ld)
         run: |
@@ -113,11 +80,19 @@ jobs:
   release-fit-ld:
     name: Timed fit and plots (--ld)
     runs-on: ubuntu-24.04
-    needs: build-release
     timeout-minutes: 360
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Rebuild gnomon (release, native cpu)
+        run: |
+          set -euxo pipefail
+          cargo clean
+          RUSTFLAGS="-C target-cpu=native" cargo build --release --bin gnomon
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -130,22 +105,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r scripts/requirements-release-fit.txt
-
-      - name: Download gnomon binary
-        uses: actions/download-artifact@v4
-        with:
-          name: gnomon-release-binary
-          path: gnomon-artifact
-
-      - name: Install gnomon binary
-        run: |
-          set -euo pipefail
-          binary_path="$(find gnomon-artifact -type f -name gnomon -print -quit)"
-          if [ -z "${binary_path}" ]; then
-            echo "Unable to locate downloaded gnomon binary" >&2
-            exit 1
-          fi
-          install -Dm755 "${binary_path}" target/release/gnomon
 
       - name: Timed gnomon fit run (--ld)
         run: |


### PR DESCRIPTION
## Summary
- drop the shared build job so each timed release-fit workflow compiles gnomon locally
- rebuild with `cargo clean` and `RUSTFLAGS="-C target-cpu=native"` to ensure a fresh native binary each run

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f6a823022c832eac955d52f2e621de