### PR TITLE
Adopt full-likelihood framing in survival plans

### DIFF
--- a/plan/survival_72953.md
+++ b/plan/survival_72953.md
@@ -10,7 +10,7 @@
 - **Data handling (`calibrate/data.rs`):** Strict schema loader for phenotype, score, sex, PCs, weights. Needs extension to ingest survival-specific columns (entry/exit age, event type) and to produce survival-specific data bundles.
 - **Basis and penalties (`calibrate/basis.rs`):** Provides B-spline basis construction, difference penalties, tensor product structures, and null-space constraints. We can reuse this machinery for the log-age baseline spline and for the PGS×age interaction smooth, but must add convenience wrappers for log-age transformations and monotonicity constraints.
 - **Design layout (`calibrate/construction.rs`):** Builds the block-structured design matrix and penalty map recorded in `ModelLayout`. Survival mode will require new block descriptors (baseline age spline, hazard shift covariates, optional tensor interactions) and updated null-space handling.
-- **Optimization (`calibrate/pirls.rs` & `calibrate/estimate.rs`):** Implements penalized iteratively reweighted least squares and nested REML optimization keyed off `ModelConfig::link_function`. We must add a new link variant with survival-specific working response and deviance calculations, plus support for the additional sufficient statistics demanded by the Fine–Gray partial likelihood (exit/entry cumulative hazards, hazard derivatives, Jacobian factors).
+- **Optimization (`calibrate/pirls.rs` & `calibrate/estimate.rs`):** Implements penalized iteratively reweighted least squares and nested REML optimization keyed off `ModelConfig::link_function`. We must add a new link variant with survival-specific working response and deviance calculations, plus support for the additional sufficient statistics demanded by the Fine–Gray full likelihood (exit/entry cumulative hazards, hazard derivatives, Jacobian factors).
 - **Model artifact (`calibrate/model.rs`):** Serializes `ModelConfig`, stores design metadata, and executes prediction with optional calibrator adjustments. Survival models must capture age transformations, baseline spline coefficients, competing-risk metadata, and a horizon-aware prediction path.
 - **Calibrator (`calibrate/calibrator.rs`):** Builds a secondary GAM using diagnostics from the base fit. Survival predictions will use different diagnostics (e.g., CIF standard errors, age-based hull distances) but can reuse the same P-IRLS machinery with tailored feature construction.
 - **Hull guard (`calibrate/hull.rs`):** Currently handles convex hulls in PGS/PC space; we will extend to include attained age for extrapolation safeguards.
@@ -33,31 +33,23 @@
   - Optional smooth interaction `f_{pgs×age}(PGS, u)` capturing non-proportional hazards. Implement as a tensor-product smooth with marginal bases: univariate B-spline in `PGS` (as already built for calibration) and the log-age spline `B(u)` with anisotropic penalties (existing `InteractionPenaltyKind::Anisotropic`). Center the interaction to ensure pure `ti()` semantics (requires extending current orthogonalization to include the new log-age marginal).
 - Whenever covariate effects vary with age, cache both the basis values and their derivatives with respect to log-age so that hazard derivatives include the term `(∂z_i(u)/∂u)^T θ`. The derivative is needed for subdistribution hazard evaluation, deviance diagnostics, and any variance calculations that involve `d/dt` of the cumulative hazard.
 
-### 3.4 Fine–Gray partial likelihood
+### 3.4 Fine–Gray full likelihood
 - For each subject `i`, define indicators and weights: `d_i = 1` when the target event occurs at `a_exit_i`, `0` otherwise; `c_i = 1` for competing events; and sample weight `w_i` (default 1).
-- Let `η_i(t)` denote the log cumulative subdistribution hazard evaluated with the Royston–Parmar basis. The subdistribution hazard on the age scale is `λ_i^*(t) = exp(η_i(t)) (∂η_i/∂t)(t)`, so derivative design matrices must supply `(∂η_i/∂t)(t)` at each risk-set evaluation time.
-- For each distinct target-event time `t_k`, build the IPCW-weighted risk denominator
+- Let `η_i(t)` denote the log cumulative subdistribution hazard evaluated with the Royston–Parmar basis. The subdistribution hazard on the age scale is `λ_i^*(t) = exp(η_i(t)) (∂η_i/∂t)(t)`, so derivative design matrices must supply `(∂η_i/∂t)(t)` at the exit age. Left truncation is handled by subtracting the cumulative hazard at entry rather than by pruning risk sets.
+- The per-subject log-likelihood for the full model is
 
