### PR TITLE
Fix survival plan formula mistakes

### DIFF
--- a/plan/survival_48271.md
+++ b/plan/survival_48271.md
@@ -107,7 +107,7 @@ For subject `i` define:
 For coefficient block `β`:
 - Score contribution:
   ```
-  g_i = δ_i * x_i^{exit} - ω_i * ΔH_i * x_i^{exit} + ω_i * exp_entry_i * x_i^{entry}
+  g_i = δ_i * x_i^{exit} - ω_i * exp_term_i * x_i^{exit} + ω_i * exp_entry_i * x_i^{entry}
   + δ_i * J_i,
   ```
   where `ω_i` already includes censoring/Fine–Gray weighting, and `J_i` captures derivatives from the hazard derivative term:
@@ -116,7 +116,7 @@ For coefficient block `β`:
   ```
 - Hessian contribution (negative definite):
   ```
-  H_i = ω_i * ΔH_i * x_i^{exit} x_i^{exit}^T - ω_i * exp_entry_i * x_i^{entry} x_i^{entry}^T
+  H_i = ω_i * exp_term_i * x_i^{exit} x_i^{exit}^T + ω_i * exp_entry_i * x_i^{entry} x_i^{entry}^T
         - δ_i * R_i,
   ```
   with `R_i` accounting for the second derivative of the log-derivative term.

--- a/plan/survival_59213.md
+++ b/plan/survival_59213.md
@@ -29,9 +29,9 @@
   - Represent survival log-likelihood via Poisson GLM on disaggregated intervals (Andersen-Gill). For Royston–Parmar, we can avoid data splitting by using analytical gradient/Hessian for log cumulative hazard basis. Use weights derived from risk set contributions at unique event ages.
   - Proposed approach: derive log-likelihood contributions
     \[
-    \ell = \sum_i \delta_i \{ \eta_i(a_i) + \log w_i \} - w_i \exp(\eta_i(a_i))
+    \ell = \sum_i \delta_i \, \eta_i(a_i) - w_i \, \exp(\eta_i(a_i))
     \]
-    where `w_i` encodes cumulative hazard exposure (requires computing interval integrals). For Fine–Gray, modify `w_i` using subdistribution weights.
+    where `w_i` encodes cumulative hazard exposure (requires computing interval integrals). For Fine–Gray, modify `w_i` using subdistribution weights but keep it outside of the logarithm so exposures only scale the cumulative hazard term.
   - Implement as custom `LinkFunction::RoystonParmar` that supplies `WorkingResponse` & `FisherWeights` to PIRLS given current `eta`.
   - Because existing PIRLS expects canonical links with known variance, extend PIRLS to accept trait-specific closures (see §5.2).
 

--- a/plan/survival_72953.md
+++ b/plan/survival_72953.md
@@ -40,10 +40,10 @@
 - The subdistribution hazard for subject `i` at age `t` is `λ_s(t | x_i) = d/dt Λ_s(t | x_i)`, where `Λ_s(t | x_i) = H_0(t) ⋅ exp(x_i^⊤ β)` with `x_i` representing covariates evaluated at age `t`. Because RP models parameterize `log Λ_s`, the linear predictor `η_i(t) = log Λ_s(t | x_i)`.
 - The Fine–Gray log-likelihood is:
   
-  `ℓ(β, θ) = Σ_{i: d_i=1} 
-     [η_i(a_exit_i) + log(Δ H_0(a_exit_i)) - log(Σ_{j} R_j(a_exit_i) Δ H_0(a_exit_i) exp(x_j^⊤ β))]`
+  `ℓ(β, θ) = Σ_{i: d_i=1}
+     [η_i(a_exit_i) - log(Σ_{j} R_j(a_exit_i) \exp(η_j(a_exit_i)))]`
   
-  where `R_j(t)` is the subdistribution risk indicator: 1 if `a_entry_j ≤ t` and the subject has neither experienced the target event before `t`, nor been censored; it remains 1 after a competing event but the covariate-dependent weight incorporates the cumulative incidence of the competing event. The term `Δ H_0` denotes the baseline cumulative hazard increment between entry and exit for each subject.
+  where `R_j(t)` is the subdistribution risk indicator: 1 if `a_entry_j ≤ t` and the subject has neither experienced the target event before `t`, nor been censored; it remains 1 after a competing event but the covariate-dependent weight incorporates the cumulative incidence of the competing event.
 - Implement the computational recipe used by Beyersmann et al.: maintain risk-set weights `W_j(t) = ℓ( max(t, a_exit_j) )` and apply the Fine–Gray cumulative incidence weighting factor `G_j(t)` (Kaplan–Meier of censoring/competing). Practical plan:
   1. Sort subjects by `a_exit`.
   2. Compute censoring weights `G_j(t)` by fitting Kaplan–Meier on the union of target + competing events, treating the target event as failure and competing as censoring for `G`.

--- a/plan/survival_8362.md
+++ b/plan/survival_8362.md
@@ -41,7 +41,7 @@
   - Censor/competing: `∂²ℓ/∂η² = -H_i(b_i)`.
 - Left truncation adds `+H_i(a_i)`.
 - Implement P-IRLS by treating `W_i = -∂²ℓ/∂η²` and `z_i = η_i - g_i/∂g/∂η`, where `g_i = ∂ℓ/∂η`. Because link is identity in η-space (η is natural parameter), the working response simplifies to `z_i = η_i + g_i/W_i`.
-- Need to ensure weights remain positive; `W_i = H_i(b_i) - H_i(a_i)` for truncated observations, which stays non-negative because `H_i` is monotone increasing in time. Guard against overflow by clamping exponentials.
+- Need to ensure weights remain positive; exit-time contributions give `W_i^{\text{exit}} = H_i(b_i)` and left-truncation adds a separate term `W_i^{\text{entry}} = H_i(a_i)` evaluated at the entry age. Both are non-negative because `H_i` is monotone increasing in time. Guard against overflow by clamping exponentials.
 - The derivative of log hazard `log[s'(u)/exp(u)]` influences the gradient; precompute `s'(u)` via derivative basis evaluation.
 
 ### 2.4 Absolute Risk Predictions


### PR DESCRIPTION
## Summary
- Correct gradient and Hessian formulas in `plan/survival_48271.md`
- Fix the Fine–Gray log-likelihood exposure handling in `plan/survival_59213.md`
- Repair the partial likelihood expression in `plan/survival_72953.md`
- Clarify P-IRLS weight contributions in `plan/survival_8362.md`

## Testing
- Not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_69010da82d04832ea9972d68a683e836