### PR TITLE
Add pysam dependency for hail PCA workflow

### DIFF
--- a/scripts/requirements-release-fit.txt
+++ b/scripts/requirements-release-fit.txt
@@ -6,3 +6,4 @@ scikit-learn
 scipy
 xgboost
 hail
+pysam


### PR DESCRIPTION
## Summary
- add pysam to the release-fit script requirements so BCF conversion fallback works in CI

## Testing
- python -m pip install pysam

------
https://chatgpt.com/codex/tasks/task_e_68f80c4b6bec832e888513adabca8153