### PR TITLE
Fix realworld penalty test for new labels

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -3599,7 +3599,7 @@ pub mod internal {
 
             let mut pgs_pc1_stats = Vec::new();
             for (idx, label) in labels.iter().enumerate() {
-                if label == "f(PGS,PC1)[1]" || label == "f(PGS,PC1)[2]" {
+                if label == "f(PGS,PC1)[PGS]" || label == "f(PGS,PC1)[PC]" {
                     let near_pos_bound = rho_values[idx] >= RHO_BOUND - 1.0;
                     pgs_pc1_stats.push((label.clone(), near_pos_bound, rho_values[idx]));
                 }
@@ -3608,7 +3608,7 @@ pub mod internal {
             assert_eq!(
                 pgs_pc1_stats.len(),
                 2,
-                "Expected two f(PGS,PC1) penalty components, found {}",
+                "Expected two f(PGS,PC1) penalty components (PGS & PC), found {}",
                 pgs_pc1_stats.len()
             );
 


### PR DESCRIPTION
## Summary
- update the realworld PGS–PC1 penalty regression test to look for the descriptive `[PGS]` and `[PC]` labels introduced by anisotropic penalties

## Testing
- ⚠️ `cargo test test_realworld_pgs_pc1_penalties_not_both_hugging_positive_bound -- --nocapture` *(aborted after ~60s because the heavy optimization loop makes the test very slow in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f841074258832e977e169e2e8c30ba