### PR TITLE
Fix typo in survival plan document

### DIFF
--- a/plan/survival.md
+++ b/plan/survival.md
@@ -126,7 +126,7 @@ U += w_i [ d_i x̃_exit - H_exit_i x_exit + H_entry_i x_entry ].
 H += w_i [ d_i x̃_exit^T x̃_exit + H_exit_i x_exit^T x_exit + H_entry_i x_entry^T x_entry ].
 ```
 - `WorkingState::eta` returns `η_exit` so diagnostics (calibrator, standard errors) can reuse it.
-- Devianee `D = -2 Σ_i ℓ_i` feeds REML/LAML.
+- Deviance `D = -2 Σ_i ℓ_i` feeds REML/LAML.
 
 ### 5.4 Monotonicity penalty
 - Add a soft inequality penalty to discourage negative `dη_exit`. Evaluate `dη` on a dense grid of ages (e.g., 200 points across training support). Accumulate `penalty += λ_soft Σ softplus(-dη_grid)` with a small weight (`λ_soft ≈ 1e-4`).


### PR DESCRIPTION
## Summary
- fix a typo in the survival plan documentation by renaming the deviance term

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69015f6ddc50832ea142bcc8759dbbea