### PR TITLE
Fix borrow checker error when reusing region filters

### DIFF
--- a/score/prepare.rs
+++ b/score/prepare.rs
@@ -296,7 +296,7 @@ pub fn prepare_for_computation(
     let mut score_iterator = KWayMergeIterator::new(
         sorted_score_files,
         &score_name_to_col_index,
-        region_filters,
+        region_filters.clone(),
         &bump,
     )?;
 


### PR DESCRIPTION
## Summary
- clone the optional region filter list before passing it into the score iterator so later diagnostics can still inspect it

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68fda8dd5750832eb129a2213ca37a68