### PR TITLE
Remove nonexistent artifacts upload from compare workflow

### DIFF
--- a/.github/workflows/compare-ld-window.yml
+++ b/.github/workflows/compare-ld-window.yml
@@ -119,4 +119,3 @@ jobs:
           name: compare-ld-window-results
           path: |
             compare-ld-window.log
-            artifacts/**


### PR DESCRIPTION
## Summary
- stop referencing the nonexistent artifacts/** glob in the compare workflow upload step so it only publishes the generated log

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f7bdebaa18832eb1a33980d19cc4e3