### PR TITLE
Ensure LD workflows always publish artifacts

### DIFF
--- a/.github/workflows/compare-ld-window.yml
+++ b/.github/workflows/compare-ld-window.yml
@@ -114,8 +114,10 @@ jobs:
             2>&1 | tee compare-ld-window.log
 
       - name: Upload comparison outputs
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: compare-ld-window-results
           path: |
             compare-ld-window.log
+          if-no-files-found: warn

--- a/.github/workflows/release-fit-ld-window.yml
+++ b/.github/workflows/release-fit-ld-window.yml
@@ -138,15 +138,30 @@ jobs:
         run: python scripts/generate_release_fit_plots.py --downsample-factor "${{ env.RELEASE_FIT_DOWNSAMPLE }}"
 
       - name: Prepare artifacts (--ld ${{ matrix.window.description }})
+        if: ${{ always() }}
         env:
           LD_SUFFIX: ${{ matrix.window.artifact_suffix }}
         run: |
           set -euo pipefail
-          mv artifacts/pc1_pc2.png artifacts/pc1_pc2_${LD_SUFFIX}.png
-          mv artifacts/pc3_pc4.png artifacts/pc3_pc4_${LD_SUFFIX}.png
-          mv artifacts/pca_projection_scores.tsv artifacts/pca_projection_scores_${LD_SUFFIX}.tsv
+          mkdir -p artifacts
+          if [ -f artifacts/pc1_pc2.png ]; then
+            mv artifacts/pc1_pc2.png artifacts/pc1_pc2_${LD_SUFFIX}.png
+          else
+            echo "pc1_pc2 plot missing; skipping rename." >&2
+          fi
+          if [ -f artifacts/pc3_pc4.png ]; then
+            mv artifacts/pc3_pc4.png artifacts/pc3_pc4_${LD_SUFFIX}.png
+          else
+            echo "pc3_pc4 plot missing; skipping rename." >&2
+          fi
+          if [ -f artifacts/pca_projection_scores.tsv ]; then
+            mv artifacts/pca_projection_scores.tsv artifacts/pca_projection_scores_${LD_SUFFIX}.tsv
+          else
+            echo "Projection scores TSV missing; skipping rename." >&2
+          fi
 
       - name: Upload PCA plot artifacts (--ld ${{ matrix.window.description }})
+        if: ${{ always() }}
         env:
           LD_SUFFIX: ${{ matrix.window.artifact_suffix }}
         uses: actions/upload-artifact@v4
@@ -157,6 +172,7 @@ jobs:
             artifacts/pc3_pc4_${LD_SUFFIX}.png
             artifacts/pca_projection_scores_${LD_SUFFIX}.tsv
             gnomon-fit-${LD_SUFFIX}.log
+          if-no-files-found: warn
 
   compare-projections:
     name: Compare LD window projection performance


### PR DESCRIPTION
## Summary
- ensure the multi-LD comparison workflow uploads its log even when a prior step fails
- make the release fit LD window matrix tolerant of missing plot outputs and always attempt artifact upload

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7d937cb3c832ebf4d89872784cc3d