### PR TITLE
Default hail PCA output prefix

### DIFF
--- a/scripts/hail_pca.py
+++ b/scripts/hail_pca.py
@@ -17,6 +17,7 @@ DEFAULT_DATA_PATH = (
 )
 GCS_CONNECTOR_URL = "https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar"
 DEFAULT_NUM_PCS = 10
+DEFAULT_OUTPUT_PREFIX = "hail_pca"
 
 
 def _normalize_vcf_path(path: str) -> str:
@@ -142,8 +143,11 @@ def parse_args(args: List[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--output-prefix",
-        required=True,
-        help="Prefix used for the exported eigenvalues, scores, and loadings.",
+        default=DEFAULT_OUTPUT_PREFIX,
+        help=(
+            "Prefix used for the exported eigenvalues, scores, and loadings. "
+            f"Defaults to '{DEFAULT_OUTPUT_PREFIX}'."
+        ),
     )
     parser.add_argument(
         "--num-pcs",


### PR DESCRIPTION
## Summary
- provide a default output prefix for the hail PCA script so pipelines do not fail when omitted

## Testing
- python -m compileall scripts/hail_pca.py

------
https://chatgpt.com/codex/tasks/task_e_68f7cff1c48c832ea919b17d5996ec0e