### PR TITLE
Update survival Hessian boundary accumulation

### DIFF
--- a/plan/survival_48271.md
+++ b/plan/survival_48271.md
@@ -114,11 +114,11 @@ For subject `i` define:
   `U = Σ_i w_i [δ_i \tilde{x}_i^{exit}(a_exit) - (H_i^*(a_exit) - H_i^*(a_entry)) x_i^{integral}]`,
 
   where `x_i^{integral}` denotes the design row used for the cumulative hazard evaluation (baseline/time-varying pieces at both entry and exit). Cache `x_i^{integral}` and the derivative-weighted hazards so the subtraction `H_i^*(a_exit) - H_i^*(a_entry)` can be formed without re-evaluating splines every iteration.
-- Build the negative Hessian by differentiating the score directly: add `w_i δ_i (\tilde{x}_i^{exit})^⊤ \tilde{x}_i^{exit}` for the event term and subtract the integral of `H_i^*(t)` times the outer product of the design rows over the interval `[a_entry, a_exit]`. In practice approximate the integral with the cached cumulative hazard difference, yielding
+- Build the negative Hessian by differentiating the score directly: add `w_i δ_i (\tilde{x}_i^{exit})^⊤ \tilde{x}_i^{exit}` for the event term and accumulate the cumulative-hazard part as the sum of boundary outer products,
 
-  `H = Σ_i w_i [δ_i (\tilde{x}_i^{exit})^⊤ \tilde{x}_i^{exit} + ΔH_i x_i^{integral ⊤} x_i^{integral}]`,
+  `H = Σ_i w_i [δ_i (\tilde{x}_i^{exit})^⊤ \tilde{x}_i^{exit} + exp(η_i^{exit}) x_i^{exit} x_i^{exit ⊤} + exp(η_i^{entry}) x_i^{entry} x_i^{entry ⊤}]`.
 
-  where `ΔH_i = H_i^*(a_exit) - H_i^*(a_entry)`. Reuse dense cross-product helpers so PIRLS sees a familiar penalized normal-equation structure.
+  Cache the boundary design rows `x_i^{exit}`/`x_i^{entry}` so PIRLS can add their contributions independently instead of scaling a single integral row.
 - The derivative of the time-varying smooth enters through `(∂z_i/∂a)`; cache these derivatives alongside basis evaluations so that hazard diagnostics and derivative-based penalties remain well defined.
 
 ### 6.4 Mapping to P-IRLS
@@ -136,6 +136,7 @@ For subject `i` define:
   ```
 - Implement `WorkingModel` for logistic, Gaussian (defer to current code), and new `RoystonParmarFineGray`. For GAM links, compute diagonal Hessian and map to existing `update_glm_vectors`. For survival, compute dense Hessian. This retains a single P-IRLS loop while letting each model supply `gradient`/`hessian`.
 - Inside `pirls::run_pirls`, replace diagonal `weights` logic with general Hessian accumulation: solve `(H + S) Δβ = g` using Faer; if Hessian is diagonal, we can form `X^T W X` as today; otherwise reuse gradient/Hessian directly to build the penalized system without constructing pseudo responses.
+- When assembling the survival Hessian, accumulate `exp(η_i^{exit}) x_i^{exit} x_i^{exit ⊤}` and `exp(η_i^{entry}) x_i^{entry} x_i^{entry ⊤}` as separate rank-one updates so no shared integral row needs to be scaled in-place.
 - Maintain workspace reuse by storing `H` in `PirslWorkspace::xtwx_buf`; ensure symmetry and add ridge if eigenvalues approach zero.
 
 ### 6.5 Deviance for REML/LAML


### PR DESCRIPTION
## Summary
- revise the Fine–Gray survival plan so the cumulative-hazard Hessian uses separate entry and exit boundary outer products
- document that PIRLS should accumulate the two boundary contributions independently instead of scaling a cached integral row

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_690141632cec832eaa1faa4483476b49