### PR TITLE
Handle LD window workflow failures more gracefully

### DIFF
--- a/.github/workflows/compare-ld-window.yml
+++ b/.github/workflows/compare-ld-window.yml
@@ -64,16 +64,32 @@ jobs:
             --branch "${BRANCH}" \
             --status success \
             --limit 1 \
-            --json databaseId,headBranch,headSha,createdAt,url,displayTitle)
-          echo "Raw gh run list JSON: ${RUN_JSON}"
+            --json databaseId,headBranch,headSha,createdAt,url,displayTitle,conclusion)
+          echo "Raw gh run list JSON (successful runs): ${RUN_JSON}"
           RUN_ID=$(echo "${RUN_JSON}" | jq -r '.[0].databaseId')
+
+          if [ -z "${RUN_ID}" ] || [ "${RUN_ID}" = "null" ]; then
+            echo "No successful runs for '${WORKFLOW_NAME}' on branch '${BRANCH}'. Falling back to most recent run regardless of conclusion." >&2
+            RUN_JSON=$(gh run list \
+              --workflow "${WORKFLOW_NAME}" \
+              --branch "${BRANCH}" \
+              --limit 1 \
+              --json databaseId,headBranch,headSha,createdAt,url,displayTitle,conclusion,status)
+            echo "Raw gh run list JSON (any conclusion): ${RUN_JSON}"
+            RUN_ID=$(echo "${RUN_JSON}" | jq -r '.[0].databaseId')
+          else
+            echo "Found successful run; skipping fallback search."
+          fi
+
           HEAD_BRANCH=$(echo "${RUN_JSON}" | jq -r '.[0].headBranch')
           HEAD_SHA=$(echo "${RUN_JSON}" | jq -r '.[0].headSha')
           CREATED_AT=$(echo "${RUN_JSON}" | jq -r '.[0].createdAt')
           RUN_URL=$(echo "${RUN_JSON}" | jq -r '.[0].url')
           TITLE=$(echo "${RUN_JSON}" | jq -r '.[0].displayTitle')
+          CONCLUSION=$(echo "${RUN_JSON}" | jq -r '.[0].conclusion')
+          STATUS=$(echo "${RUN_JSON}" | jq -r '.[0].status // "unknown"')
 
-          test -n "${RUN_ID}" && test "${RUN_ID}" != "null" || { echo "No successful runs for '${WORKFLOW_NAME}' on branch '${BRANCH}'." >&2; false; }
+          test -n "${RUN_ID}" && test "${RUN_ID}" != "null" || { echo "No runs for '${WORKFLOW_NAME}' on branch '${BRANCH}'." >&2; false; }
 
           echo "Selected run metadata:"
           echo "  run_id=${RUN_ID}"
@@ -82,10 +98,12 @@ jobs:
           echo "  head_sha=${HEAD_SHA}"
           echo "  created_at=${CREATED_AT}"
           echo "  run_url=${RUN_URL}"
+          echo "  conclusion=${CONCLUSION}"
+          echo "  status=${STATUS}"
 
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
           echo "::notice title=Using artifacts from::${WORKFLOW_NAME} • ${TITLE} • run_id=${RUN_ID}"
-          echo "::notice title=Run metadata::branch=${HEAD_BRANCH} sha=${HEAD_SHA} created=${CREATED_AT} url=${RUN_URL}"
+          echo "::notice title=Run metadata::branch=${HEAD_BRANCH} sha=${HEAD_SHA} created=${CREATED_AT} url=${RUN_URL} conclusion=${CONCLUSION} status=${STATUS}"
 
       - name: Download artifacts from that run
         env:

--- a/.github/workflows/release-fit-ld-window.yml
+++ b/.github/workflows/release-fit-ld-window.yml
@@ -141,6 +141,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts
+          if [ -f gnomon-fit-${LD_SUFFIX}.log ]; then
+            mv gnomon-fit-${LD_SUFFIX}.log artifacts/gnomon-fit-${LD_SUFFIX}.log
+          else
+            echo "Timed fit log missing; skipping move." >&2
+          fi
           if [ -f artifacts/pc1_pc2.png ]; then
             mv artifacts/pc1_pc2.png artifacts/pc1_pc2_${LD_SUFFIX}.png
           else
@@ -168,7 +173,7 @@ jobs:
             artifacts/pc1_pc2_${LD_SUFFIX}.png
             artifacts/pc3_pc4_${LD_SUFFIX}.png
             artifacts/pca_projection_scores_${LD_SUFFIX}.tsv
-            gnomon-fit-${LD_SUFFIX}.log
+            artifacts/gnomon-fit-${LD_SUFFIX}.log
           if-no-files-found: warn
 
   compare-projections:


### PR DESCRIPTION
## Summary
- ensure the release LD window sweep workflow moves the timed fit log into the artifacts directory so uploads run on failures
- update the comparison workflow to fall back to the most recent run when no successful sweep runs exist, while surfacing run status metadata

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f8f70fd924832ea447d71698a345e2