### PR TITLE
Add xgboost dependency for release fit requirements

### DIFF
--- a/scripts/requirements-release-fit.txt
+++ b/scripts/requirements-release-fit.txt
@@ -4,4 +4,5 @@ tqdm
 numpy
 scikit-learn
 scipy
+xgboost
 hail


### PR DESCRIPTION
## Summary
- add xgboost to the release-fit script requirements so the new classifier import works

## Testing
- not run (dependency list update only)


------
https://chatgpt.com/codex/tasks/task_e_68f7eed0376c832e8e1d5c7794698e8b