### PR TITLE
Handle mislabelled VCF files in Hail PCA helper

### DIFF
--- a/.github/workflows/release-fit.yml
+++ b/.github/workflows/release-fit.yml
@@ -160,7 +160,9 @@ jobs:
       - name: Run hail PCA warmup
         run: |
           set -euo pipefail
-          python scripts/hail_pca.py 2>&1 | tee hail_pca.log
+          python scripts/hail_pca.py \
+            --data-path gs://gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2/*.bcf \
+            2>&1 | tee hail_pca.log
 
       - name: Upload warmup log
         uses: actions/upload-artifact@v4

--- a/scripts/hail_pca.py
+++ b/scripts/hail_pca.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import gzip
 import logging
 import shutil
 from pathlib import Path
@@ -13,32 +14,101 @@ from urllib.request import urlopen
 import hail as hl
 
 DEFAULT_DATA_PATH = (
-    "gs://gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2/"
+    "gs://gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2/*.bcf"
 )
 GCS_CONNECTOR_URL = "https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar"
 DEFAULT_NUM_PCS = 10
 DEFAULT_OUTPUT_PREFIX = "hail_pca"
 
 
-def _normalize_vcf_path(path: str) -> str:
-    """Return a glob that selects all VCFs under *path*.
+def _infer_variant_format(path: str) -> str | None:
+    """Return the obvious variant format for *path* if one is implied."""
 
-    Parameters
-    ----------
-    path
-        The user supplied path which might point to a directory or already
-        contain a glob pattern.
-    """
+    lowered = path.lower()
+    if lowered.endswith((".bcf", ".bcf.bgz", ".bcf.gz")):
+        return "bcf"
+    if lowered.endswith((".vcf", ".vcf.gz", ".vcf.bgz")):
+        return "vcf"
+    return None
+
+
+def _detect_variant_format_from_file(path: str) -> str | None:
+    """Return ``"bcf"`` or ``"vcf"`` if the file content makes it obvious."""
+
+    try:
+        with hl.hadoop_open(path, "rb") as raw:
+            prefix = raw.read(4)
+    except Exception as exc:  # pragma: no cover - filesystem errors
+        raise RuntimeError(f"Unable to inspect '{path}' to determine its format") from exc
+
+    if prefix.startswith(b"BCF"):
+        return "bcf"
+    if prefix.startswith(b"##"):
+        return "vcf"
+    if prefix[:2] != b"\x1f\x8b":
+        return None
+
+    try:
+        with hl.hadoop_open(path, "rb") as compressed, gzip.GzipFile(fileobj=compressed) as gz:
+            header = gz.read(4)
+    except Exception as exc:  # pragma: no cover - filesystem errors
+        raise RuntimeError(
+            f"Unable to inspect compressed file '{path}' to determine its format"
+        ) from exc
+
+    if header.startswith(b"BCF"):
+        return "bcf"
+    if header.startswith(b"##"):
+        return "vcf"
+    return None
+
+
+def _resolve_variant_path(path: str) -> tuple[str, str]:
+    """Return a glob that selects variants under *path* alongside the format."""
 
     trimmed = path.rstrip("/")
+    inferred = _infer_variant_format(trimmed)
+    if inferred is not None:
+        return trimmed, inferred
+
     if "*" in trimmed:
-        return trimmed
+        raise ValueError(
+            "Unable to infer variant format from glob pattern. "
+            "Please include a file extension in the --data-path value."
+        )
 
-    known_suffixes = (".vcf", ".vcf.gz", ".vcf.bgz")
-    if trimmed.endswith(known_suffixes):
-        return trimmed
+    listing_target = path if path.endswith("/") else f"{path}/"
+    try:
+        entries = hl.hadoop_ls(listing_target)
+    except Exception as exc:  # pragma: no cover - filesystem errors
+        raise FileNotFoundError(
+            f"Failed to list files under '{listing_target}'. Ensure the path exists."
+        ) from exc
 
-    return f"{trimmed}/*.vcf.bgz"
+    files = [entry["path"] for entry in entries if not entry.get("is_dir")]
+    if not files:
+        raise FileNotFoundError(f"No files were found under '{listing_target}'.")
+
+    for suffix, fmt in (
+        (".bcf", "bcf"),
+        (".bcf.bgz", "bcf"),
+        (".bcf.gz", "bcf"),
+        (".vcf.bgz", "vcf"),
+        (".vcf.gz", "vcf"),
+        (".vcf", "vcf"),
+    ):
+        matching = [name for name in files if name.lower().endswith(suffix)]
+        if not matching:
+            continue
+
+        detected = _detect_variant_format_from_file(matching[0]) or fmt
+        base = listing_target.rstrip("/")
+        return f"{base}/*{suffix}", detected
+
+    raise FileNotFoundError(
+        "Unable to determine whether the input files are VCF or BCF. "
+        "Please pass a path with an explicit extension."
+    )
 
 
 def _ensure_gcs_connector() -> str:
@@ -78,15 +148,20 @@ def _spark_conf_for_path(path: str) -> dict[str, str]:
 
 
 def _read_genotypes(path: str) -> hl.MatrixTable:
-    """Read genotype data from either a MatrixTable or VCF inputs."""
+    """Read genotype data from either a MatrixTable or variant inputs."""
 
     if path.endswith(".mt"):
         logging.info("Reading MatrixTable from %s", path)
         return hl.read_matrix_table(path)
 
-    vcf_path = _normalize_vcf_path(path)
-    logging.info("Importing VCFs from %s", vcf_path)
-    return hl.import_vcf(vcf_path, force_bgz=True, array_elements_required=False)
+    variant_path, variant_format = _resolve_variant_path(path)
+
+    if variant_format == "bcf":
+        logging.info("Importing BCFs from %s", variant_path)
+        return hl.import_bcf(variant_path)
+
+    logging.info("Importing VCFs from %s", variant_path)
+    return hl.import_vcf(variant_path, force_bgz=True, array_elements_required=False)
 
 
 def _export_scores(scores: hl.Table, output_prefix: str) -> None:
@@ -137,8 +212,8 @@ def parse_args(args: List[str] | None = None) -> argparse.Namespace:
         "--data-path",
         default=DEFAULT_DATA_PATH,
         help=(
-            "Path to a Hail MatrixTable (.mt) or directory/glob of VCFs. "
-            "Defaults to the public HGDP/1kG VCF directory."
+            "Path to a Hail MatrixTable (.mt) or directory/glob of VCF/BCF files. "
+            "Defaults to the public HGDP/1kG BCF directory."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- add file content inspection to differentiate between BCF and VCF inputs
- ensure mislabelled bgzipped VCFs are still imported via the VCF reader

## Testing
- python -m compileall scripts/hail_pca.py

------
https://chatgpt.com/codex/tasks/task_e_68f7ed4bce1c832ebfad1b6e8e1b9f76