### PR TITLE
Generate tabix indexes for converted BCF inputs

### DIFF
--- a/scripts/hail_pca.py
+++ b/scripts/hail_pca.py
@@ -202,6 +202,9 @@ def _convert_bcf_inputs_to_vcf(pattern: str) -> tuple[List[str], Path, Optional[
                 for record in reader:
                     writer.write(record)
 
+        logging.info("Indexing converted VCF %s", dest_path)
+        pysam.tabix_index(str(dest_path), preset="vcf", force=True)
+
         try:
             local_bcf.unlink()
         except FileNotFoundError:  # pragma: no cover - cleanup race


### PR DESCRIPTION
## Summary
- tabix index temporary VCFs generated from BCF inputs so Hail can import them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7feb7a614832eaeeca85996f77e94