### PR TITLE
Improve PIRLS warm starts and adaptive tolerances

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -2252,6 +2252,7 @@ mod tests {
             &rs_list,
             &layout,
             &cfg,
+            None,
         )
         .expect("pirls");
 
@@ -2313,6 +2314,7 @@ mod tests {
             &rs_list,
             &layout,
             &cfg,
+            None,
         )
         .expect("pirls");
 
@@ -2769,6 +2771,7 @@ mod tests {
             &rs_original,
             &layout,
             &cfg,
+            None,
         )
         .expect("real PIRLS fit failed")
     }
@@ -3976,6 +3979,7 @@ mod tests {
             &penalty_roots,
             &layout,
             &cfg,
+            None,
         )
         .expect("fixed-rho PIRLS (low)");
         let fit_high = pirls::fit_model_for_fixed_rho(
@@ -3987,6 +3991,7 @@ mod tests {
             &penalty_roots,
             &layout,
             &cfg,
+            None,
         )
         .expect("fixed-rho PIRLS (high)");
 


### PR DESCRIPTION
## Summary
- add PIRLS control and warm-start plumbing so the solver can reuse prior coefficients, relax tolerances early in BFGS, and cap step-halving attempts
- teach the REML state to maintain the last converged fit and feed dynamic control options into the inner solve
- update calibrator/tests to call the expanded PIRLS API

## Testing
- cargo test pirls (fails: interrupted due to long dependency compilation)
- cargo check --lib (fails: interrupted due to compile time limits)


------
https://chatgpt.com/codex/tasks/task_e_68fe6f139b6c832ebfae541a2a3c9d30