### PR TITLE
Remove loop-seconds argument from hail PCA warmup job

### DIFF
--- a/.github/workflows/release-fit.yml
+++ b/.github/workflows/release-fit.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Run hail PCA warmup
         run: |
           set -euo pipefail
-          python scripts/hail_pca.py --loop-seconds 3600 2>&1 | tee hail_pca.log
+          python scripts/hail_pca.py 2>&1 | tee hail_pca.log
 
       - name: Upload warmup log
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- remove the unsupported `--loop-seconds` argument from the hail PCA warmup workflow step so the script runs with its default behavior

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f7dc3eb9d4832ea1342b395641de45