### PR TITLE
Clarify Fine-Gray survival plan math

### DIFF
--- a/plan/survival_48271.md
+++ b/plan/survival_48271.md
@@ -1,0 +1,247 @@
+# Royston–Parmar Fine–Gray Survival Integration Plan
+
+## 1. Purpose and scope
+This document defines the end-to-end design for adding Royston–Parmar flexible parametric survival models with Fine–Gray competing-risk support to the `gnomon` codebase. It addresses data ingestion, basis construction, penalized optimization, competing-risk likelihood evaluation, prediction APIs, and calibrator integration. The intended implementers are Rust developers familiar with the existing penalized GAM engine in `calibrate/`.
+
+## 2. Current architecture audit
+- **Data ingestion** (`calibrate::data`, `calibrate/data.rs`): Enforces a fixed TSV schema and returns `TrainingData`/`PredictionData` bundles with phenotype, PGS, PCs, sex, and weights.
+- **Basis & penalties** (`calibrate::basis`, `calibrate/basis.rs`): Generates B-spline bases, applies constraints, and caches results. Penalty roots are assembled here.
+- **Design assembly** (`calibrate::construction`, `calibrate/construction.rs`): Converts `ModelConfig` + `TrainingData` into dense design matrices and aligned penalty blocks via `ModelLayout`.
+- **Optimization** (`calibrate::pirls`, `calibrate::estimate`): P-IRLS solves penalized normal equations using working responses/weights derived by `update_glm_vectors`; REML/LAML outer loop in `estimate.rs` updates smoothing parameters.
+- **Model artifact & scoring** (`calibrate::model`): Serializes configuration/coefficients and reconstructs designs during prediction; orchestrates optional calibrator application.
+- **Calibrator** (`calibrate::calibrator`): Fits secondary GAM using diagnostics from the base fit, reusing the same penalty and REML infrastructure.
+
+The survival extension must respect these boundaries: reuse basis caching, hook into `ModelLayout`, leverage existing Faer-based solves, and emit metadata compatible with `TrainedModel`.
+
+## 3. Statistical specification
+### 3.1 Baseline model
+- Time scale: attained age (years) with log transform `u = log(age)` to stabilize tail behavior.
+- Baseline cumulative subdistribution hazard for event of interest: `H_0^*(a) = exp(f_0(u))`, with `f_0` represented via penalized B-spline basis.
+- Individual subdistribution cumulative hazard: `H_i^*(a) = H_0^*(a) * exp(x_i^T γ + g_{pgs}(PGS_i, u))`, where:
+  - `x_i` contains static covariates (PGS, PCs, sex) with proportional hazards coefficients `γ`.
+  - `g_{pgs}` is a smooth varying-coefficient term for `PGS × age` built from tensor-product basis (PGS marginal basis ⊗ age basis without intercept column so proportional hazard is recovered when smooth is zero).
+- Subdistribution hazard: `λ_i^*(a) = d/da H_i^*(a)` = `H_i^*(a) * (df_0/da + ∂g_{pgs}/∂a)`.
+
+### 3.2 Likelihood with left truncation and competing risks
+- Observed tuple per subject: `(a_entry, a_exit, δ_target, δ_competing, weight)`, where `δ_target` = 1 if event-of-interest by `a_exit`, `δ_competing` = 1 if competing event occurred first, and right-censor when both zero.
+- Fine–Gray pseudo-likelihood (Lambert & Royston 2017) expresses the log-likelihood as
+  - `ℓ = Σ_i [ δ_i log λ_i^*(a_i) + log G_i(a_i) + log w_i(a_i) - ∫_{a_entry}^{a_exit} λ_i^*(a) S_i^*(a) / G_i(a) da ]`, where `G_i` is censoring survival and `w_i` Fine–Gray weights. Implement with counting-process form using cumulative subdistribution hazard `H_i^*` so the integral reduces to `H_i^*(a_exit) - H_i^*(a_entry)` once the pseudo-risk weights are incorporated.
+- Left truncation handled by conditioning on survival up to `a_entry`, yielding subtraction of `H_i^*(a_entry)` within the integral term.
+- Competing events modify both event indicators and at-risk weighting. Use pseudo-observations weights `ω_i = Π_j I(T_j ≥ T_i) / ᵍ_j` from Fine–Gray; maintain them explicitly per record to avoid on-the-fly recomputation.
+
+### 3.3 Penalization
+- Baseline smooth `f_0` penalized with difference penalty of order `ModelConfig::penalty_order` on the age spline coefficients.
+- Varying-coefficient tensor product `g_{pgs}` penalized anisotropically (reuse `InteractionPenaltyKind`) combining PGS marginal penalty and age-direction penalty.
+- Covariate main effects `γ` are unpenalized (enter penalty nullspace).
+
+## 4. Data pipeline extensions
+### 4.1 Schema changes (`calibrate/data.rs`)
+- Extend TSV expectations to include columns: `age_entry`, `age_exit`, `event_target`, `event_competing`, `censoring_weight` (optional), `age_current` (for scoring), `horizon` (for evaluation dataset only).
+- Update `TrainingData` with fields:
+  ```rust
+  pub struct SurvivalTrainingData {
+      pub age_entry: Array1<f64>,
+      pub age_exit: Array1<f64>,
+      pub event_target: Array1<f64>, // 0/1
+      pub event_competing: Array1<f64>, // 0/1
+      pub censoring_weights: Array1<f64>, // default 1.0 if absent
+      pub pgs: Array1<f64>,
+      pub sex: Array1<f64>,
+      pub pcs: Array2<f64>,
+      pub prior_weights: Array1<f64>,
+  }
+  ```
+- Provide survival-specific loaders `load_survival_training_data` and `load_survival_prediction_data` that validate monotone ages (`age_entry < age_exit`), finite values, event indicator exclusivity, and precompute Fine–Gray risk weights if provided externally.
+- Maintain backward compatibility by keeping existing GAM loader; CLI will select survival loader when new flag `--survival` is passed.
+
+### 4.2 Fine–Gray weight preprocessing
+- Add helper to compute pseudo-risk weights `ω_i`:
+  - Sort by `age_exit`.
+  - Compute Kaplan–Meier estimate of censoring survival `G(a)` using `censoring_weights`.
+  - For each record, assign `ω_i = prior_weights[i] * I(age_entry < age_exit) / G(a_exit)` with adjustments for left truncation `G(a_entry)`.
+  - Store both `ω_exit` and `ω_entry` to reuse during iterations.
+
+## 5. Basis & design construction updates
+### 5.1 Baseline age spline
+- Extend `basis::create_bspline_basis` to support evaluating both basis values and their derivatives with respect to log-age.
+- Implement `basis::evaluate_derivative` returning `(B(u), B'(u))` for a vector of `u` values.
+- Cache derivative evaluations keyed by `(knots_hash, degree, penalty_order, derivative=1)` using the existing LRU infrastructure.
+
+### 5.2 Survival model layout
+- Introduce new builder `construction::build_survival_design` alongside the existing GAM builder. Responsibilities:
+  1. Transform ages to log scale with centering/rescaling stored in `ModelConfig`.
+  2. Construct baseline spline matrix `X_baseline_exit`/`X_baseline_entry` and derivative matrices `D_baseline_exit` for hazard term.
+  3. Build PGS marginal spline and PC smooths exactly as current GAM to maintain reuse of `BasisConfig`/penalty assembly.
+  4. Create tensor product for `PGS × age` varying coefficient using `basis::tensor_product` with age marginal identical to baseline but drop the first column to avoid non-identifiable intercept.
+  5. Package the matrices into an augmented `ModelLayout::Survival` variant encapsulating:
+     ```rust
+     pub enum ModelLayoutKind {
+         Gam,
+         Survival(SurvivalLayout {
+             baseline_exit: Array2<f64>,
+             baseline_entry: Array2<f64>,
+             baseline_derivative_exit: Array2<f64>,
+             age_scale: (f64, f64), // mean, std for log-age
+             time_varying_exit: Array2<f64>,
+             time_varying_entry: Array2<f64>,
+         }),
+     }
+     ```
+  6. Share penalty assembly logic: baseline smooth penalty uses `PenaltyMatrix` with derivative order from config; time-varying smooth uses anisotropic penalty.
+- Ensure the `ModelLayout` retains ability to produce overall dense design for `pirls` (for linear algebra) while storing survival-specific matrices for gradient computations.
+
+## 6. Survival log-likelihood, gradient, and Hessian
+### 6.1 Linear predictors
+For subject `i` define:
+- `η_i^{exit} = X_i^{exit} β`, where `X_i^{exit}` is the concatenation `[B_exit, PGS_i, sex_i, PC_i, TP_exit]`.
+- `η_i^{entry} = X_i^{entry} β`, sharing coefficients but with baseline/time-varying blocks evaluated at `age_entry`.
+- `exp_term_i = exp(η_i^{exit})`, `exp_entry_i = exp(η_i^{entry})`.
+- `ΔH_i = exp_term_i - exp_entry_i` (always ≥ 0 with monotone ages).
+
+### 6.2 Event contributions
+- Event density term: `δ_i log λ_i^*(a_exit)` requires derivative of baseline spline: `log λ_i^* = η_i^{exit} + log( d/da f_0(u_exit) + ∂g_{pgs}/∂a )`.
+- Precompute `∂f_0/∂u` via derivative basis and scale by `1/age` from chain rule. Similarly compute derivative for time-varying term `PGS × ∂T/∂u`.
+- Implement safe guard ensuring `d/da f_0 + ... > 0` by exponentiating a log-derivative parameterization or clamping to small positive constant (e.g., `1e-6`) before taking log.
+
+### 6.3 Gradient/Hessian formulas
+For coefficient block `β`:
+- Score contribution:
+  ```
+  g_i = δ_i * x_i^{exit} - ω_i * ΔH_i * x_i^{exit} + ω_i * exp_entry_i * x_i^{entry}
+  + δ_i * J_i,
+  ```
+  where `ω_i` already includes censoring/Fine–Gray weighting, and `J_i` captures derivatives from the hazard derivative term:
+  ```
+  J_i = (d/da log λ_i^*)' x_i^{exit}.
+  ```
+- Hessian contribution (negative definite):
+  ```
+  H_i = ω_i * ΔH_i * x_i^{exit} x_i^{exit}^T - ω_i * exp_entry_i * x_i^{entry} x_i^{entry}^T
+        - δ_i * R_i,
+  ```
+  with `R_i` accounting for the second derivative of the log-derivative term.
+
+### 6.4 Mapping to P-IRLS
+- Augment `pirls::WorkingModel` abstraction:
+  ```rust
+  pub trait WorkingModel {
+      fn update(&mut self, beta: &Array1<f64>) -> WorkingState;
+  }
+  pub struct WorkingState {
+      pub eta: Array1<f64>,
+      pub gradient: Array1<f64>,
+      pub hessian: Array2<f64>, // dense p×p before penalties
+      pub deviance: f64,
+  }
+  ```
+- Implement `WorkingModel` for logistic, Gaussian (defer to current code), and new `RoystonParmarFineGray`. For GAM links, compute diagonal Hessian and map to existing `update_glm_vectors`. For survival, compute dense Hessian. This retains a single P-IRLS loop while letting each model supply `gradient`/`hessian`.
+- Inside `pirls::run_pirls`, replace diagonal `weights` logic with general Hessian accumulation: solve `(H + S) Δβ = g` using Faer; if Hessian is diagonal, we can form `X^T W X` as today; otherwise reuse gradient/Hessian directly to build the penalized system without constructing pseudo responses.
+- Maintain workspace reuse by storing `H` in `PirslWorkspace::xtwx_buf`; ensure symmetry and add ridge if eigenvalues approach zero.
+
+### 6.5 Deviance for REML/LAML
+- Define survival deviance as `-2ℓ` using the Fine–Gray log-likelihood with weights and penalty adjustments. Provide `calculate_survival_deviance` called by REML to keep gradient consistency.
+- Update `estimate.rs` to branch on `ModelLayoutKind` for deviance, gradient, and `PirslResult` extraction.
+
+## 7. REML/LAML integration
+- Extend `ModelConfig` with `enum ModelFamily { Gam(LinkFunction), Survival(SurvivalSpec) }`. `SurvivalSpec` stores:
+  ```rust
+  pub struct SurvivalSpec {
+      pub age_basis: BasisConfig,
+      pub num_age_knots: usize,
+      pub time_varying_basis: BasisConfig,
+      pub competing: bool,
+      pub firth_bias_reduction: bool, // not used but kept for API parity
+  }
+  ```
+- Update `estimate::train_model` to dispatch:
+  1. Build appropriate design layout via `ModelFamily`.
+  2. Instantiate `pirls::WorkingModel` accordingly.
+  3. Compute REML objective using survival deviance and penalty traces. Derive trace term `tr(W^{-1}S)` from Hessian as in GAM but using eigen decomposition of Hessian (Faer already available).
+- Ensure smoothing parameter gradient uses new Hessian as base; reuse `compute_penalty_square_roots`.
+
+## 8. Prediction and scoring API
+### 8.1 Baseline survival reconstruction
+- Extend `TrainedModel` with survival metadata:
+  ```rust
+  pub struct SurvivalModelArtifacts {
+      pub age_knots: Array1<f64>,
+      pub age_transform: (f64, f64),
+      pub baseline_coeffs: Vec<f64>,
+      pub time_varying_coeffs: Vec<f64>,
+      pub gamma: Vec<f64>,
+      pub competing: bool,
+  }
+  ```
+- Provide helper `evaluate_cumulative_hazard(age, covariates)` computing `H_i^*(age)` and derivative via stored bases.
+
+### 8.2 Absolute risk API
+- Add method `TrainedModel::predict_survival_risk(age_current, horizon, pgs, pcs, sex, calibrate: bool)` returning cumulative incidence between `age_current` and `age_current + horizon`:
+  ```
+  risk = F^*(age_current + horizon) - F^*(age_current)
+       = 1 - exp(-H_i^*(age_current + horizon)) - (1 - exp(-H_i^*(age_current))).
+  ```
+- Accept vectorized inputs for batch scoring. Provide CLI subcommand `score survival` accepting TSV with columns `age_current`, `horizon`, `score`, `sex`, `PC*`.
+
+### 8.3 Calibration integration
+- Extend calibrator feature computation to survival context:
+  - Baseline predictor: log cumulative incidence ratio at requested horizon.
+  - Standard error: delta method using Hessian inverse; reuse `pirls::penalized_hessian_transformed` to compute variance of log cumulative hazard difference.
+  - Distance-to-hull: reuse existing `PeeledHull` but ensure age dimension added? (Option: keep PGS/PC hull only; age handled via safe range check.)
+- Calibrator link remains `Logit` but on absolute risk; calibrator design uses same code path with new feature adapter bridging survival outputs to calibrator inputs.
+
+## 9. Competing risk handling
+- Represent event state via two indicator vectors; compute Fine–Gray weights once during preprocessing.
+- Provide optional cause-specific hazard output for debugging by exposing `predict_cause_specific_hazard(age)` (target cause only); but core API returns subdistribution risk.
+- Store metadata about competing-risk handling (e.g., `competing_events_present: bool`, `num_competing_events: usize`) in `SurvivalModelArtifacts` for downstream compatibility checks.
+
+## 10. CLI & configuration updates
+- Update `cli/main.rs` to accept `--model-family survival` and optional age knot configuration flags.
+- Provide default knot placements (e.g., 5 internal knots) with quantile spacing on log-age range.
+- Extend CLI scoring to read survival models and output risk across user-specified horizons with calibrator applied when available.
+- Ensure serialization/deserialization in `model.rs` handles new `ModelFamily` variant while preserving backward compatibility for existing GAM models.
+
+## 11. Testing & validation strategy
+### 11.1 Unit tests
+- `basis::tests`: verify derivative evaluations against finite differences for log-age basis.
+- `construction::tests`: ensure survival layout builds consistent baseline/time-varying matrices and penalties (dimensions, null spaces).
+- `pirls::tests`: create synthetic survival dataset with known parameters; compare estimated coefficients against analytic solution (simulate exponential hazards where Royston–Parmar reduces to linear model).
+- `estimate::tests`: end-to-end training on toy data; check REML convergence and monotonic cumulative incidence.
+- `model::tests`: verify serialization/deserialization of `SurvivalModelArtifacts` and risk predictions.
+- `calibrator::tests`: ensure calibrator attaches to survival models and outputs probabilities within [0,1].
+
+### 11.2 Integration tests
+- Compare risk predictions against reference implementation (`rstpm2::stpm2cr`) on matched dataset (load offline results into fixtures). Validate log-likelihood within tolerance and horizon-specific risk differences < 1e-3.
+- Stress-test left truncation: simulate cohort with delayed entry and confirm monotonicity of predicted risk vs. horizon.
+- Competing-risk edge cases: dataset with only censoring, only target events, or only competing events; ensure training handles gracefully (guard rails + informative errors).
+
+### 11.3 Numerical diagnostics
+- Evaluate Hessian eigenvalues across iterations; assert minimum eigenvalue > -1e-8 after ridge to catch instability.
+- Confirm `ΔH_i` remains non-negative; if not, log warning and apply floor.
+- Validate calibrator inputs by checking mean absolute calibration residual on held-out dataset.
+
+## 12. Performance considerations
+- Precompute `log-age` vectors and share across baseline/time-varying evaluations to avoid repeated `ln`.
+- Cache `exp(η)` terms and Fine–Gray weights between gradient/Hessian computations within an iteration.
+- Use Faer batched GEMM to form Hessian contributions: treat baseline/entry matrices as separate blocks and accumulate into shared buffer.
+- Exploit sparsity: baseline/time-varying design matrices can remain dense but low-rank; ensure `PirslWorkspace::xtwx_buf` sized accordingly.
+- For large cohorts, compute pseudo-risk weights using streaming approach to avoid storing full risk set matrix (O(n) memory).
+
+## 13. Implementation sequence & checkpoints
+1. **Data layer**: introduce survival loaders, update CLI gating. Validate TSV parsing via unit tests.
+2. **Basis derivative support**: extend `basis.rs`, add tests verifying derivative accuracy.
+3. **Survival layout**: implement `ModelLayoutKind::Survival`, build baseline/time-varying design matrices, extend penalty assembly.
+4. **Working model abstraction**: refactor `pirls` to use trait-based likelihood interface; ensure logistic/Gaussian paths unchanged (add regression tests to compare coefficients pre/post refactor).
+5. **Survival likelihood implementation**: code gradient/Hessian, integrate with `pirls` iteration, add synthetic data tests.
+6. **REML integration**: adapt outer loop for survival deviance, confirm smoothing parameter optimization converges on synthetic dataset.
+7. **Model artifact & scoring**: extend serialization, implement risk prediction API, create CLI surfaces.
+8. **Calibrator support**: adapt diagnostic extraction, fit calibrator on simulated survival outputs, verify probability bounds.
+9. **Competing-risk validation**: compare against reference (imported CSV of benchmarks), write regression tests for absolute risk at multiple horizons.
+10. **Documentation**: update `calibrate/README.md` and CLI docs to describe survival workflow, expected columns, and example commands.
+
+## 14. Risks & mitigations
+- **Non-concave likelihood**: enforce age monotonicity (`ΔH_i ≥ 0`) and apply adaptive ridge if Hessian loses definiteness.
+- **Derivative underflow**: floor `d/da f_0` contributions and consider modeling log-derivative via separate smooth to guarantee positivity.
+- **Pseudo-weight instability**: guard against small censoring survival `G(a)` by applying floor (e.g., 1e-6) and dropping observations beyond support.
+- **Calibration mismatch**: provide switch to disable calibrator until survival diagnostics validated; default to disabled until tests confirm stability.
+
+This plan provides all architectural decisions, mathematical details, and implementation checkpoints required to integrate Royston–Parmar Fine–Gray survival modeling into `gnomon` while respecting existing design principles.

