### PR TITLE
Cache balanced penalty root across PIRLS solves

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -2265,6 +2265,7 @@ mod tests {
             y,
             w_prior,
             &rs_list,
+            None,
             &layout,
             &cfg,
         )
@@ -2326,6 +2327,7 @@ mod tests {
             y,
             w_prior,
             &rs_list,
+            None,
             &layout,
             &cfg,
         )
@@ -2782,6 +2784,7 @@ mod tests {
             y.view(),
             w_prior.view(),
             &rs_original,
+            None,
             &layout,
             &cfg,
         )
@@ -3986,6 +3989,7 @@ mod tests {
             y.view(),
             w.view(),
             &penalty_roots,
+            None,
             &layout,
             &cfg,
         )
@@ -3997,6 +4001,7 @@ mod tests {
             y.view(),
             w.view(),
             &penalty_roots,
+            None,
             &layout,
             &cfg,
         )


### PR DESCRIPTION
## Summary
- allow the PIRLS solver to reuse a caller-supplied balanced penalty root instead of recomputing it each call
- cache the lambda-independent balanced penalty root in `RemlState` and related evaluation paths so REML/gradient evaluations share it
- update call sites and helpers to pass either the cached root or explicitly opt out in unit tests

## Testing
- cargo test calibrate::pirls:: -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68ffa62a07d0832e92dc40983b74bdb4