### PR TITLE
Restrict release fit LD window workflow to manual runs

### DIFF
--- a/.github/workflows/release-fit-ld-window.yml
+++ b/.github/workflows/release-fit-ld-window.yml
@@ -7,9 +7,6 @@ on:
         description: 'Downsampling factor applied during PCA plot generation (>=1)'
         required: false
         default: '1'
-  push:
-    paths:
-      - 'map/**/*.rs'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- remove the push trigger from the Release Fit LD Window Sweep workflow so it can only run via manual dispatch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7f15eff54832e8ed75f8078ef0c97