### PR TITLE
Fix target directory helper signature

### DIFF
--- a/shared/build.rs
+++ b/shared/build.rs
@@ -1152,7 +1152,8 @@ fn scan_for_ignored_tests() -> Vec<String> {
     all_violations
 }
 
-fn is_in_target_directory(path: &Path) -> bool {
-    path.components()
+fn is_in_target_directory(path: impl AsRef<Path>) -> bool {
+    path.as_ref()
+        .components()
         .any(|component| matches!(component, Component::Normal(name) if name == "target"))
 }


### PR DESCRIPTION
## Summary
- adjust `is_in_target_directory` to accept any path-like input so `DirEntry::path()` calls compile again

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68f96e86a568832eaf24a8a6dff21d5c