### PR TITLE
Add workflow to compare latest LD window release artifacts

### DIFF
--- a/.github/workflows/compare-ld-window.yml
+++ b/.github/workflows/compare-ld-window.yml
@@ -1,0 +1,122 @@
+name: Compare Using Latest Release Fit LD Window Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to source artifacts from (e.g., main)"
+        required: false
+        default: "main"
+      folds:
+        description: "Number of CV folds for comparison"
+        required: false
+        default: "50"
+      random_state:
+        description: "Random seed for CV shuffling"
+        required: false
+        default: "42"
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: compare-ld-window-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare-latest:
+    name: Python-only comparison using latest LD window artifacts
+    runs-on: ubuntu-22.04
+    env:
+      PY_REQ: scripts/requirements-release-fit.txt
+      WORKFLOW_NAME: Release Fit LD Window Sweep
+      ARTIFACT_PATTERN: gnomon-release-fit-*
+      DOWNLOAD_DIR: comparison
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: ${{ env.PY_REQ }}
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r "${PY_REQ}"
+
+      - name: Locate latest successful '${{ env.WORKFLOW_NAME }}' run
+        id: find
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="${{ github.event.inputs.branch || 'main' }}"
+          RUN_JSON=$(gh run list \
+            --workflow "${WORKFLOW_NAME}" \
+            --branch "${BRANCH}" \
+            --status success \
+            --limit 1 \
+            --json databaseId,headBranch,headSha,createdAt,url,displayTitle)
+          RUN_ID=$(echo "${RUN_JSON}" | jq -r '.[0].databaseId')
+          HEAD_BRANCH=$(echo "${RUN_JSON}" | jq -r '.[0].headBranch')
+          HEAD_SHA=$(echo "${RUN_JSON}" | jq -r '.[0].headSha')
+          CREATED_AT=$(echo "${RUN_JSON}" | jq -r '.[0].createdAt')
+          RUN_URL=$(echo "${RUN_JSON}" | jq -r '.[0].url')
+          TITLE=$(echo "${RUN_JSON}" | jq -r '.[0].displayTitle')
+
+          test -n "${RUN_ID}" && test "${RUN_ID}" != "null" || { echo "No successful runs for '${WORKFLOW_NAME}' on branch '${BRANCH}'." >&2; false; }
+
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Using artifacts from::${WORKFLOW_NAME} • ${TITLE} • run_id=${RUN_ID}"
+          echo "::notice title=Run metadata::branch=${HEAD_BRANCH} sha=${HEAD_SHA} created=${CREATED_AT} url=${RUN_URL}"
+
+      - name: Download artifacts from that run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p "${DOWNLOAD_DIR}"
+          gh run download "${{ steps.find.outputs.run_id }}" --pattern "${ARTIFACT_PATTERN}" -D "${DOWNLOAD_DIR}"
+          echo "Downloaded files:"
+          ls -R "${DOWNLOAD_DIR}" || true
+
+      - name: Sanity check projection TSVs exist
+        run: |
+          set -euo pipefail
+          mapfile -t tsvs < <(find "${DOWNLOAD_DIR}" -name 'pca_projection_scores_*.tsv' | sort)
+          if [ "${#tsvs[@]}" -lt 2 ]; then
+            echo "Expected at least two projection TSV files but found ${#tsvs[@]}."
+            ls -R "${DOWNLOAD_DIR}" || true
+            exit 1
+          fi
+          printf '%s\n' "${tsvs[@]}"
+
+      - name: Run comparison (Python only)
+        run: |
+          set -euo pipefail
+          FOLDS="${{ github.event.inputs.folds || '50' }}"
+          SEED="${{ github.event.inputs.random_state || '42' }}"
+          echo "::notice title=Compare settings::folds=${FOLDS} seed=${SEED}"
+          args=""
+          while IFS= read -r file; do
+            base=$(basename "$file")
+            label=${base#pca_projection_scores_}
+            label=${label%.tsv}
+            args="$args --projection ${label}=$file"
+          done < <(find "${DOWNLOAD_DIR}" -name 'pca_projection_scores_*.tsv' | sort)
+          python scripts/compare_release_fit_projections.py \
+            --folds "${FOLDS}" \
+            --random-state "${SEED}" \
+            ${args} \
+            2>&1 | tee compare-ld-window.log
+
+      - name: Upload comparison outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: compare-ld-window-results
+          path: |
+            compare-ld-window.log
+            artifacts/**


### PR DESCRIPTION
## Summary
- add a reusable workflow that locates the most recent successful "Release Fit LD Window Sweep" run
- download its LD window projection artifacts and run the cached comparison script across them
- publish the comparison log and derived artifacts for inspection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7af70f8ac832eb6a6a0c09d1719e6