### PR TITLE
Speed up PIRLS warm start and adaptive tolerance

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -2252,6 +2252,7 @@ mod tests {
             &rs_list,
             &layout,
             &cfg,
+            pirls::PirlsOptions::default(),
         )
         .expect("pirls");
 
@@ -2313,6 +2314,7 @@ mod tests {
             &rs_list,
             &layout,
             &cfg,
+            pirls::PirlsOptions::default(),
         )
         .expect("pirls");
 
@@ -2769,6 +2771,7 @@ mod tests {
             &rs_original,
             &layout,
             &cfg,
+            pirls::PirlsOptions::default(),
         )
         .expect("real PIRLS fit failed")
     }
@@ -3976,6 +3979,7 @@ mod tests {
             &penalty_roots,
             &layout,
             &cfg,
+            pirls::PirlsOptions::default(),
         )
         .expect("fixed-rho PIRLS (low)");
         let fit_high = pirls::fit_model_for_fixed_rho(
@@ -3987,6 +3991,7 @@ mod tests {
             &penalty_roots,
             &layout,
             &cfg,
+            pirls::PirlsOptions::default(),
         )
         .expect("fixed-rho PIRLS (high)");
 


### PR DESCRIPTION
## Summary
- add a `PirlsOptions` helper that lets callers warm start and scale the inner-loop tolerance while keeping the solver in the transformed basis
- persist the most recent successful P-IRLS result inside `RemlState` so repeated solves can reuse coefficients and loosen tolerances when the outer optimizer is still far from convergence

## Testing
- `cargo test pirls -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68fe6f139b6c832ebfae541a2a3c9d30