### PR TITLE
Expand sample identifier detection for release fit plots

### DIFF
--- a/scripts/generate_release_fit_plots.py
+++ b/scripts/generate_release_fit_plots.py
@@ -95,12 +95,18 @@ def _load_sample_population_mapping(path: Path) -> pd.DataFrame:
             "Sample population mapping is missing required columns 'meta_subpopulation' or 'meta_superpopulation'."
         )
 
+    def _is_sample_identifier_column(column: str) -> bool:
+        normalized = "".join(char for char in column.lower() if char.isalnum())
+        if not normalized:
+            return False
+        return "sampleid" in normalized or "samplename" in normalized
+
     sample_id_columns = [
-        column for column in mapping_df.columns if column.lower().startswith("sample_id")
+        column for column in mapping_df.columns if _is_sample_identifier_column(column)
     ]
     if not sample_id_columns:
         raise ValueError(
-            "Sample population mapping did not contain any columns beginning with 'sample_id'."
+            "Sample population mapping did not contain any columns with sample identifiers."
         )
 
     records: list[dict[str, str | None]] = []


### PR DESCRIPTION
## Summary
- broaden the heuristic that extracts sample identifiers from the population mapping file
- ensure the script recognises SGDP sample IDs such as LP6005441-DNA_F08 to avoid missing-population warnings

## Testing
- not run (data files not available in repository)


------
https://chatgpt.com/codex/tasks/task_e_68f6bdd2eca4832e9fd14801973cf43a