### PR TITLE
Fix zero-penalty handling and tolerance in reparameterization

### DIFF
--- a/calibrate/construction.rs
+++ b/calibrate/construction.rs
@@ -1616,7 +1616,15 @@ pub fn stable_reparameterization(
     }
 
     if !has_nonzero {
-        s_balanced = Array2::eye(p);
+        return Ok(ReparamResult {
+            s_transformed: Array2::zeros((p, p)),
+            log_det: 0.0,
+            det1: Array1::zeros(lambdas.len()),
+            qs: Array2::eye(p),
+            rs_transformed: vec![],
+            rs_transposed: vec![],
+            e_transformed: Array2::zeros((0, p)),
+        });
     }
 
     let (bal_eigenvalues, bal_eigenvectors): (Array1<f64>, Array2<f64>) =
@@ -1643,7 +1651,7 @@ pub fn stable_reparameterization(
     let max_bal = bal_eigenvalues_ordered
         .iter()
         .fold(0.0_f64, |acc, &v| acc.max(v.abs()));
-    let rank_tol = if max_bal > 0.0 { max_bal * 1e-8 } else { 1e-12 };
+    let rank_tol = if max_bal > 0.0 { max_bal * 1e-12 } else { 1e-12 };
     let penalized_rank = bal_eigenvalues_ordered
         .iter()
         .take_while(|&&val| val > rank_tol)
@@ -1694,11 +1702,6 @@ pub fn stable_reparameterization(
             }
         }
 
-        s_lambda.fill(0.0);
-        for (lambda, rs_k) in lambdas.iter().zip(rs_transformed.iter()) {
-            let s_k = penalty_from_root(rs_k);
-            s_lambda.scaled_add(*lambda, &s_k);
-        }
     }
 
     let mut s_transformed = Array2::zeros((p, p));


### PR DESCRIPTION
## Summary
- short-circuit the reparameterization when every penalty matrix is zero to preserve the null-space split
- align the balanced penalty rank tolerance with the pseudo-inverse threshold and remove redundant S_lambda recomputation

## Testing
- cargo test stable_reparameterization --lib

------
https://chatgpt.com/codex/tasks/task_e_68fe90cdb9b0832eb1d42cea5488ba9c