--- a/plan/survival_59213.md
+++ b/plan/survival_59213.md
@@ -1,0 +1,266 @@
+# Royston–Parmar Attained-Age Survival Integration Plan
+
+## 1. Vision and Constraints
+- **Goal**: Add a Royston–Parmar flexible parametric survival engine (including Fine–Gray competing risks) that reuses the penalized GAM infrastructure (`calibrate::*`) to fit age-as-time hazard models and expose calibrated absolute risk predictions.
+- **Branch Context**: Target branch `feature/royston-parmar-survival` already contains GAM tooling optimized around binary/continuous outcomes with B-spline bases, tensor-product penalties, and REML-driven smoothing selection.
+- **Non-negotiables**:
+  - Retain REML/P-IRLS as the inner/outer optimization with minimal duplication.
+  - Preserve calibration pipeline (optionally disable via `set_calibrator_enabled`).
+  - Avoid forcing per-horizon refits; predictions must integrate hazard over arbitrary future intervals using one fitted model.
+  - Support left truncation (delayed entry), right censoring, and cause-specific competing risks within the Fine–Gray subdistribution framework.
+  - Maintain compatibility with existing CLI/config APIs (no breaking changes for non-survival models unless explicitly version-gated).
+
+## 2. Mathematical Blueprint
+### 2.1 Baseline Structure
+- Use attained age \(a\) as analysis time. Let \(t = \log(a)\) for spline modeling stability.
+- Baseline cumulative hazard on original time scale: \(H_0(a) = \exp\{ s(t) \}\), where \(s(t)\) is a penalized B-spline.
+- Baseline hazard: \(h_0(a) = H'_0(a) = H_0(a) \cdot s'(t) / a\) (needed for Fine–Gray likelihood and optional diagnostics).
+- Model linear predictor: \( \eta_i(a) = s(\log a) + x_i^\top \beta + z_i(a)^\top \gamma \), where
+  - `x_i`: time-invariant covariates (PGS, PCs, sex, optional offsets).
+  - `z_i(a)`: time-varying effects (PGS×age smooth, optional PC×age). Start with PGS×age (tensor-product of PGS basis with age basis sharing baseline knots to ease penalty reuse).
+- Hazard for subject `i`: \( h_i(a) = h_0(a) \, \exp( x_i^\top \beta + z_i(a)^\top \gamma ) \).
+
+### 2.2 Likelihoods
+- **Primary endpoint**: Fine–Gray subdistribution hazard for competing risks.
+  - Use counting-process notation with cumulative incidence \(F_k(a)\) for cause `k`.
+  - Subdistribution hazard: \( \tilde{h}_k(a|X) = h_0(a) \exp( X\beta ) \).
+  - Construct pseudo-observations using Fine–Gray weighting (see Gray (1999)). Implementation should follow the data augmentation strategy from Andersen et al., aligning with the Poisson trick enabling P-IRLS.
+- **IRLS Formulation**:
+  - Represent survival log-likelihood via Poisson GLM on disaggregated intervals (Andersen-Gill). For Royston–Parmar, we can avoid data splitting by using analytical gradient/Hessian for log cumulative hazard basis. Use weights derived from risk set contributions at unique event ages.
+  - Proposed approach: derive log-likelihood contributions
+    \[
+    \ell = \sum_i \delta_i \{ \eta_i(a_i) + \log w_i \} - w_i \exp(\eta_i(a_i))
+    \]
+    where `w_i` encodes cumulative hazard exposure (requires computing interval integrals). For Fine–Gray, modify `w_i` using subdistribution weights.
+  - Implement as custom `LinkFunction::RoystonParmar` that supplies `WorkingResponse` & `FisherWeights` to PIRLS given current `eta`.
+  - Because existing PIRLS expects canonical links with known variance, extend PIRLS to accept trait-specific closures (see §5.2).
+
+### 2.3 Absolute Risk Prediction
+- After fitting, compute cumulative incidence for horizon \(h\) at current age \(a_0\):
+  \[
+  \Pr(T \le a_0+h, \text{cause}=k \mid T > a_0) = \frac{F_k(a_0+h) - F_k(a_0)}{1 - \sum_j F_j(a_0)}
+  \]
+  where \(F_k\) denotes the Fine–Gray cumulative incidence for cause \(k\). Because the subdistribution hazard references the original time-zero risk set, conditioning on survival to \(a_0\) requires renormalizing by the remaining survival mass \(1 - \sum_j F_j(a_0)\). If a cause-specific conditioning workflow is needed, convert the fitted subdistribution hazards into cause-specific hazards before evaluating the CIF.
+- Provide scoring API: `predict_absolute_risk(current_age, horizon, pgs, pcs, sex, optional offsets)` returning CIF along with baseline survival, cause-specific hazard, and optionally standard errors via delta method (if feasible).
+
+## 3. Data Layer Extensions (`calibrate::data`)
+### 3.1 Training Schema
+- Augment TSV schema to include survival columns:
+  - `age_entry`: left-truncation age (continuous, same units as horizon input).
+  - `age_exit`: observed age at event or censoring.
+  - `event_primary`: {0,1} indicator for target event.
+  - `event_competing`: {0,1} indicator for competing event (death). Additional columns for multiple competing risks should be specifiable (see §3.4).
+  - `calendar_time` optional? Not required for attained-age models; ignore for now.
+- All ages must be >0 and `age_exit >= age_entry`. Validate monotonicity, finite values, minimal spread.
+- Provide `TrainingDataSurvival` struct separate from existing `TrainingData` to avoid breaking binary regression users.
+  ```rust
+  pub struct TrainingDataSurvival {
+      pub age_entry: Array1<f64>,
+      pub age_exit: Array1<f64>,
+      pub event_primary: Array1<f64>,
+      pub event_competing: Array1<f64>,
+      pub y_pseudo: Array1<f64>,           // filled later by Fine–Gray augmentation
+      pub weight_pseudo: Array1<f64>,      // event weights for PIRLS
+      pub offsets: Array1<f64>,            // log exposure offsets if Poisson trick used
+      pub baseline_knots: Array1<f64>,     // saved for ModelConfig
+      pub p: Array1<f64>,
+      pub pcs: Array2<f64>,
+      pub sex: Array1<f64>,
+      pub weights: Array1<f64>,
+  }
+  ```
+- Extend `load_training_data` with mode switch `TrainingKind::Standard | TrainingKind::Survival`. Introduce enum to reuse internal parsing pipeline but map to either struct.
+- Update CLI/config to request survival mode explicitly (e.g., `--survival`).
+
+### 3.2 Prediction Schema
+- Introduce `PredictionDataSurvival` with `current_age`, `pgs`, `pcs`, `sex`, optionally `horizon` vector (or pass at scoring time). If horizon column provided, allow per-person horizon.
+
+### 3.3 Risk-Set Preprocessing
+- Precompute unique sorted event ages (including competing events) for baseline spline support.
+- Derive log-age transformation arrays and Jacobians (1/a) for derivative calculations.
+- Compute Fine–Gray weights before PIRLS: apply cumulative incidence weighting using Kaplan–Meier of censoring/competing risk (requires partial sorting). Use `ndarray` operations; consider `faer` for prefix sums if necessary.
+
+### 3.4 Multiple Competing Risks (Future-proofing)
+- For now restrict to a single competing event column. Document extension path: generalize to `Vec<Array1<f64>>` with event type codes.
+
+## 4. Model Representation (`calibrate::model`)
+### 4.1 LinkFunction Extension
+- Add variant `LinkFunction::RoystonParmarSurvival` capturing metadata:
+  ```rust
+  pub enum LinkFunction {
+      Logit,
+      Identity,
+      RoystonParmarSurvival(SurvivalLinkConfig),
+  }
+  
+  pub struct SurvivalLinkConfig {
+      pub attained_age_origin: f64,
+      pub log_age_scale: f64,
+      pub baseline_knot_count: usize,
+      pub baseline_degree: usize,
+      pub fine_gray: bool,
+      pub log_time_offset: bool,
+  }
+  ```
+- `SurvivalLinkConfig` stored in `ModelConfig` for inference. Contains baseline spline metadata, integration step size, penalty order(s), mapping between design blocks and covariates.
+
+### 4.2 New ModelConfig Fields
+- Add survival-specific configuration: baseline knot placement (quantiles of event ages), penalty structure for baseline/time-varying effects, smoothing parameter priors, offset usage.
+- Expand `MappedCoefficients` with survival-specific surfaces (baseline, PGS×age). Provide names for new terms to maintain serialization compatibility.
+- Document serialization changes in README.
+
+### 4.3 Null Space & Constraints
+- Ensure baseline smooth satisfies identifiability: enforce \(H_0(a_{ref}) = 0\) or \(s(\log a_{ref}) = 0\) to avoid non-identifiable intercept. Choose anchor at median attained age or `log_age = 0` via offset subtraction. Represent via constraint matrix `Z_baseline`. Hook into `sum_to_zero_constraints` map.
+
+## 5. Design & Penalty Construction (`calibrate::construction`)
+### 5.1 Baseline B-spline
+- Reuse `create_bspline_basis` with log-age input and baseline knots/degree from config.
+- Build penalty matrix using existing difference penalty utilities; ensure first derivative penalty for baseline cumulative hazard to enforce smooth log-H0.
+- Save baseline basis matrix `B_age` and penalty block `S_age`.
+
+### 5.2 Time-Varying Interactions
+- Construct tensor-product basis between log-age and PGS basis for PGS×age effect.
+- Use anisotropic penalties by default: `S = λ_age S_age ⊗ I + λ_pgs I ⊗ S_pgs`. Reuse `create_balanced_penalty_root` for null-space handling.
+- Guarantee that PGS main effect remains orthogonal to age interaction via `interaction_orth_alpha` infrastructure (existing pure-ti code path). Confirm compatibility; adjust if `ModelLayout` expects logistic identity (examine `build_design_and_penalty_matrices`).
+
+### 5.3 ModelLayout Enhancements
+- Extend `ModelLayout` to tag columns belonging to baseline/time-varying blocks. Provide metadata for PIRLS to compute hazard integrals (e.g., `baseline_column_range` stored in `ModelLayout`).
+- Provide ability to supply custom offset vector (log exposure) along with design matrix.
+
+## 6. PIRLS & REML Core Changes (`calibrate::pirls`, `calibrate::estimate`)
+### 6.1 PIRLS Input Generalization
+- Introduce trait `LikelihoodFamily` encapsulating link-specific operations: working response, weights, deviance, gradient, Hessian contributions. Implementations for `Logit`, `Identity`, and new `RoystonParmar`.
+  ```rust
+  pub trait LikelihoodFamily {
+      fn update_working_quantities(&self, eta: ArrayView1<f64>, y: ArrayView1<f64>,
+                                   prior_weights: ArrayView1<f64>,
+                                   work: &mut PirlsWorkspace) -> Result<PirlsIterationState, EstimationError>;
+      fn deviance(&self, ...);
+      fn gradient_hessian(&self, ...);
+  }
+  ```
+- Modify `run_pirls` to dispatch on `ModelConfig.link_function` by obtaining boxed `LikelihoodFamily`. This isolates survival-specific math without polluting logistic implementation.
+
+### 6.2 Survival Working Quantities
+- `y` in survival context becomes Fine–Gray pseudo response; `prior_weights` incorporate risk-set weights.
+- For each subject/time, compute `mu = exp(eta + offset)` (hazard). Working response: `z = eta + (y - mu)/mu` (Poisson canonical). Fisher weight: `w = mu` times prior weights.
+- Provide deviance/residual calculations consistent with Poisson log-likelihood (for monitoring but not exported to user).
+- Ensure offset is fed into PIRLS pipeline (currently supported? check `run_pirls` signature). If absent, extend to accept optional offset array.
+
+### 6.3 REML Gradient/Hessian
+- REML objective requires log determinant of penalized Hessian. With new link, Hessian is `X^T W X + Sλ` as before. Ensure gradient contributions from `family.deviance` align with Poisson.
+- Validate that existing `RemlState` logic (kahan sums, `compute_penalty_square_roots`) remains applicable.
+- Provide guard rails for cases with near-zero events (add ridge, drop terms?). Possibly incorporate Firth-like correction for separation analog (rare events) by reusing existing Firth toggles? Document as future work.
+
+## 7. Fine–Gray Specific Machinery
+### 7.1 Risk Set Construction Module
+- Add new module `calibrate::survival::fine_gray` to encapsulate data prep independent of PIRLS.
+  - Input: `(age_entry, age_exit, event_primary, event_competing, weights)`.
+  - Output: `pseudo_y`, `pseudo_weights`, `offset_log_exposure`, `ordering_indices`, `baseline_knots` suggestions.
+  - Steps:
+    1. Sort by `age_exit`.
+    2. Compute Kaplan–Meier for censoring/competing risk.
+    3. Derive Fine–Gray weights `w_i = G(age_exit_i -)`, where `G` is survivor function of censoring/competing events.
+    4. Compute `y_i = event_primary_i` (since FG uses subdistribution hazard) but ensure weight `w_i` zeroes out competing events past event time.
+    5. Build offsets representing exposure length: `offset_i = log( cumulative_hazard_increment(age_entry_i, age_exit_i) )`. For Royston–Parmar this is integral of baseline hazard; approximate using quadrature with baseline basis evaluation once per iteration (requires storing basis integrals; see §8.2).
+- Provide ability to recompute offsets each iteration if baseline hazard changes. To avoid expensive recomputation, express hazard integral analytically: integrate `exp(s(t))` over interval using pre-integrated basis functions. Precompute matrix `I_age` where each row corresponds to subject integral of basis over `[log age_entry, log age_exit]`. Then offset update each iteration reduces to `offset_i = log( I_age[i] · exp(coefficients_baseline) )`. See §8.2 for details.
+
+### 7.2 Baseline Integral Representation
+- Represent baseline smooth as \(s(t) = B(t) \theta\), where `B` is basis row.
+- Need integral \( \int_{a_{start}}^{a_{end}} \exp(B(t) \theta) \frac{1}{a} dt \) (since dt = da/a). Hard to integrate analytically; choose Gauss-Legendre quadrature on log-age scale using precomputed nodes/weights for each interval (3-5 nodes). Implementation steps:
+  - Precompute quadrature nodes (e.g., 7-point Gauss-Legendre) on reference interval [0,1].
+  - For each subject, map to `[log a_start, log a_end]`, evaluate `B(t_j)` at nodes, compute `s(t_j)`; hazard integral approximated as `∑ w_j exp(s(t_j))` times `Δt`.
+  - Store matrix of basis evaluations at nodes to avoid repeated `create_bspline_basis` calls each iteration (heavy). Reuse basis cache (ensured by `basis::` module).
+- Use `offset_i = log( integral )` to feed PIRLS.
+- Because offsets depend on current `theta_baseline`, we need iterative update inside PIRLS: after each `eta` update, recompute offsets (since baseline coefficients change). To integrate with PIRLS, treat offset as function of coefficients; we can re-express the score and Hessian to incorporate integral without offset recomputation by using derivative-of-integral. Implementation detail: treat baseline coefficients as part of `Xβ` and include `I_age θ` rows in design matrix. Derive gradient contributions explicitly (requires customizing PIRLS). Document two options and pick one (see §8.3).
+
+## 8. Survival-Specific Linear Algebra
+### 8.1 Design Matrix Augmentation
+- Extend design builder to compute:
+  - `B_baseline`: n × m_b matrix of baseline basis at exit age.
+  - `B_pgs`: n × m_p for PGS main effect.
+  - `B_pcs`: as existing.
+  - `B_pgs_age`: n × (m_p * m_age) for interaction.
+  - `I_baseline`: n × m_b matrix representing integrals over interval (for hazard exposures).
+- Compose linear predictor for event contributions: `eta = B_baseline θ + X β + ...`.
+- Exposure integral enters log-likelihood as `exp(eta_offset)`, so we must adjust `z`/`w` accordingly. Implementation options:
+  1. Introduce iteration step to recompute `mu` using `integral = exp(I_baseline θ)` without storing as offset.
+  2. Expand dataset with quadrature nodes so that standard Poisson GLM approximates integral via repeated rows (Simpler but increases data). Evaluate trade-off: more rows but avoids custom derivatives. Considering performance (~29k lines), prefer quadrature expansion because `faer` handles large matrices and logistic models already support big n. Document in §8.3.
+
+### 8.2 Quadrature Expansion Strategy
+- For each subject interval `[a_entry, a_exit]`, create `Q` pseudo-rows (Q=5-7) with design rows evaluated at quadrature nodes `a_j`. Response `y_j = event_primary_i * δ_{j=last}`? Instead, treat hazard integral as sum of exposures `μ_j = w_j * exp(η(a_j))`. We can restructure as Poisson regression where each pseudo-row has `offset = log(w_j Δt)` and event count `y_j=0`, except final row representing event with `y=1`. Validate correctness with log-likelihood equivalence (should approximate integral). Document theoretical justification referencing Bender et al. (2005). Provide plan to implement helper generating expanded arrays (n×Q). Manage memory by streaming into `Array2` with parallel loops.
+- Evaluate performance: With Q=7 and n ~200k, we get 1.4M rows, still manageable given `faer` HPC but ensure workspace scaling (update `PirlsWorkspace::new`).
+
+### 8.3 Alternative: Analytical Gradients (Future Option)
+- Document in plan but not immediate: using expectation of derivative to avoid data expansion. Provide stub for future to convert to closed-form integrals once base implementation validated.
+
+## 9. Calibration Layer Integration (`calibrate::calibrator`)
+- Survival predictions output absolute risk (probability). Feed calibrator with features similar to logistic case: predicted CIF, standard error (approx), hull distance.
+- Need to supply `pred_identity` as base CIF (bounded 0-1). Since calibrator expects real-valued link, convert CIF to logit for calibrator fit. Provide `LinkFunction::Logit` to calibrator while storing survival context for documentation.
+- Ensure calibrator training uses same sample weights as survival risk set (use `FineGray` weights aggregated per subject). Provide aggregator mapping from quadrature pseudo-rows back to individuals for calibrator features (since calibration should operate at individual horizon predictions, not pseudo-rows). Possibly reuse `peeled hull` infrastructure for features.
+
+## 10. Scoring API & CLI
+### 10.1 Rust API (`calibrate::model::TrainedModel`)
+- Extend `TrainedModel` with survival-specific inference method:
+  ```rust
+  impl TrainedModel {
+      pub fn predict_survival(&self, request: SurvivalRequest) -> Result<SurvivalPrediction, PredictionError>;
+  }
+  ```
+  - `SurvivalRequest` contains arrays for `current_age`, `horizon`, `pgs`, `pcs`, `sex`, `weights` (optional), `calibration: bool`.
+  - `SurvivalPrediction` returns CIFs, baseline survival, log cumulative hazard, optionally hazard ratios.
+- Ensure compatibility with existing logistic `predict` by gating on `link_function` variant.
+
+### 10.2 CLI
+- Add `score` subcommand options: `--survival`, `--horizon YEARS`, `--per-row-horizon-column horizon_col`.
+- Provide training CLI toggle to ingest survival schema, choose baseline knots (# internal knots default 8) and degree (cubic).
+- Document new CLI flags in README.
+
+## 11. Testing Strategy
+### 11.1 Unit Tests
+- `calibrate::survival::fine_gray` unit tests: verify weight computation on synthetic dataset vs reference R `cmprsk::crr` outputs.
+- Baseline basis integrals: check quadrature approximations converge for known analytic `s(t)` (simulate simple log-linear hazard).
+- PIRLS dispatch: ensure logistic/Gaussian unchanged via regression tests (existing suite). Add `LinkFunction::RoystonParmarSurvival` branch coverage.
+
+### 11.2 Integration Tests
+- Fit small dataset replicating published example (e.g., ovarian cancer data). Compare predicted CIF at ages 50, 60 with `rstpm2` or `flexsurv` references.
+- Competing risk scenario: dataset where all events are competing; verify CIF = 0 and model remains stable.
+- Left-truncation: create dataset with `age_entry > 0`, ensure risk set excludes earlier times (simulate by verifying log-likelihood vs manual calculation).
+
+### 11.3 Calibration Tests
+- Run calibrator on simulated data with known truth to ensure calibrated CIF matches empirical incidence (Kolmogorov–Smirnov test).
+- Regression tests for serialization/deserialization of survival models (round-trip via TOML file, ensure predictions preserved).
+
+## 12. Performance & Stability Considerations
+- Precompute and cache B-spline basis for log-age evaluations (both event ages and quadrature nodes) to minimize repeated computation. Reuse `basis::` caching with deterministic keys (include node positions and baseline knots in hash).
+- Monitor condition numbers in PIRLS: baseline block may become ill-conditioned due to quadrature rows. Use existing `calculate_condition_number` to adapt ridge.
+- Provide configuration to adjust quadrature order for accuracy/performance trade-offs.
+- Ensure memory usage of `Array2` in quadrature expansion remains manageable (maybe chunked assembly). Use `ndarray::parallel` loops to build design matrix chunk-by-chunk.
+- For extremely old ages (tails), add prior penalty on baseline slope to prevent divergence (increase `penalty_order` or add boundary knots repeated).
+
+## 13. Documentation Deliverables
+- Update `calibrate/README.md` with survival overview, CLI usage, mathematical derivations.
+- Provide example pipeline in `examples/` directory (e.g., `examples/survival.rs` or notebook) demonstrating training + scoring + calibration.
+- Document API in Rustdoc for new structs/enums.
+- Add developer doc in `plan/` referencing this plan for historical context.
+
+## 14. Implementation Sequencing & Validation Checkpoints
+1. **Data Layer**: Implement survival schema parsing (`TrainingDataSurvival`, CLI toggles). Validation: unit test verifying parsing & validation.
+2. **Fine–Gray Preprocessing Module**: Build risk set weights, quadrature expansion scaffolding. Validation: compare to R reference.
+3. **Design/Penalty Updates**: Extend `ModelLayout`, `build_design_and_penalty_matrices` to produce survival design. Validation: ensure logistic path unaffected (existing tests) and new survival-specific tests compile.
+4. **LikelihoodFamily Abstraction**: Refactor PIRLS to use trait. Regression test logistic/Gaussian to ensure identical outputs (floating tolerance).
+5. **Survival Family Implementation**: Hook survival-specific working response and quadrature offsets. Validation: simple dataset with constant hazard yields closed-form solution; compare to expected cumulative hazard.
+6. **REML Integration**: Ensure smoothing selection works with new family; check gradient/Hessian finite and monotonic. Validate with small dataset (monitor `rho` convergence).
+7. **Scoring API**: Implement `predict_survival`. Validation: ensure outputs monotone in horizon, bounded 0-1, consistent with training data by comparing to Monte Carlo simulation.
+8. **Calibration Layer**: Adapt calibrator inputs for survival predictions; ensure toggles respect `calibrator_enabled`. Validation: run calibrator training pipeline.
+9. **CLI + Examples + Docs**: Expose features and document usage. Validation: CLI integration test on sample dataset.
+10. **Performance Profiling**: Benchmark on realistic dataset; tune quadrature order, caching, and parallelism. Provide metrics.
+
+## 15. Future Extensions (Document but Out-of-Scope)
+- Multiple competing risks generalization using stacked Fine–Gray pseudo-data.
+- Non-proportional hazards for PCs or sex via additional interactions.
+- Time-varying covariates implemented via counting process rows.
+- Stratified baselines (sex-specific) implemented by block-diagonal penalties.
+- Analytical integral approach to replace quadrature for improved speed.
+- Bayesian smoothing priors to encode prior knowledge of hazard shape.
+

--- a/plan/survival_72953.md
+++ b/plan/survival_72953.md
@@ -1,0 +1,252 @@
+# Royston–Parmar Fine–Gray Survival Integration Plan
+
+## 1. Objectives and Scope
+1. Extend the `calibrate/` crate to support a Royston–Parmar flexible parametric survival model that uses attained age as the timescale and accounts for competing risks via a Fine–Gray subdistribution hazard formulation.
+2. Preserve and reuse the existing penalized GAM infrastructure—basis generation (`basis.rs`), design assembly (`construction.rs`), P-IRLS solver (`pirls.rs`), and REML/LAML smoothing selection (`estimate.rs`)—while introducing survival-specific data structures, likelihood computations, and prediction logic.
+3. Deliver an inference API capable of producing calibrated absolute risk between an individual’s current age and arbitrary future horizons, integrating with the existing post-hoc calibrator when enabled.
+4. Maintain backward compatibility with binary and Gaussian models by isolating survival functionality behind new model types, configuration flags, and serialization fields.
+
+## 2. Current Infrastructure Survey
+- **Data handling (`calibrate/data.rs`):** Strict schema loader for phenotype, score, sex, PCs, weights. Needs extension to ingest survival-specific columns (entry/exit age, event type) and to produce survival-specific data bundles.
+- **Basis and penalties (`calibrate/basis.rs`):** Provides B-spline basis construction, difference penalties, tensor product structures, and null-space constraints. We can reuse this machinery for the log-age baseline spline and for the PGS×age interaction smooth, but must add convenience wrappers for log-age transformations and monotonicity constraints.
+- **Design layout (`calibrate/construction.rs`):** Builds the block-structured design matrix and penalty map recorded in `ModelLayout`. Survival mode will require new block descriptors (baseline age spline, hazard shift covariates, optional tensor interactions) and updated null-space handling.
+- **Optimization (`calibrate/pirls.rs` & `calibrate/estimate.rs`):** Implements penalized iteratively reweighted least squares and nested REML optimization keyed off `ModelConfig::link_function`. We must add a new link variant with survival-specific working response and deviance calculations, plus support for the additional sufficient statistics the survival likelihood requires (risk-set denominators, counting-process weights).
+- **Model artifact (`calibrate/model.rs`):** Serializes `ModelConfig`, stores design metadata, and executes prediction with optional calibrator adjustments. Survival models must capture age transformations, baseline spline coefficients, competing-risk metadata, and a horizon-aware prediction path.
+- **Calibrator (`calibrate/calibrator.rs`):** Builds a secondary GAM using diagnostics from the base fit. Survival predictions will use different diagnostics (e.g., CIF standard errors, age-based hull distances) but can reuse the same P-IRLS machinery with tailored feature construction.
+- **Hull guard (`calibrate/hull.rs`):** Currently handles convex hulls in PGS/PC space; we will extend to include attained age for extrapolation safeguards.
+
+## 3. Mathematical Specification
+### 3.1 Time scale and transformations
+- Let `a` denote attained age in years. Training data provide `a_entry` (left truncation) and `a_exit` (event or censoring age). Define transformation constants: `a_min = min(a_entry)` and `δ = 0.1` years (guard). Map each age to `u = log(a - a_min + δ)` so the spline basis operates on a stabilized log-age scale. Record `(a_min, δ)` and `a_max = max(a_exit)` for prediction.
+- Evaluate baseline basis functions at both entry and exit ages to compute cumulative hazard differences, a requirement for Fine–Gray risk increments.
+
+### 3.2 Baseline cumulative hazard
+- Represent the log cumulative baseline hazard `ℓ(a) = log H_0(a)` as a penalized B-spline smooth over `u`. Let `B(u)` be the basis matrix (rows = observations, columns = spline coefficients). The baseline contribution to the linear predictor for subject `i` at age `a_exit_i` is `η_{0,i} = B(u_exit_i) θ`. For left truncation we subtract the baseline evaluated at entry age: `η_{0,i}^{entry} = B(u_entry_i) θ`. The effective cumulative hazard contribution for the observation interval is `exp(η_{0,i}) - exp(η_{0,i}^{entry})`.
+- Enforce identifiability via one of two equivalent constraints: (a) impose `ℓ(a_ref) = 0` at reference age `a_ref` (e.g., weighted median of `a_exit`) by subtracting `B(u_ref)` from each basis evaluation; or (b) drop the first column of the constrained basis (`basis.rs` already supports sum-to-zero transformations). Option (a) preserves interpretability and will be implemented by augmenting the basis builder to subtract `B(u_ref)` before applying difference penalties.
+- Apply a second-order difference penalty on `θ` (wiggliness control) using existing `difference_penalty` function. Provide a configuration knob for penalty order in `ModelConfig` (default 2, optional 3 for extra smoothness).
+
+### 3.3 Covariate effects
+- The hazard multiplicative shifts are additive on the log cumulative hazard scale:
+  - `β_pgs` for the raw polygenic score.
+  - Optional `β_sex` (binary).
+  - Linear coefficients `β_pc_j` for each principal component (default), with option to promote to smooths if future work requires.
+  - Optional smooth interaction `f_{pgs×age}(PGS, u)` capturing non-proportional hazards. Implement as a tensor-product smooth with marginal bases: univariate B-spline in `PGS` (as already built for calibration) and the log-age spline `B(u)` with anisotropic penalties (existing `InteractionPenaltyKind::Anisotropic`). Center the interaction to ensure pure `ti()` semantics (requires extending current orthogonalization to include the new log-age marginal).
+
+### 3.4 Fine–Gray subdistribution hazard
+- For each subject `i`, define:
+  - `d_i = 1` if the target event occurred at `a_exit_i`, `0` otherwise.
+  - `c_i = 1` if a competing event occurred, `0` otherwise.
+  - Weight `w_i` from training data (defaults to 1).
+- The subdistribution hazard for subject `i` at age `t` is `λ_s(t | x_i) = d/dt Λ_s(t | x_i)`, where `Λ_s(t | x_i) = H_0(t) ⋅ exp(x_i^⊤ β)` with `x_i` representing covariates evaluated at age `t`. Because RP models parameterize `log Λ_s`, the linear predictor `η_i(t) = log Λ_s(t | x_i)`.
+- The Fine–Gray log-likelihood is:
+  
+  `ℓ(β, θ) = Σ_{i: d_i=1} w_i [η_i(a_exit_i) - log(Σ_{j ∈ R(a_exit_i)} w_j G_j(a_exit_i) exp(η_j(a_exit_i)))]`
+
+  where `R(a_exit_i)` is the Fine–Gray risk set evaluated just before the event time, `G_j` is the censoring weight, and `w_i` is the subject weight from the training data. The log-likelihood depends on the shared risk-set denominator; there is no separate `Δ H_0` factor because the Royston–Parmar parameterization already expresses the cumulative hazard through `η`.
+- Implement the computational recipe used by Beyersmann et al.: maintain risk-set weights `W_j(t) = ℓ( max(t, a_exit_j) )` and apply the Fine–Gray cumulative incidence weighting factor `G_j(t)` (Kaplan–Meier of censoring/competing). Practical plan:
+  1. Sort subjects by `a_exit`.
+  2. Compute censoring weights `G_j(t)` by fitting Kaplan–Meier on the union of target + competing events, treating the target event as failure and competing as censoring for `G`.
+  3. For each event time, accumulate `risk_sum = Σ_j w_j G_j(t) exp(η_j(t))` over all subjects with `a_entry_j ≤ t`.
+  4. Score contribution for event `i`: `w_i [η_i(a_exit_i) - log(risk_sum)]`.
+- Because RP models provide `η_i(a_exit)` directly, we avoid time-derivative computations; however, we need `exp(η_i)` for risk-set sums and `∂ℓ/∂η` for P-IRLS.
+
+- Denote `r_i = w_i` if `d_i=1`, else 0. Let `s_i = w_i G_i(a_exit_i) exp(η_i(a_exit_i)) / risk_sum(a_exit_i)` for all subjects with `a_entry_i ≤ a_exit_i`. The score with respect to `η_i` is `U_i = r_i - Σ_{k: events at t_k} s_i(t_k)` where the sum covers event times `t_k` where subject `i` is in the Fine–Gray risk set. For efficiency we precompute `Σ_{k} s_i(t_k)` using cumulative sums over the sorted time axis.
+- Assemble the negative Hessian as the full risk-set cross-product: for each event time `t_k`, form `W_k = diag(s(t_k)) - s(t_k) s(t_k)^⊤` over the risk-set vector `s(t_k)` and accumulate `H = Σ_k X_{R(t_k)}^⊤ W_k X_{R(t_k)}`. This preserves the off-diagonal curvature induced by shared risk denominators and prevents the Newton step from collapsing when multiple individuals share an event time. Implement the accumulation via existing dense cross-product utilities, processing one event slice at a time to control memory.
+- Solve the linear system `H δ = U` with the penalized normal-equation solver to obtain the Newton step, then set the working response `z = η + δ`. Inject a small ridge (`1e-8`) into `H` if it becomes near-singular. Observations with zero risk-set involvement contribute only through penalties.
+- Provide helper `update_fine_gray_vectors(eta, survival_stats) -> (mu, hessian, z)` returning `mu = exp(η)` for reuse in prediction-standard-error calculations and the assembled Hessian blocks for REML updates.
+- Deviance for monitoring: `D = -2 Σ_{events} w_i [η_i(a_exit_i) - log(risk_sum(a_exit_i))]` plus constant; store unpenalized deviance for diagnostics.
+
+## 4. Data Schema and Preprocessing
+### 4.1 Survival data structs
+```rust
+pub struct SurvivalTrainingData {
+    pub pgs: Array1<f64>,
+    pub sex: Array1<f64>,
+    pub pcs: Array2<f64>,
+    pub weights: Array1<f64>,
+    pub age_entry: Array1<f64>,
+    pub age_exit: Array1<f64>,
+    pub event_type: Array1<u8>, // 0=censor,1=target,2=competing
+}
+```
+- Add `SurvivalPredictionInputs` for inference:
+```rust
+pub struct SurvivalPredictionInputs<'a> {
+    pub pgs: ArrayView1<'a, f64>,
+    pub sex: ArrayView1<'a, f64>,
+    pub pcs: ArrayView2<'a, f64>,
+    pub current_age: ArrayView1<'a, f64>,
+    pub horizon_age: ArrayView1<'a, f64>, // same length as individuals or length-1 broadcast
+}
+```
+
+### 4.2 Loader enhancements (`calibrate/data.rs`)
+- Introduce `load_survival_training_data(path, num_pcs)` alongside existing loaders. Required columns: `score`, `sex`, `PC*`, `weights`, `age_entry`, `age_exit`, `event_type`. Optional `phenotype` is ignored in survival mode to prevent confusion.
+- Validation logic:
+  - Confirm `age_entry`, `age_exit` numeric, positive, finite.
+  - Enforce `age_exit >= age_entry` with tolerance `1e-6`.
+  - Map `event_type` strings/numbers to `u8`. Accept synonyms: `{0, "censor", "none"}`, `{1, "event", "case"}`, `{2, "compete", "death"}`.
+  - Disallow all-zero events; raise informative error prompting user to verify event coding.
+  - Ensure at least one primary event and one censored observation for identifiability.
+- Compute and return sorted indices by `age_exit`; store for reuse in survival preprocessor.
+
+### 4.3 Survival preprocessor module
+- Create `calibrate/survival/mod.rs` housing:
+  - `struct SurvivalStats` containing sorted ages, entry/exit indices, Fine–Gray risk weights, censoring KM estimates, event indicators, and helper arrays for cumulative sums.
+  - `fn build_survival_stats(data: &SurvivalTrainingData, prior_weights: &Array1<f64>) -> SurvivalStats` performing:
+    1. Sort indices by `age_exit`.
+    2. Compute Kaplan–Meier censoring weights `G(t)` treating competing events as censoring.
+    3. Precompute for each subject the set of event time positions they influence; encode as `Vec<Range<usize>>` or compressed sparse row arrays to evaluate `Σ s_i(t_k)` quickly.
+    4. Precompute `baseline_entry_matrix = B(u_entry)` and `baseline_exit_matrix = B(u_exit)`; store to avoid recomputation per IRLS iteration.
+- Provide methods on `SurvivalStats` to update risk-set denominators given current `eta`, returning `RiskContributions` with per-event denominators, subject-level cumulative `s_i` sums, and the working weights `W_i`.
+
+## 5. Design and Penalty Construction
+### 5.1 Extending `ModelLayout`
+- Add new enum variant `ModelFamily::SurvivalFineGray` stored in `ModelConfig`. Extend `ModelLayout` to track:
+  - `baseline_exit_design: Array2<f64>` and `baseline_entry_design: Array2<f64>`.
+  - Column ranges for baseline smooth, covariate shifts, tensor interactions.
+  - Penalty metadata: `baseline_penalty_id`, `pgs_age_penalty_id`, etc.
+- Modify `construction::build_design_and_penalty_matrices` to branch on `ModelFamily`. In survival mode:
+  - Build baseline spline using new helper `basis::log_age_spline(age_values, knots, degree, reference_age)`.
+  - Append covariate columns (PGS, sex, PCs) as dense columns.
+  - If `pgs_age_interaction` enabled, use existing `tensor_product_basis` function with log-age basis and PGS basis; ensure orthogonalization w.r.t. main effects (`interaction_orth_alpha` map in `ModelConfig`).
+  - Generate penalties using `difference_penalty` for baseline, `tensor_penalty` for interactions, and `null_shrinkage` as needed.
+- Update `ModelLayout::total_coeffs` and penalty assembly to include the new blocks. Provide functions to retrieve baseline column indices for downstream prediction routines.
+
+### 5.2 Null-space handling
+- Baseline smooth must have one degree of freedom removed to anchor the cumulative hazard. Implement via `basis::apply_reference_constraint` returning `(design_matrix, z_transform)` to drop the null direction. Store `z_transform` in `ModelConfig::sum_to_zero_constraints` under key `"baseline_age"` to reproduce predictions.
+- Ensure PGS and PC columns remain unpenalized and orthogonal to the baseline by subtracting weighted means (existing code already handles centering for parametric columns; confirm and extend if necessary).
+- For tensor interactions, reuse existing `interaction_orth_alpha` logic to ensure no leakage into main effects.
+
+## 6. Solver Integration
+### 6.1 Link function expansion
+- In `calibrate/model.rs`, add:
+```rust
+pub enum LinkFunction {
+    Logit,
+    Identity,
+    FineGrayRp,
+}
+```
+- Update all `match` statements (e.g., default iteration counts, scale estimation) to handle the new variant. For survival, set `min_iterations = 5` to guard against premature convergence due to complex likelihood surfaces.
+
+### 6.2 Working response computation
+- Add module `calibrate/survival/irls.rs` with:
+```rust
+pub fn update_fine_gray_vectors(
+    eta: &Array1<f64>,
+    stats: &SurvivalStats,
+) -> (Array1<f64>, Array1<f64>, Array1<f64>, FineGrayIterationState)
+```
+  returning `mu`, `weights`, `z`, and auxiliary state (risk denominators per event, cumulative hazard increments) used later for deviance and smoothing gradient calculations.
+- Modify `pirls::update_glm_vectors` to delegate to survival helper when `link == FineGrayRp`. Provide access to `SurvivalStats` via new field in `ModelLayout` or via closure capturing from `estimate::train_model`.
+- Ensure P-IRLS workspace caches working vectors sized to survival data. Some arrays (e.g., `delta_eta`) remain applicable without change.
+
+### 6.3 Deviance and gradient tracking
+- Add `calculate_survival_deviance(mu, stats, iter_state)` to compute `-2 ℓ`. Integrate into `calculate_deviance` by pattern matching on link. Store deviance per iteration for convergence diagnostics and REML objective.
+- Update gradient norm computation to use survival-specific residuals `U_i`. Provide fallback if all weights zero (e.g., due to zero events) with descriptive error.
+
+### 6.4 REML/LAML adjustments
+- In `estimate.rs`, treat `FineGrayRp` like other non-Gaussian links: LAML objective with log determinant adjustments. Ensure derivative of penalized deviance with respect to smoothing parameters uses the survival Hessian; `pirls.rs` already returns `penalized_hessian` and `edf`, so as long as survival branch populates them correctly no extra work is needed.
+- Disable Firth bias reduction in survival mode by erroring if `firth_bias_reduction=true && link==FineGrayRp` (document limitation).
+
+## 7. Prediction Pipeline
+### 7.1 Baseline evaluation
+- Store in `TrainedModel`:
+  - `age_transform: AgeTransform { a_min, delta, reference_age }`.
+  - `baseline_knots` and `baseline_degree` for reproducing spline basis.
+  - `baseline_z_transform` for constraint reproduction.
+  - `baseline_coefficients` subset of overall coefficient vector (extract via column ranges recorded in `ModelLayout`).
+  - Optional precomputed `baseline_cumulative_grid` (Array1) evaluated on a fine log-age grid to speed up interpolation.
+- Provide helper `fn evaluate_baseline_cumhaz(&self, age: f64) -> f64` performing: transform age to `u`, evaluate constrained basis, compute `H_0(age) = exp(B(u) θ)`, optionally using interpolation if grid available.
+
+### 7.2 Absolute risk computation
+- Extend `TrainedModel::predict` signature or add `predict_survival` method that accepts `SurvivalPredictionInputs` and returns `Array1<f64>` of absolute risk over the specified horizon(s).
+- Steps per individual:
+  1. Clamp `current_age` and `horizon_age` within `[a_min + δ, a_max + margin]`, using hull guard to detect extrapolation.
+  2. Evaluate the target-event baseline cumulative hazard at both ages: `Λ0_target(current)` and `Λ0_target(horizon)`. Reuse the stored Kaplan–Meier curve for competing events to obtain `CIF_competing(current)`.
+  3. Compute covariate shift `s = exp(x^⊤ β)` using stored coefficients (PGS, sex, PCs, optional PGS×age evaluated at `horizon_age`).
+  4. Convert to subject-specific cumulative incidences: `CIF_target(age) = 1 - exp(-Λ0_target(age) ⋅ s)` for both `age = current` and `age = horizon`.
+  5. Conditional absolute risk for the interval is `(CIF_target(horizon) - CIF_target(current)) / max(1e-12, 1 - CIF_target(current) - CIF_competing(current))`, ensuring the probability is conditioned on having avoided both the target and competing events up to `current_age`.
+  6. Return the conditional risk, optionally along with `linear_predictor` and `std_error` if caller requests.
+- Provide convenience for multiple horizons: accept `horizon_grid: &[f64]` and vectorize evaluation by reusing baseline grid and covariate shifts.
+
+### 7.3 Integration with calibrator
+- When calibrator enabled, compute diagnostics in survival context:
+  - Baseline absolute risk (`CIF`),
+  - Approximate variance of `η` using diagonal of inverse penalized Hessian and delta method to get variance of `CIF`,
+  - Hull distance in extended feature space (PGS, PCs, age).
+- Build calibrator design using existing routines but mark link as `Logit` to keep outputs in (0,1). Provide new calibrator feature generator `compute_survival_alo_features` mirroring `compute_alo_features` but using survival diagnostics.
+- Apply calibrator at prediction time by mapping base CIF to logits, adding calibrator correction, and mapping back via logistic transform.
+
+## 8. CLI and Configuration
+- Add CLI enum `ModelKind { Binary, Continuous, Survival }` in `cli` crate. Update argument parser to accept `--survival` or `--model-kind survival`.
+- In training command:
+  - Route to survival loader and builder when `ModelKind::Survival`.
+  - Expose additional flags: `--baseline-knots`, `--baseline-degree`, `--pgs-age-interaction`, `--no-competing` (if user wants to drop competing events), `--no-calibrator` (already supported), `--horizon` for evaluation summary.
+- In inference command:
+  - Require input columns `current_age` and `horizon_age` (or `years_ahead`), verifying numeric and finite.
+  - Output CSV with columns `sample_id`, `current_age`, `horizon_age`, `absolute_risk`, `calibrated_absolute_risk` (if calibrator active), `std_error` (optional).
+
+## 9. Implementation Sequence & Milestones
+1. **Design groundwork**
+   - Introduce `ModelFamily::SurvivalFineGray` and `LinkFunction::FineGrayRp` scaffolding without behavior. Update serialization/tests to ensure round-trip.
+2. **Data ingestion**
+   - Implement survival data loader, validations, and unit tests covering missing columns, invalid codes, degenerate datasets.
+3. **Survival statistics module**
+   - Build `SurvivalStats` with Kaplan–Meier weights and risk-set structures. Validate via tests comparing to manual calculations on toy datasets.
+4. **Baseline spline support**
+   - Extend `basis.rs` with log-age helper and reference constraints. Add tests verifying monotonic cumulative hazard when coefficients increase.
+5. **Model layout adjustments**
+   - Modify `construction.rs` to assemble survival design/penalties. Ensure compatibility with existing logistic/Gaussian cases through regression tests.
+6. **P-IRLS integration**
+   - Implement `update_fine_gray_vectors`, hook into `pirls.rs`, and verify convergence on toy survival dataset (simulate via Python/R). Inspect deviance trajectory for monotonic decrease.
+7. **REML coupling**
+   - Enable smoothing parameter optimization; ensure gradients finite using numerical checks. Compare λ estimates to R `rstpm2` on matched dataset.
+8. **Prediction API**
+   - Add survival scoring path, baseline evaluation, CIF computation, and hull extension. Provide unit tests for monotonicity in age and horizon.
+9. **Calibrator adjustments**
+   - Extend feature extraction and calibrator design for survival. Validate that calibrator training converges and reduces Brier score on held-out simulation.
+10. **CLI integration & documentation**
+    - Wire CLI options, update README, and provide usage examples.
+11. **End-to-end validation**
+    - Full training/inference pipeline on synthetic dataset with known CIF; compare predictions vs. R reference to <1e-3 absolute difference.
+    - Stress tests: heavy censoring, all competing events, extremely late entry ages.
+
+## 10. Testing Strategy
+- **Unit tests**
+  - `data::load_survival_training_data`: invalid event labels, negative ages, exit < entry, no events.
+  - `survival::build_survival_stats`: confirm risk-set counts match brute-force enumeration on small dataset (≤5 subjects).
+  - `survival::update_fine_gray_vectors`: compare gradient/Hessian to finite differences.
+  - `basis::log_age_spline`: ensure evaluation at reference age yields zero contribution after constraint.
+- **Property tests**
+  - Simulate data from known RP model (use Python or Rust to generate). Fit survival model and assert estimated coefficients within tolerance (e.g., |β_est - β_true| < 0.05) and CIF predictions within ±0.01.
+  - Randomly permute input order to ensure invariance (risk sets rely on sorting; tests ensure stable results).
+- **Integration tests**
+  - CLI-driven training/inference with sample TSVs; confirm output schema and calibration.
+  - Compare to R `rstpm2`/`cmprsk` by exporting training data and verifying log-likelihood and CIF at several ages.
+- **Performance benchmarks**
+  - Benchmark training on synthetic dataset with 100k subjects to ensure runtime scales sub-quadratically and memory remains within reasonable bounds. Profile risk-set preprocessing to identify bottlenecks.
+- **Calibrator validation**
+  - Evaluate Brier score and calibration plots before/after calibrator on validation split. Confirm calibrator does not violate monotonicity with age by checking CIF increases with horizon after calibration.
+
+## 11. Performance and Numerical Stability Considerations
+- Precompute and reuse `exp(η)` and risk-set denominators within each IRLS iteration to avoid repeated exponentiation.
+- Implement Kahan summation or pairwise summation for risk-set accumulations to reduce floating-point error when risk sets are large.
+- Guard against zero denominators by adding floor `1e-12` to risk sums; report descriptive error if all weights vanish (indicative of malformed data).
+- Apply step-halving when deviance increases or when cumulative hazard becomes non-monotonic (detected via negative increments). Reuse existing step-halving infrastructure in `pirls.rs`.
+- Extend hull to include age axis: build 3D convex hull over `(PGS, PC1..PCk, age_exit)` or compute axis-aligned guard with signed distance function to detect extrapolation. Reuse `hull::PeeledHull` by augmenting input matrix with age column.
+
+## 12. Documentation & Communication
+- Update `calibrate/README.md` with a dedicated survival section covering mathematical formulation, data requirements, CLI usage, and prediction semantics.
+- Add Rustdoc comments to new structs (`SurvivalTrainingData`, `SurvivalStats`, `AgeTransform`, etc.) clarifying the Fine–Gray formulation and referencing key equations.
+- Provide example workflow in `examples/` (e.g., `examples/survival/README.md`) demonstrating training on synthetic data and scoring multiple horizons.
+- Coordinate with maintainers to ensure release notes highlight survival support and note limitations (single competing event type, static covariates).
+
+## 13. Future Extensions (Post-MVP)
+- Multi-state extension supporting >1 competing risk by fitting separate subdistribution hazards with shared baseline or cause-specific baselines.
+- Support for time-varying covariates by interval-splitting each subject and reusing the counting-process representation.
+- Stratified baselines (e.g., by sex) by adding additional baseline smooth blocks with shared penalties.
+- Explore alternative link functions (e.g., log cumulative odds) for different risk interpretations.
+- GPU-accelerated risk-set computations if profiling reveals bottlenecks.
+

--- a/plan/survival_8362.md
+++ b/plan/survival_8362.md
@@ -1,0 +1,275 @@
+# Royston–Parmar Fine–Gray Survival Integration Plan
+
+## 1. Context, Goals, and High-Level Design Principles
+- **Objective.** Extend the penalized GAM infrastructure in `calibrate/` to fit Royston–Parmar flexible parametric survival models with Fine–Gray subdistribution hazards, using attained age as analysis time and supporting absolute risk predictions between a current age and user-specified horizons.
+- **Constraints.**
+  - Reuse the existing P-IRLS + REML machinery in `calibrate/pirls.rs` and `calibrate/estimate.rs` to optimize smoothing parameters jointly with regression coefficients.
+  - Maintain backwards compatibility for existing logistic and Gaussian workflows (`LinkFunction::{Logit, Identity}`) while introducing survival as an additional analysis mode.
+  - Keep serialization/deserialization stable via `calibrate/model.rs::TrainedModel`; new fields must be optional/defaulted for previously trained models.
+  - Integrate with the existing post-hoc calibrator (`calibrate/calibrator.rs`) so survival risk outputs can be optionally calibrated in the same pipeline.
+- **Design heuristics.**
+  - Introduce a **family abstraction** that decouples the P-IRLS core from distribution-specific math. Logistic and Gaussian become implementations; survival is a third implementation.
+  - Treat survival as a **new model variant** with its own response schema, design blocks, and prediction interface, rather than overloading `LinkFunction` semantics.
+  - Ensure the baseline log cumulative hazard spline is handled with the same penalty infrastructure (difference penalties, null/range splits) for consistency.
+  - Preserve numerical stability by carefully evaluating spline basis and derivatives on the log-age scale and by caching baseline evaluations for scoring.
+
+## 2. Mathematical Specification
+### 2.1 Parameterization
+- Let attained age be the time scale. For subject *i*: entry age `a_i`, exit age `b_i`, event indicator `d_i ∈ {0,1}`, competing-risk indicator `c_i ∈ {0,1}` (1 if competing event occurred at `b_i`).
+- Define log-time variable `u = log(b_i)`; for left-truncated contributions use both `log(a_i)` and `log(b_i)`.
+- Baseline cumulative subdistribution hazard: `log H_0(u) = Σ_j γ_j B_j(u)` where `{B_j}` is a B-spline basis on the log-age scale. Penalty is applied to γ via difference matrix as in existing smooth terms.
+- Linear predictor: `η_i(u) = log H_0(u) + x_i^T β + z_i(u)^T θ`, where
+  - `x_i` includes baseline covariates (PGS main effect, PCs, optional sex) with proportional hazard interpretation.
+  - `z_i(u)` can encode time-varying effects such as PGS×age (basis for interaction). Begin with optional PGS×log-age smooth.
+- Cumulative subdistribution hazard: `H_i(u) = exp(η_i(u))`.
+- Subdistribution hazard: `h_i(u) = H_i(u) * (dη_i(u)/du) / exp(u)` where `dη_i(u)/du = Σ_j γ_j B'_j(u) + (∂z_i(u)/∂u)^T θ`. Time-varying covariate bases must therefore supply their derivatives with respect to `u = log(age)`; when no time-varying terms are used the second summand vanishes.
+
+### 2.2 Likelihood Contributions
+- Use the Fine–Gray pseudo partial likelihood expressed over distinct event ages \(t_k\). For each such age, define the Fine–Gray risk set \(R(t_k) = \{ i : a_i \le t_k,\; d_i(t_k^-) = 0 \}\) and censoring weight \(G_i(t_k)\) (Kaplan–Meier for censoring/competing events evaluated just prior to \(t_k\)).
+- The log-likelihood contribution for the target event that occurs at \(t_k\) for individual \(i\) is
+  \[
+  \ell_k = w_i\Big[ \eta_i(t_k) - \log \Big( \sum_{j \in R(t_k)} w_j\,G_j(t_k)\,\exp\{\eta_j(t_k)\} \Big) \Big],
+  \]
+  where \(\eta_i(t)\) is the log cumulative subdistribution hazard evaluated at age \(t\) using the current coefficients.
+- Individuals who experience a competing event remain in the risk set with the same \(G_j(t_k)\) weighting; censored individuals simply stop contributing once they exit the risk set. There is **no** additional `log S_i` term for the individual event—the denominator above already captures survival of the Fine–Gray risk set.
+- Left truncation is handled by ensuring \(R(t_k)\) includes only subjects with \(a_i \le t_k\); no extra additive term is required because the risk set definition already conditions on survival to the entry age.
+- The total weighted log-likelihood is \(\ell = \sum_k \ell_k\), summed over observed target-event ages.
+
+### 2.3 Gradients / IRLS quantities
+- Let \(Y_i(t_k) = 1\) if subject \(i\) is in the Fine–Gray risk set at \(t_k\) and 0 otherwise, and define
+  \[
+  p_i(t_k) = \frac{w_i\,G_i(t_k)\,\exp\{\eta_i(t_k)\}}{\sum_{j \in R(t_k)} w_j\,G_j(t_k)\,\exp\{\eta_j(t_k)\}}.
+  \]
+- The score with respect to \(\eta_i\) accumulates contributions across all event ages where \(i\) is at risk:
+  \[
+  U_i = \sum_{k} w_i\,Y_i(t_k)\big[\mathbf{1}\{i \text{ has event at } t_k\} - p_i(t_k)\big].
+  \]
+  This captures the observed-minus-expected counting-process structure characteristic of the Fine–Gray pseudo-likelihood.
+- The negative Hessian is the sum of risk-set covariance terms:
+  \[
+  H = \sum_k X_{R(t_k)}^\top\Big( \operatorname{diag}(p(t_k)) - p(t_k) p(t_k)^\top \Big) X_{R(t_k)},
+  \]
+  where \(X_{R(t_k)}\) denotes the design matrix rows for subjects in \(R(t_k)\).
+- Implement P-IRLS by letting the survival family return \(g = U\) and \(H\) for the current coefficients. For computational efficiency retain per-event cached vectors \(p(t_k)\) and reuse the shared Faer linear solvers to solve \((H + S)\,\delta = g\). Because \(\operatorname{diag}(p) - p p^\top\) is positive semi-definite, adding the penalty ensures the working weights remain non-negative.
+- Derivatives of the hazard derivative (terms involving \(s'(u)\)) still need to be provided for evaluating \(\eta_i(t_k)\); precompute spline derivatives exactly as outlined in §2.1.
+
+### 2.4 Absolute Risk Predictions
+- Evaluate the cumulative incidence function \(F(t) = 1 - \exp\{-H(t)\}\) for the fitted subdistribution hazard at both the current age \(t_0\) and the future horizon \(t_1\).
+- The unconditional absolute risk over \([t_0, t_1]\) is \(F(t_1) - F(t_0) = \exp\{-H(t_0)\} - \exp\{-H(t_1)\}\).
+- When the consumer wants the probability conditional on having avoided both the target event and competing events up to \(t_0\), divide by the remaining survival mass: \(\text{Risk}_{\text{cond}} = [F(t_1) - F(t_0)] / [1 - F(t_0) - F_{\text{comp}}(t_0)]\), where \(F_{\text{comp}}\) is the cumulative incidence for the competing endpoint.
+- Cache basis evaluations for \(t_0\) and \(t_1\) to reuse across batch predictions; the spline metadata needed for this (knots, degrees, centering constants) must be serialized with the model artifacts as noted in later sections.
+
+## 3. Data & Schema Extensions (`calibrate/data.rs`)
+### 3.1 Input Columns
+- Extend training TSV schema to include:
+  - `age_start`: optional (defaults to baseline age if not provided). Required when left truncation occurs.
+  - `age_stop`: required (event/censor age).
+  - `event`: 1 if event of interest, 0 otherwise.
+  - `competing`: 1 if competing event occurred at `age_stop`, 0 otherwise.
+- Validate mutual exclusivity: `event` and `competing` cannot both be 1.
+- Ensure `age_stop > age_start` and both are finite; allow inclusive start for immediate entry.
+- Optionally support `left_trunc = false` path where `age_start` column missing → default to minimum age in dataset minus small ε for stability.
+- For prediction scoring API, add `current_age` column optional (if not provided, inference caller passes age per query) and no event/censor columns.
+
+### 3.2 Data Structures
+- Introduce `enum AnalysisMode` in `calibrate/data.rs` or new module to indicate standard vs survival dataset.
+- Add `SurvivalTrainingData` struct with fields:
+  ```rust
+  pub struct SurvivalTrainingData {
+      pub age_start: Array1<f64>,
+      pub age_stop: Array1<f64>,
+      pub event: Array1<f64>, // binary 0/1
+      pub competing: Array1<f64>,
+      pub p: Array1<f64>,
+      pub sex: Array1<f64>,
+      pub pcs: Array2<f64>,
+      pub weights: Array1<f64>,
+  }
+  ```
+- Modify `load_training_data` to detect presence of survival columns and return `TrainingDataVariant::Standard(TrainingData)` or `TrainingDataVariant::Survival(SurvivalTrainingData)`.
+- Update CLI (`cli/main.rs::train`) to branch on analysis mode. Survival-specific CLI options (baseline knot count, etc.) should become flags.
+
+## 4. Model Configuration & Serialization (`calibrate/model.rs`)
+### 4.1 Extended Config
+- Introduce `enum ModelFamily { Standard(LinkFunction), Survival(SurvivalSpec) }` within `ModelConfig`.
+- `SurvivalSpec` should contain:
+  - `baseline_basis: BasisConfig` (knots/degree on log-age scale).
+  - `time_range: (f64, f64)` storing training age range for knot placement.
+  - `pgs_time_interaction: Option<BasisConfig>` and metadata for optional time-varying PGS effect.
+  - `penalty_order_baseline: usize` for difference penalty on baseline spline.
+  - `hazard_offset: Option<f64>` reserved for future (set 0 now).
+  - `fine_gray: bool` (default true) to allow toggling to cause-specific if needed.
+- Maintain `link_function` for backward compatibility but mark deprecated path when `family` is Standard; when `family` is Survival, ignore `link_function` and set to sentinel (maybe keep but set to Identity?). Add serde attributes to keep old models loading (`#[serde(default)]`).
+- Update `TrainedModel::predict*` to branch: standard predictions use existing path; survival predictions delegate to new functions (see Section 8).
+- Store baseline spline coefficients separately in `MappedCoefficients` or extend structure with `Option<SurvivalCoefficients>` containing:
+  ```rust
+  pub struct SurvivalCoefficients {
+      pub baseline: Vec<f64>,
+      pub baseline_knot_vector: Array1<f64>,
+      pub baseline_penalty_transform: Array2<f64>,
+      pub pgs_main: Vec<f64>,
+      pub pcs: HashMap<String, Vec<f64>>,
+      pub pgs_time: Option<Vec<f64>>,
+  }
+  ```
+  Keep logistic fields for compatibility; restructure mapping helpers to populate whichever variant is active.
+
+### 4.2 Layout Consistency Checks
+- Extend `TrainedModel::rebuild_layout_from_config` to understand survival layout: baseline block first, PGS/PC blocks next, optional interaction block. Ensure `ModelLayout` is enhanced (Section 5) to represent survival terms.
+- When loading older models without survival info, maintain existing behavior. When survival model missing calibrator/hull, allow optional.
+
+## 5. Design & Penalty Construction (`calibrate/construction.rs`)
+### 5.1 New Layout Support
+- Introduce new `TermKind::BaselineSpline`, `TermKind::SurvivalCovariate`, `TermKind::TimeInteraction` in `ModelLayout` to describe survival-specific column spans.
+- Extend `build_design_and_penalty_matrices` to accept `TrainingDataVariant` and `ModelConfig::family`:
+  - For survival: evaluate baseline B-spline on `log(age_stop)` and `log(age_start)`; also compute derivative basis `B'(u)` for log-hazard derivative needed later (store for reuse by `pirls` in `ModelLayout` or extra arrays).
+  - Apply sum-to-zero constraint for baseline? For log cumulative hazard, identifiability is provided by intercept; need to fix intercept by centering or by dropping final coefficient. Strategy: enforce mean-zero on baseline to avoid confounding with intercept; store transformation matrices (Z) in config.
+  - Build penalty for baseline via `create_difference_penalty_matrix` using `penalty_order_baseline` and convert to block in `PenaltyMatrix`.
+  - For PGS main effect and PCs: reuse existing basis + penalty infrastructure (range/null transforms). For survival, these effects multiply hazard; treat them as linear terms (no additional smoothing) or re-use smoothing as before. Most likely keep PGS/PC smooths same as logistic but interpret as log-H scale; ensure penalty structures identical.
+  - Optional PGS×age interaction: build tensor-product between PGS range basis and baseline log-age basis; use anisotropic penalty to allow separate smoothing on time dimension vs PGS dimension. Represent as new penalty block in layout.
+- Provide derivative basis matrix `baseline_deriv` to PIRLS (maybe store inside `ModelLayout` or `SurvivalWorkspace` struct). This matrix is evaluation of `∂B/∂u` on log-age. Need ability to evaluate at both `age_start` and `age_stop`; store both arrays.
+
+### 5.2 Balanced Penalty Roots / Constraints
+- Extend `compute_penalty_square_roots` and `create_balanced_penalty_root` to handle survival baseline penalty. No conceptual change; just ensure new block included.
+- Ensure sum-to-zero constraint logic doesn’t drop baseline intercept inadvertently; the baseline needs intercept to capture cumulative hazard scale. Implement `apply_sum_to_zero_constraint` with caution: probably maintain intercept but impose roughness penalty only on higher-order components (like difference penalty). Document reasoning inside plan.
+
+## 6. PIRLS & REML Adaptation (`calibrate/pirls.rs`, `calibrate/estimate.rs`)
+### 6.1 Family Abstraction
+- Introduce trait in `calibrate/pirls.rs`:
+  ```rust
+  pub trait PirlsFamily {
+      fn initialize_eta(
+          y: ArrayView1<f64>,
+          offset: ArrayView1<f64>,
+      ) -> Array1<f64>;
+      fn mu_from_eta(eta: ArrayView1<f64>) -> Array1<f64>;
+      fn compute_working_quantities(
+          eta: ArrayView1<f64>,
+          y: ArrayView1<f64>,
+          offset: ArrayView1<f64>,
+          weights: ArrayView1<f64>,
+          aux: &FamilyWorkspace,
+      ) -> (Array1<f64>, Array1<f64>, f64, Array1<f64>);
+      fn deviance(
+          y: ArrayView1<f64>,
+          mu: ArrayView1<f64>,
+          offset: ArrayView1<f64>,
+      ) -> f64;
+  }
+  ```
+- `FamilyWorkspace` can hold scratch buffers per family. For survival, needs `baseline_stop`, `baseline_start`, derivative arrays, hazard caches.
+- Refactor logistic and identity flows to implement trait; existing code for weights/z/residuals migrates into `BinomialFamily` and `GaussianFamily` modules.
+
+### 6.2 Survival Family Implementation
+- Implement `RoystonParmarFineGrayFamily` with:
+  - Inputs: `ModelLayout` should provide arrays `baseline_stop_design`, `baseline_start_design`, `baseline_stop_deriv`, `baseline_start_deriv` to compute `H(b)` and `H(a)` for each subject using current β.
+  - Additional data: `event`, `competing`, `weights` from `SurvivalTrainingData`.
+  - `initialize_eta`: start from log cumulative hazard based on Nelson-Aalen style estimator or start with `η = log(-log(1 - empirical CIF))`. Simpler: start from baseline-only fit (γ initial) by solving for intercept using events/weights or using log of (events / risk). Provide fallback constant.
+  - `compute_working_quantities`: For each observation compute `H_stop = exp(η_stop)` and `H_start = exp(η_start)` using matrix multiplication `X_stop dot β`, `X_start dot β`. Keep both because design matrix is same for stop and start but offset differs (left truncation subtract). Evaluate derivatives `s'(u)` using derivative design times coefficients for baseline block only; combine to compute hazard `h_stop`. Provide stable evaluation by clamping `η` to [-700, 700].
+  - Compute gradient `g_i` and weights `W_i` per Section 2.3. Return `z = eta + g/W`, `sqrt_w = sqrt(weights * sample_weight)`. Provide `mu` analog as `H_stop` for deviance computation.
+  - Provide log-likelihood contributions for deviance (deviance = -2 * weighted log-likelihood). Use aggregated sums to ensure numerical stability (Kahan summation).
+  - Provide Firth-like adjustments? Not required initially but keep path for potential future bias reduction.
+
+### 6.3 REML Outer Loop Changes (`calibrate/estimate.rs`)
+- When `ModelFamily::Survival`, `internal::RemlState::new` should accept survival-specific data (two design matrices for stop/start?). Options:
+  - Build single combined design `X` on stop times; incorporate left truncation via offset vector stored separately; treat contributions inside family functions rather than in `X`. Keep `X` as the standard design for stop times. Provide extra arrays in `RemlState` for start times.
+- Update REML log-likelihood computation to use survival deviance and penalty term; derivative/hessian computations rely on `PirlsResult` outputs unaffected by family abstraction.
+- Ensure Gaussian scale profiling is skipped in survival branch.
+- Update gradient check/test harness to handle `ModelFamily::Survival` by verifying finite values.
+
+## 7. Training Pipeline Integration (`calibrate/estimate.rs::train_model`)
+- Accept `TrainingDataVariant`. For survival branch:
+  1. Build design/penalty via new path.
+  2. Initialize `RemlState` with survival-specific data.
+  3. Run REML optimization as usual.
+  4. Map coefficients into `SurvivalCoefficients` using new layout mapping helper.
+  5. Skip PHC hull (not meaningful in survival) or redesign hull to operate on `(PGS, PCs)` ignoring age; consider storing for calibrator features (PGS, PCs) only if beneficial.
+  6. Compute penalized Hessian and store for inference (used for variance of η if needed). Provide optional ability to store baseline evaluation grid for faster scoring.
+- Update logging messages to mention survival mode and dataset size.
+
+## 8. Prediction & Scoring API (`calibrate/model.rs`)
+### 8.1 Survival Prediction Methods
+- Add methods:
+  ```rust
+  impl TrainedModel {
+      pub fn predict_survival_eta(
+          &self,
+          p: ArrayView1<f64>,
+          sex: ArrayView1<f64>,
+          pcs: ArrayView2<f64>,
+          ages: ArrayView1<f64>,
+      ) -> Result<Array1<f64>, ModelError>;
+
+      pub fn absolute_risk(
+          &self,
+          p: ArrayView1<f64>,
+          sex: ArrayView1<f64>,
+          pcs: ArrayView2<f64>,
+          current_age: f64,
+          horizon_age: f64,
+      ) -> Result<f64, ModelError>;
+  }
+  ```
+- Implement helper to evaluate baseline spline and derivative at arbitrary ages using saved knots and coefficient transforms.
+- `predict_detailed` should branch: in survival mode, return tuple `(eta_stop, risk, Array1::zeros, None)` where `risk` is e.g. `1 - exp(-ΔH)` over a default horizon; document difference. For compatibility, maybe keep method returning CIF at `age_stop` for training data predictions; provide new method for horizon-specific risk.
+
+### 8.2 Batch Scoring API
+- Add struct in new module `calibrate/survival/predict.rs` exposing function to compute vectorized absolute risks for arrays of horizons. Accept arrays of `current_age`, `horizon`, `pgs`, `pcs`. Provide ability to reuse basis evaluation caching for repeated queries.
+- Update CLI `infer` to support `--current-age` and `--horizon` flags (or TSV columns) for survival models. Output should include baseline CIF and optionally hazard.
+
+### 8.3 Calibration Integration
+- For survival, calibrator should operate on absolute risk predictions (bounded [0,1]). Reuse logistic calibrator by applying logit transform of risk as `pred`. Provide SEs via delta method using Hessian (if stored) or fallback to zero. Update calibrator input building to handle survival-specific features (PGS, age, risk) and to optionally include `current_age` for hull distance.
+- Ensure `set_calibrator_enabled` flag applies uniformly.
+
+## 9. CLI & User-Facing Changes (`cli/main.rs`)
+- Add CLI flags to specify survival mode explicitly (`--analysis survival`) or auto-detect based on columns.
+- Introduce survival-specific hyperparameters: `--baseline-knots`, `--baseline-degree`, `--baseline-penalty-order`, `--pgs-age-knots`, etc.
+- Update `train` command to build `SurvivalSpec` from CLI options. When survival, skip auto-detecting `LinkFunction` and set `ModelFamily::Survival`.
+- Update `infer` command to support survival models: accept `--current-age`, `--horizon`, or TSV with `current_age` column. Print risk estimates with optional calibration.
+- Provide helpful error messages if user requests survival scoring from non-survival model or vice versa.
+
+## 10. Testing & Validation Strategy
+### 10.1 Unit Tests
+- **Basis derivatives:** Add tests in `calibrate/basis.rs` verifying new derivative evaluator against finite differences on known spline (log-age grid).
+- **Family math:** Unit-test `RoystonParmarFineGrayFamily` weight/gradient computation on synthetic data with known hazard to ensure gradient/Hessian match numerical differentiation.
+- **Prediction identity:** Confirm `absolute_risk` integrates to zero horizon and matches expected CIF for simple exponential baseline (use known parameters).
+- **Serialization:** Round-trip survival `TrainedModel` through TOML to ensure optional fields default correctly.
+
+### 10.2 Integration Tests
+- Add tests under `calibrate/tests/` comparing fitted survival model against reference (R `rstpm2` or `flexsurv`). Use small dataset with known CIF to verify parameter recovery within tolerance.
+- Validate Fine–Gray competing risks by simulating dataset where competing events dominate; confirm predictions match numerical integration of CIF.
+- Regression tests for existing logistic/Gaussian flows to ensure no changes in outputs; reuse existing harness (e.g., `calibrate/tests/run_calibrate.py`).
+
+### 10.3 Performance & Numerical Diagnostics
+- Benchmark training runtime vs dataset size; ensure derivative evaluation and hazard computation vectorized and cache-friendly.
+- Add logging of min/max `η`, `H`, weights to detect overflow; clamp values to avoid NaNs.
+- Consider precomputing baseline basis for unique ages to reduce repeated evaluation.
+
+## 11. Performance Considerations
+- Baseline B-spline evaluation on log-age: use existing caching infrastructure in `basis.rs` keyed by knot vector + derivative order (extend cache key to include derivative flag).
+- For left truncation, maintain separate design matrices for start and stop; share coefficient vector to avoid duplication. Represent as `Array2` views inside `RemlState` to prevent repeated allocation.
+- Use `ndarray::Zip` to compute gradient/weights in survival family to maximize SIMD and minimize temporaries.
+- For scoring multiple horizons, precompute basis per unique horizon (store in `HashMap<f64, Arc<Array1<f64>>>`) or use vector evaluation to avoid repeated B-spline evaluation per individual.
+
+## 12. Documentation & Examples
+- Update `README.md` and `calibrate/README.md` to describe survival mode, required columns, CLI usage, and prediction semantics.
+- Provide worked example in `examples/` showing training survival model on synthetic dataset, scoring absolute risk, and comparing to standard logistic model.
+- Document mathematical derivations (Section 2) in new markdown under `docs/` or extend plan after implementation.
+
+## 13. Validation Checkpoints & Rollout Sequence
+1. **Refactor PIRLS family abstraction** (ensure existing models still fit).
+2. **Implement basis derivative support** with tests.
+3. **Add survival data schema and config structures**; ensure CLI can detect mode.
+4. **Implement survival design construction** and extend `ModelLayout`.
+5. **Implement survival family** and integrate with REML.
+6. **Fit basic survival model without competing risks**; validate vs exponential baseline.
+7. **Add Fine–Gray contributions**; validate on simulated data.
+8. **Wire prediction API** for absolute risk and verify with training-time predictions.
+9. **Integrate calibrator** and update CLI outputs.
+10. **Expand tests/documentation** and run full CI/regression suite.
+
+## 14. Future Extensions Considered
+- Time-varying covariates: design can be extended by splitting intervals; plan preserves ability by structuring start/stop arrays and by not assuming single record per person.
+- Stratified baselines: extend `SurvivalSpec` with optional factor variable that replicates baseline spline per stratum.
+- Alternative survival families (cause-specific hazards, accelerated failure time) can implement additional `PirlsFamily` variants without disturbing infrastructure.
+


### PR DESCRIPTION
## Summary
- restore the survival planning documents on the feature branch
- correct the Fine–Gray pseudo-likelihood narrative and conditional risk formulas in the survival plans

## Testing
- not run (markdown-only changes)


------
https://chatgpt.com/codex/tasks/task_e_690103bd97d8832eba83280934d9bf91