### PR TITLE
Handle zero-penalty reparameterization edge cases

### DIFF
--- a/calibrate/basis.rs
+++ b/calibrate/basis.rs
@@ -687,7 +687,7 @@ mod internal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ndarray::{array, Array1};
+    use ndarray::{Array1, array};
 
     /// Independent recursive implementation of B-spline basis function evaluation.
     /// This implements the Cox-de Boor algorithm using recursion, following the
@@ -1067,10 +1067,8 @@ mod tests {
             "Recursive evaluation length mismatch"
         );
 
-        for (i, (&recursive, &expected_value)) in recursive_values
-            .iter()
-            .zip(expected.iter())
-            .enumerate()
+        for (i, (&recursive, &expected_value)) in
+            recursive_values.iter().zip(expected.iter()).enumerate()
         {
             assert_abs_diff_eq!(recursive, expected_value, epsilon = 1e-12);
             assert_abs_diff_eq!(iterative_basis[i], expected_value, epsilon = 1e-12);

--- a/calibrate/construction.rs
+++ b/calibrate/construction.rs
@@ -1616,7 +1616,15 @@ pub fn stable_reparameterization(
     }
 
     if !has_nonzero {
-        s_balanced = Array2::eye(p);
+        return Ok(ReparamResult {
+            s_transformed: Array2::zeros((p, p)),
+            log_det: 0.0,
+            det1: Array1::zeros(m),
+            qs: Array2::eye(p),
+            rs_transformed: rs_list.iter().cloned().collect(),
+            rs_transposed: rs_list.iter().map(|rs| rs.t().to_owned()).collect(),
+            e_transformed: Array2::zeros((0, p)),
+        });
     }
 
     let (bal_eigenvalues, bal_eigenvectors): (Array1<f64>, Array2<f64>) =
@@ -1643,7 +1651,11 @@ pub fn stable_reparameterization(
     let max_bal = bal_eigenvalues_ordered
         .iter()
         .fold(0.0_f64, |acc, &v| acc.max(v.abs()));
-    let rank_tol = if max_bal > 0.0 { max_bal * 1e-8 } else { 1e-12 };
+    let rank_tol = if max_bal > 0.0 {
+        max_bal * 1e-12
+    } else {
+        1e-12
+    };
     let penalized_rank = bal_eigenvalues_ordered
         .iter()
         .take_while(|&&val| val > rank_tol)
@@ -1693,12 +1705,6 @@ pub fn stable_reparameterization(
                 rs.slice_mut(s![.., ..penalized_rank]).assign(&updated);
             }
         }
-
-        s_lambda.fill(0.0);
-        for (lambda, rs_k) in lambdas.iter().zip(rs_transformed.iter()) {
-            let s_k = penalty_from_root(rs_k);
-            s_lambda.scaled_add(*lambda, &s_k);
-        }
     }
 
     let mut s_transformed = Array2::zeros((p, p));
@@ -1715,7 +1721,11 @@ pub fn stable_reparameterization(
     let max_eigenval = s_eigenvalues_raw
         .iter()
         .fold(0.0_f64, |a, &b| a.max(b.abs()));
-    let tolerance = max_eigenval * 1e-12;
+    let tolerance = if max_eigenval > 0.0 {
+        max_eigenval * 1e-12
+    } else {
+        1e-12
+    };
     let penalty_rank = s_eigenvalues_raw
         .iter()
         .filter(|&&ev| ev > tolerance)


### PR DESCRIPTION
## Summary
- short-circuit the stable reparameterization when every penalty matrix is numerically zero to preserve the identity basis
- align the balanced-spectrum and pseudo-inverse tolerances and drop the redundant S_lambda rebuild
- apply rustfmt updates in touched tests

## Testing
- `cargo test stable_reparameterization --lib` *(fails: cancelled due to lengthy dependency downloads in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe90558b20832e9a8576c9d8b90c36