-  `R(t_k) = Σ_{j: a_{entry,j} ≤ t_k} w_j G_j(t_k) exp(η_j(t_k)) (∂η_j/∂t)(t_k)`,
+  `ℓ_i = w_i [d_i (η_i(a_exit_i) + log (∂η_i/∂t)(a_exit_i)) - (H_i(a_exit_i) - H_i(a_entry_i))]`,
 
-  where `G_j(t_k)` is the Kaplan–Meier estimate of the censoring/competing survival evaluated just prior to `t_k`. Subjects who experienced a competing event before `t_k` stay in the sum through the weight `G_j(t_k)`.
-- The log-likelihood contribution for an event `i` at `t_k` is
-
-  `ℓ_i^{event} = w_i [η_i(t_k) + log (∂η_i/∂t)(t_k) - log R(t_k)]`.
-
-  Non-events (`d_i = 0`) do not contribute a numerator term but remain in all denominators for `t_k ≥ a_{entry,i}`. Left truncation is handled by excluding individuals with `a_{entry,i} > t_k` from the risk set and by tracking cumulative hazards at entry ages for diagnostics.
+  with `H_i(a) = exp(η_i(a))`. Competing events set `d_i = 0` but still subtract the cumulative hazard increment `ΔH_i = H_i(a_exit_i) - H_i(a_entry_i)` so Fine–Gray semantics are preserved inside a true likelihood objective.
 - Implementation steps:
-  1. Precompute design matrices `X_exit`, `X_entry` for `η` at exit and entry ages, alongside derivative matrices `D_exit`, `D_entry` that encode `(∂η/∂t)` via the chain rule on the log-age scale.
-  2. Precompute censoring survival `G_j(t_k)` for each distinct event age, storing it in a structure shared across IRLS iterations.
-  3. During each IRLS iteration evaluate `η_exit = X_exit β̃`, `dη_exit = D_exit β̃`, and form `H_exit = exp(η_exit)`; guard derivative values from numerical underflow via a small positive floor before taking logs.
-  4. Assemble risk-set weights `s_j(t_k) = w_j G_j(t_k) H_j(t_k) (∂η_j/∂t)(t_k) / R(t_k)` for use in score and Hessian calculations.
-- Define the augmented design row `\tilde{X}_i^{exit}(t) = X_i^{exit} + D_i^{exit} / (∂η_i/∂t)(t)` so differentiation of `log h_i(t)` and `log R(t)` share the same derivative-aware terms.
-- Score vector for coefficient block `β̃` at event time `t_k`:
-  - Event contribution: `U_i^{event} = w_i \tilde{X}_i^{exit}(t_k)`.
-  - Risk-set subtraction: `U_{risk}(t_k) = Σ_{j∈R_k} s_j(t_k) \tilde{X}_j^{exit}(t_k)`.
-  - Total score accumulates `Σ_{k} (U_i^{event} - U_{risk}(t_k))` over all event times plus penalty gradients.
-- Observed negative Hessian at `t_k` is `\tilde{X}_{R_k}^⊤ [diag(s(t_k)) - s(t_k) s(t_k)^⊤] \tilde{X}_{R_k}` plus the derivative block `Σ_{i∈D_k} w_i (D_i^{exit})^⊤ D_i^{exit} / (∂η_i/∂t)(t_k)^2`. Summing over event times and adding penalty matrices yields the full Hessian used inside PIRLS.
-- Deviance for diagnostics follows Fine–Gray practice: `D = -2 Σ_{k} Σ_{i∈D_k} w_i [η_i(t_k) + log (∂η_i/∂t)(t_k) - log R(t_k)]`. Track this per iteration for convergence checks and REML updates.
+  1. Precompute design matrices `X_exit`, `X_entry` for `η` at exit and entry ages, alongside derivative matrices `D_exit` that encode `(∂η/∂t)` via the chain rule on the log-age scale.
+  2. During each IRLS iteration evaluate `η_exit = X_exit β̃`, `η_entry = X_entry β̃`, and `dη_exit = D_exit β̃`; form `H_exit = exp(η_exit)` and `H_entry = exp(η_entry)` with safeguards for numerical underflow.
+  3. Compute cumulative hazard differences `ΔH = H_exit - H_entry` (clamped at zero) and the event hazard `λ_i^*(a_exit_i) = H_exit ⊙ dη_exit / a_exit_i` using cached Jacobians.
+  4. Accumulate score and Hessian contributions per observation rather than per risk set, reusing cached designs for both event and integral terms.
+- Define the augmented design row `\tilde{X}_i^{exit} = X_i^{exit} + D_i^{exit} / (∂η_i/∂t)(a_exit_i)` so differentiation of `log λ_i^*(a_exit_i)` collects both baseline and time-varying pieces.
+- Score vector for coefficient block `β̃` becomes `U = Σ_i w_i [d_i \tilde{X}_i^{exit} - ΔH_i X_i^{integral}]`, where `X_i^{integral}` reuses entry/exit design rows to approximate the cumulative hazard gradient.
+- Observed negative Hessian is `H = Σ_i w_i [d_i \tilde{X}_i^{exit ⊤} \tilde{X}_i^{exit} + ΔH_i X_i^{integral ⊤} X_i^{integral}]` plus penalty matrices. This dense matrix drops neatly into the PIRLS linear solves.
+- Deviance for diagnostics is `D = -2 Σ_i w_i [d_i log λ_i^*(a_exit_i) - ΔH_i]`; track it per iteration for convergence checks and REML updates.
 
 ## 4. Data Schema and Preprocessing
 ### 4.1 Survival data structs

