### PR TITLE
Use faer Frobenius norm helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,3 +101,7 @@ grep = "0.3.2"
 [[bench]]
 name = "path_benchmark"
 harness = false
+
+[[bench]]
+name = "frobenius_norm"
+harness = false

--- a/benches/frobenius_norm.rs
+++ b/benches/frobenius_norm.rs
@@ -1,0 +1,51 @@
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use gnomon::calibrate::faer_ndarray::FaerArrayView;
+use ndarray::Array2;
+use rand::distributions::Standard;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+fn manual_frobenius(matrix: &Array2<f64>) -> f64 {
+    matrix.iter().map(|&x| x * x).sum::<f64>().sqrt()
+}
+
+fn faer_frobenius(matrix: &Array2<f64>) -> f64 {
+    FaerArrayView::new(matrix).as_ref().norm_l2()
+}
+
+fn random_matrix(size: usize) -> Array2<f64> {
+    let mut rng = StdRng::seed_from_u64(0x5EED_F64 + size as u64);
+    Array2::from_shape_fn((size, size), |_| rng.sample(Standard))
+}
+
+fn benchmark_frobenius(c: &mut Criterion) {
+    let sizes = [50_usize, 100, 200];
+    let matrices: Vec<_> = sizes
+        .iter()
+        .map(|&size| (size, random_matrix(size)))
+        .collect();
+
+    let mut group = c.benchmark_group("frobenius_norm");
+    for (size, matrix) in matrices.iter() {
+        let elements = (*size * *size) as u64;
+        group.throughput(Throughput::Elements(elements));
+
+        group.bench_with_input(BenchmarkId::new("manual", size), matrix, |b, input| {
+            b.iter(|| {
+                let norm = manual_frobenius(black_box(input));
+                black_box(norm);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("faer", size), matrix, |b, input| {
+            b.iter(|| {
+                let norm = faer_frobenius(black_box(input));
+                black_box(norm);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(frobenius_norm, benchmark_frobenius);
+criterion_main!(frobenius_norm);

--- a/calibrate/construction.rs
+++ b/calibrate/construction.rs
@@ -1,7 +1,7 @@
 use crate::calibrate::basis::{self, create_bspline_basis, create_difference_penalty_matrix};
 use crate::calibrate::data::TrainingData;
 use crate::calibrate::estimate::EstimationError;
-use crate::calibrate::faer_ndarray::{FaerEigh, FaerLinalgError, FaerSvd};
+use crate::calibrate::faer_ndarray::{FaerArrayView, FaerEigh, FaerLinalgError, FaerSvd};
 use crate::calibrate::model::{InteractionPenaltyKind, ModelConfig};
 use faer::Side;
 use ndarray::parallel::prelude::*;
@@ -1608,7 +1608,7 @@ pub fn stable_reparameterization(
     let mut s_balanced = Array2::zeros((p, p));
     let mut has_nonzero = false;
     for s_k in &s_original_list {
-        let frob_norm = s_k.iter().map(|&x| x * x).sum::<f64>().sqrt();
+        let frob_norm = FaerArrayView::new(s_k).as_ref().norm_l2();
         if frob_norm > 1e-12 {
             s_balanced.scaled_add(1.0 / frob_norm, s_k);
             has_nonzero = true;


### PR DESCRIPTION
## Summary
- swap the manual Frobenius norm in `stable_reparameterization` for faer's optimized `norm_l2`
- register a criterion benchmark for comparing manual and faer Frobenius norms

## Testing
- `cargo test stable_reparameterization --lib`


------
https://chatgpt.com/codex/tasks/task_e_68feab31d56c832e91c3345dba0b107d