### PR TITLE
Run hail PCA warmup in separate job

### DIFF
--- a/.github/workflows/release-fit.yml
+++ b/.github/workflows/release-fit.yml
@@ -38,13 +38,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r scripts/requirements-release-fit.txt
 
-      - name: Launch hail PCA warmup
-        run: |
-          set -euo pipefail
-          timeout 60 python scripts/hail_pca.py --loop-seconds 3600 > hail_pca_no_ld.log 2>&1 &
-          echo "HAIL_PCA_PID=$!" >> "$GITHUB_ENV"
-          echo "HAIL_PCA_LOG=hail_pca_no_ld.log" >> "$GITHUB_ENV"
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
@@ -73,19 +66,6 @@ jobs:
           mv artifacts/pc1_pc2.png artifacts/pc1_pc2_no_ld.png
           mv artifacts/pc3_pc4.png artifacts/pc3_pc4_no_ld.png
           mv artifacts/pca_projection_scores.tsv artifacts/pca_projection_scores_no_ld.tsv
-
-      - name: Wait for hail PCA warmup (no --ld)
-        if: env.HAIL_PCA_PID
-        run: |
-          set -euo pipefail
-          set +e
-          wait "$HAIL_PCA_PID"
-          status=$?
-          set -e
-          cat "$HAIL_PCA_LOG" || true
-          if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then
-            exit "$status"
-          fi
 
       - name: Upload PCA plot artifacts (no --ld)
         uses: actions/upload-artifact@v4
@@ -117,13 +97,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r scripts/requirements-release-fit.txt
 
-      - name: Launch hail PCA warmup
-        run: |
-          set -euo pipefail
-          timeout 60 python scripts/hail_pca.py --loop-seconds 3600 > hail_pca_ld.log 2>&1 &
-          echo "HAIL_PCA_PID=$!" >> "$GITHUB_ENV"
-          echo "HAIL_PCA_LOG=hail_pca_ld.log" >> "$GITHUB_ENV"
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
@@ -154,19 +127,6 @@ jobs:
           mv artifacts/pc3_pc4.png artifacts/pc3_pc4_ld.png
           mv artifacts/pca_projection_scores.tsv artifacts/pca_projection_scores_ld.tsv
 
-      - name: Wait for hail PCA warmup (--ld)
-        if: env.HAIL_PCA_PID
-        run: |
-          set -euo pipefail
-          set +e
-          wait "$HAIL_PCA_PID"
-          status=$?
-          set -e
-          cat "$HAIL_PCA_LOG" || true
-          if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then
-            exit "$status"
-          fi
-
       - name: Upload PCA plot artifacts (--ld)
         uses: actions/upload-artifact@v4
         with:
@@ -176,6 +136,37 @@ jobs:
             artifacts/pc3_pc4_ld.png
             artifacts/pca_projection_scores_ld.tsv
             gnomon-fit-ld.log
+
+  hail-pca-warmup:
+    name: Warm up hail PCA
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: scripts/requirements-release-fit.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/requirements-release-fit.txt
+
+      - name: Run hail PCA warmup
+        run: |
+          set -euo pipefail
+          python scripts/hail_pca.py --loop-seconds 3600 2>&1 | tee hail_pca.log
+
+      - name: Upload warmup log
+        uses: actions/upload-artifact@v4
+        with:
+          name: gnomon-release-fit-hail-pca
+          path: hail_pca.log
 
   compare-projections:
     name: Compare LD vs no-LD projection performance


### PR DESCRIPTION
## Summary
- remove the inline hail PCA warmup steps from the LD and no-LD jobs
- add a dedicated hail-pca-warmup workflow job that runs independently and publishes its log

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f7d6e99d9c832eb350ccab845eff95