--- a/plan/survival_8362.md
+++ b/plan/survival_8362.md
@@ -25,22 +25,22 @@
 - Subdistribution hazard: `h_i(u) = H_i(u) * (dη_i(u)/du) / exp(u)` where `dη_i(u)/du = Σ_j γ_j B'_j(u) + (∂z_i(u)/∂u)^T θ`. Time-varying covariate bases must therefore supply their derivatives with respect to `u = log(age)`; when no time-varying terms are used the second summand vanishes.
 
 ### 2.2 Likelihood Contributions
-- Adopt the Fine–Gray *partial likelihood with a parametric baseline*: the Royston–Parmar spline determines `log H_0`, while the risk-set denominators follow the standard Fine–Gray construction (Beyersmann et al. 2010). We do **not** form a full likelihood; only event-time risk-set ratios contribute.
-- For each distinct event time `t_k`, compute the weighted risk denominator
+- Adopt a Fine–Gray style **full likelihood** with the Royston–Parmar spline supplying the parametric subdistribution hazard. Each individual contributes the log-likelihood of an interval-censored subdistribution time-to-event model rather than just a risk-set ratio.
+- For subject `i` with entry age `a_i` and exit age `b_i`, evaluate the cumulative subdistribution hazard difference `ΔH_i = H_i(b_i) - H_i(a_i)` (with `H_i(a_i) = 0` when no left truncation). The weighted log-likelihood contribution is
 
-  `R(t_k) = Σ_{j: a_j ≤ t_k} w_j G_j(t_k) exp(η_j(t_k)) (∂η_j/∂t)(t_k)`,
+  `ℓ_i = w_i [d_i log h_i(b_i) - ΔH_i]`,
 
-  where `G_j` is the Kaplan–Meier censoring/competing survival and `(∂η_j/∂t)(t_k)` comes from the derivative design matrices (baseline derivative scaled by the Jacobian plus any time-varying covariate derivatives). Event `i` at `t_k` contributes `w_i [η_i(t_k) + log (∂η_i/∂t)(t_k) - log R(t_k)]`, so the hazard ratio inside the partial likelihood uses the Royston–Parmar subdistribution hazard.
-- Left truncation enters through the same risk sets: individuals with `a_i > t_k` are excluded from `R(t_k)`, and their cumulative hazard contribution subtracts `H_i(a_i)` from `H_i(b_i)` so that the working increments remain `ΔH_i = exp(η_i(b_i)) - exp(η_i(a_i)) ≥ 0`.
-- Maintain competing-event records in the risk set after their event time, consistent with Fine–Gray, by leaving their `G_j` weights active but setting the event indicator to zero.
+  where `d_i` is 1 only when the event of interest occurs at `b_i`. Competing events correspond to `d_i = 0` but still subtract their cumulative hazard through `ΔH_i`, preserving the Fine–Gray subdistribution semantics while keeping a true likelihood objective.
+- The derivative term `(∂η_i/∂t)(t)` remains essential because `h_i(t) = H_i(t) (∂η_i/∂t)(t) / exp(t)`; cache both `H_i` and the derivative so that gradient/Hessian code reuses them across REML iterations.
+- Left truncation is handled directly via `H_i(a_i)`: subtract the cumulative hazard evaluated at entry so the likelihood conditions on survival up to `a_i`.
 - Multiply all contributions by sample weights before accumulating the score or Hessian.
 
 ### 2.3 Gradients / IRLS quantities
