### PR TITLE
Fix cargo asm ambiguity in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,7 +162,7 @@ jobs:
           echo "---"
           # `score::batch` now lives under the `score` module, so keep the inspected symbol
           # aligned with the library's public path to avoid false CI failures.
-          cargo +nightly asm -C lto=off --profile profiling --features no-inline-profiling --lib --intel gnomon::score::batch::process_tile
+          cargo +nightly asm -C lto=off --profile profiling --features no-inline-profiling --lib --intel gnomon::score::batch::process_tile 0
 
       - name: Cache getdoc binary
         id: getdoc_cache


### PR DESCRIPTION
## Summary
- ensure the assembly inspection step selects the intended symbol non-interactively

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_69002dff2c90832ea325e23c20f0c00f