### PR TITLE
Clarify survival monotonicity enforcement

### DIFF
--- a/plan/survival.md
+++ b/plan/survival.md
@@ -102,7 +102,8 @@ pub struct SurvivalLayout {
 ### 5.1 Per-subject quantities
 - `η_exit = X_exit β`, `η_entry = X_entry β`.
 - `H_exit = exp(η_exit)`, `H_entry = exp(η_entry)`.
-- `ΔH = H_exit - H_entry` (non-negative by construction of the cumulative hazard).
+- `ΔH = H_exit - H_entry` where the enforced monotonicity (Section 5.4) keeps the cumulative hazard non-decreasing across
+  checkpoints.
 - `dη_exit = D_exit β` already on the age scale.
 - Target event indicator `d = event_target`, sample weight `w = sample_weight`.
 
@@ -129,8 +130,13 @@ H += w_i [ d_i x̃_exit^T x̃_exit + H_exit_i x_exit^T x_exit + H_entry_i x_entr
 - Devianee `D = -2 Σ_i ℓ_i` feeds REML/LAML.
 
 ### 5.4 Monotonicity penalty
-- Add a soft inequality penalty to discourage negative `dη_exit`. Evaluate `dη` on a dense grid of ages (e.g., 200 points across training support). Accumulate `penalty += λ_soft Σ softplus(-dη_grid)` with a small weight (`λ_soft ≈ 1e-4`).
-- Add the barrier Hessian/gradient to the working state like any other smoothness penalty. Remove any ad-hoc derivative clamping.
+- Keep the working coefficients unconstrained but evaluate `dη` on a dense grid of ages (e.g., 200 points across training
+  support) and treat the grid evaluations as interior-point variables. Accumulate an interior barrier `penalty += μ Σ -log(dη_grid)`
+  with a small weight (`μ ≈ 1e-4`).
+- During each Newton update, reject any line-search candidate that drives a grid evaluation non-positive; shrink the step until the
+  barrier remains finite. This coercive strategy keeps every accepted iterate strictly inside the positive orthant.
+- Add the barrier gradient/Hessian to the working state like any other smoothness penalty. Because every accepted iterate satisfies
+  `dη_grid > 0`, the log-likelihood term `log(dη_exit)` never receives a non-positive argument, so no clamping is required.
 
 ## 6. REML / smoothing integration
 - The outer REML loop is unchanged. It now receives `WorkingState` with dense Hessians when the survival family is active.


### PR DESCRIPTION
## Summary
- explain how the monotonicity mechanism keeps the cumulative hazard non-decreasing
- replace the soft penalty with an interior barrier and line-search rejection description
- document how the barrier guarantees strictly positive derivatives for the log term

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69015f6a2c9c832e9d57f5ac1bd1f6a9