-- Define the augmented design row `\tilde{X}_i^{exit}(t) = X_i^{exit} + D_i^{exit} / (∂η_i/∂t)(t)` so that differentiation of `log h_i(t)` and `log R(t)` uses the same derivative-aware combination.
-- Express the score in risk-set form: for subject `i`, `U_i = w_i d_i \tilde{X}_i^{exit}(t_{event}) - Σ_{k: t_k ≥ a_i} w_i G_i(t_k) exp(η_i(t_k)) (∂η_i/∂t)(t_k) / R(t_k) · \tilde{X}_i^{exit}(t_k)`, where `d_i` is 1 when `i` experiences the target event at `t_k`. Cache the cumulative sum `Σ_k s_i(t_k)` with `s_i(t_k) = w_i G_i(t_k) exp(η_i(t_k))(∂η_i/∂t)(t_k) / R(t_k)` so the subtraction uses precomputed totals during each IRLS iteration. Include the derivative contribution from time-varying effects via `(∂z_i(u)/∂u)^T θ` when evaluating both hazard and gradient terms.
-- Assemble the negative Hessian as `H = Σ_k \tilde{X}_{R(t_k)}^⊤ [diag(s(t_k)) - s(t_k) s(t_k)^⊤] \tilde{X}_{R(t_k)}` with `s(t_k)` defined using the derivative-weighted hazards above, and add the per-event derivative blocks `Σ_{i: d_i=1} w_i (D_i^{exit})^⊤ D_i^{exit} / (∂η_i/∂t)(t_k)^2`. This retains the off-diagonal curvature induced by shared denominators and matches the Fine–Gray Fisher information. Reuse dense cross-product helpers to stream over event times.
-- Left truncation contributes additively to the diagonal through `exp(η_i(a_i))`, so the effective diagonal weights become `exp(η_i(b_i)) - exp(η_i(a_i)) ≥ 0`. No negative working weights should occur provided the baseline cumulative hazard remains monotone; enforce monotonicity through the `log H_0` parameterization.
-- The working response can continue to use `z = η + H^{-1} U` inside the penalized Newton update, leveraging the same solver infrastructure as other families.
+- Define the augmented design row `\tilde{X}_i^{exit}(t) = X_i^{exit} + D_i^{exit} / (∂η_i/∂t)(t)` so that differentiation of `log h_i(t)` collects both baseline and time-varying pieces.
+- Express the score per subject: `U_i = w_i [d_i \tilde{X}_i^{exit}(b_i) - ΔH_i X_i^{integral}]`, where `X_i^{integral}` combines the entry/exit design rows used to evaluate the cumulative hazard difference. Cache these rows alongside `ΔH_i` so PIRLS iterations can reuse them without regenerating spline evaluations.
+- Assemble the negative Hessian as `H = Σ_i w_i [d_i \tilde{X}_i^{exit ⊤} \tilde{X}_i^{exit} + ΔH_i X_i^{integral ⊤} X_i^{integral}]` and add penalty blocks. This retains the off-diagonal curvature needed for REML and mirrors the structure expected by the existing linear algebra routines.
+- Left truncation already appears through `ΔH_i = H_i(b_i) - H_i(a_i)`; ensure monotonicity of `H_i` to keep `ΔH_i ≥ 0` and avoid negative working weights.
+- The working response continues to use `z = η + H^{-1} U` inside the penalized Newton update, leveraging the same solver infrastructure as other families.
 
 ### 2.4 Absolute Risk Predictions
 - Absolute risk between current age `t0` and horizon `t1` requires conditioning on being event-free (for all causes) at `t0`. Evaluate `CIF_target(t) = 1 - exp(-H_i(t))` and retain the Fine–Gray-derived competing incidence `CIF_competing(t)` from the censoring weights.


### PR DESCRIPTION
## Summary
- update survival design plans to describe Fine–Gray estimation via a full likelihood with parametric Royston–Parmar baselines
- refresh gradient/Hessian sections so PIRLS notes rely on per-subject contributions rather than risk-set ratios
- clarify supporting research notes to emphasize choosing full-likelihood approaches over partial-likelihood alternatives

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_69013a62e084832e8e5cc5bb6a8df600