### PR TITLE
Handle unknown variant counts during projection

### DIFF
--- a/map/project.rs
+++ b/map/project.rs
@@ -161,7 +161,13 @@ impl<'model> HwePcaProjector<'model> {
         P: ProjectionProgressObserver,
     {
         let n_samples = source.n_samples();
-        let n_variants = source.n_variants();
+        let variant_hint = source.n_variants();
+        let model_variants = self.model.n_variants();
+        let expected_variants = if variant_hint == 0 {
+            model_variants
+        } else {
+            variant_hint
+        };
         let components = self.model.components();
 
         if opts.return_alignment && !opts.missing_axis_renormalization {
@@ -175,7 +181,7 @@ impl<'model> HwePcaProjector<'model> {
                 "Projection requires at least one sample",
             ));
         }
-        if n_variants != self.model.n_variants() {
+        if variant_hint != 0 && variant_hint != model_variants {
             return Err(HwePcaError::InvalidInput(
                 "Projection variant dimension must match fitted model",
             ));
@@ -205,7 +211,7 @@ impl<'model> HwePcaProjector<'model> {
             .map_err(|e| HwePcaError::Source(Box::new(e)))?;
 
         let block_capacity =
-            projection_block_capacity(self.model.n_samples(), n_samples, n_variants);
+            projection_block_capacity(self.model.n_samples(), n_samples, expected_variants);
         let elements = n_samples
             .checked_mul(block_capacity)
             .ok_or_else(|| HwePcaError::InvalidInput("Projection workspace size overflow"))?;
@@ -236,7 +242,10 @@ impl<'model> HwePcaProjector<'model> {
             None
         };
 
-        progress.on_stage_start(ProjectionProgressStage::Projection, n_variants);
+        progress.on_stage_start(ProjectionProgressStage::Projection, variant_hint);
+        if variant_hint == 0 && expected_variants > 0 {
+            progress.on_stage_total(ProjectionProgressStage::Projection, expected_variants);
+        }
 
         loop {
             let filled = source
@@ -245,10 +254,12 @@ impl<'model> HwePcaProjector<'model> {
             if filled == 0 {
                 break;
             }
-            if processed + filled > n_variants {
-                return Err(HwePcaError::InvalidInput(
-                    "VariantBlockSource returned more variants than reported",
-                ));
+            if processed + filled > expected_variants {
+                if variant_hint != 0 || processed + filled > model_variants {
+                    return Err(HwePcaError::InvalidInput(
+                        "VariantBlockSource returned more variants than reported",
+                    ));
+                }
             }
 
             let mut block = MatMut::from_column_major_slice_mut(
@@ -354,10 +365,17 @@ impl<'model> HwePcaProjector<'model> {
             progress.on_stage_advance(ProjectionProgressStage::Projection, processed);
         }
 
-        if processed != n_variants {
-            return Err(HwePcaError::InvalidInput(
-                "VariantBlockSource terminated early during projection",
-            ));
+        if processed != expected_variants {
+            if variant_hint != 0 {
+                return Err(HwePcaError::InvalidInput(
+                    "VariantBlockSource terminated early during projection",
+                ));
+            }
+            if processed != model_variants {
+                return Err(HwePcaError::InvalidInput(
+                    "VariantBlockSource terminated early during projection",
+                ));
+            }
         }
 
         progress.on_stage_finish(ProjectionProgressStage::Projection);


### PR DESCRIPTION
## Summary
- derive an expected variant count from the source hint, falling back to the model when the loader does not report one
- relax projection validation to accept unknown hints while still enforcing the model dimensions and block sizing
- extend projection progress reporting with a total update hook so spinners can switch to determinate progress once the total is known

## Testing
- `cargo fmt`
- `cargo test` *(fails: calibrate::calibrator::tests::alo_error_is_driven_by_saturated_points, calibrate::calibrator::tests::calibrator_improves_more_for_large_miscalibration_binary, calibrate::calibrator::tests::external_opt_converges_deterministically; run interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68f7f8680e64832e81b4cbe137232875