### PR TITLE
Clarify competing event age expectations

### DIFF
--- a/plan/survival.md
+++ b/plan/survival.md
@@ -32,16 +32,20 @@ Deliver a first-class survival model family built on the Royston–Parmar (RP) p
 ## 3. Data schema and ingestion
 ### 3.1 Required columns
 Expect TSV/Parquet columns (names fixed):
-- `age_entry`, `age_exit` (years, `age_entry < age_exit`),
+- `age_entry`, `age_exit` (years, `age_entry < age_exit`; `age_exit` is the administrative end of follow-up regardless of whether the row experiences a target event, competing event, or censoring),
+- `age_competing_event` (optional numeric column; required and finite when `event_competing = 1`, empty/`NaN` otherwise),
 - `event_target`, `event_competing` (0/1 integers, mutually exclusive, both zero for censoring),
 - `sample_weight` (optional, defaults to 1.0 and multiplies log-likelihood contributions directly),
 - covariates: `pgs`, `sex`, `pc1..pcK`, plus optional additional columns already supported by the GAM path.
+
+Rows that record a competing event set `event_competing = 1`, `event_target = 0`, and must satisfy `age_entry < age_competing_event ≤ age_exit`. When an external registry extends follow-up beyond the competing occurrence, `age_exit` captures that administrative horizon while `age_competing_event` pins the actual occurrence time.
 
 ### 3.2 Training and scoring bundles
 ```rust
 pub struct SurvivalTrainingData {
     pub age_entry: Array1<f64>,
     pub age_exit: Array1<f64>,
+    pub age_competing_event: Option<Array1<f64>>,
     pub event_target: Array1<u8>,
     pub event_competing: Array1<u8>,
     pub sample_weight: Array1<f64>,
@@ -56,13 +60,14 @@ pub struct SurvivalTrainingData {
 pub struct SurvivalPredictionInputs<'a> {
     pub age_entry: ArrayView1<'a, f64>,
     pub age_exit: ArrayView1<'a, f64>,
+    pub age_competing_event: Option<ArrayView1<'a, f64>>,
     pub event_target: ArrayView1<'a, u8>,
     pub event_competing: ArrayView1<'a, u8>,
     pub sample_weight: ArrayView1<'a, f64>,
     pub covariates: CovariateViews<'a>,
 }
 ```
-- Loaders validate ordering, exclusivity, and finiteness. There is no construction of inverse-probability weights or risk-set slices.
+- Loaders validate ordering, exclusivity, and finiteness: `age_entry < age_exit`, `event_target + event_competing ≤ 1`, and the competing indicator requires `age_competing_event` within `(age_entry, age_exit]`. They additionally check that `age_competing_event` never exceeds `age_exit` and that non-competing rows leave the optional column empty. There is no construction of inverse-probability weights or risk-set slices.
 
 ## 4. Basis, transforms, and constraints
 ### 4.1 Guarded age transform


### PR DESCRIPTION
## Summary
- clarify that age_exit is the administrative end of follow-up for every record
- add optional age_competing_event column and describe expectations for competing rows
- extend loader validations to enforce the competing-event contract

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_690164f2475c832eac64502ffe2b9be7