### PR TITLE
Strengthen survival derivative safeguards

### DIFF
--- a/plan/survival.md
+++ b/plan/survival.md
@@ -103,19 +103,22 @@ pub struct SurvivalLayout {
 - `η_exit = X_exit β`, `η_entry = X_entry β`.
 - `H_exit = exp(η_exit)`, `H_entry = exp(η_entry)`.
 - `ΔH = H_exit - H_entry` (non-negative by construction of the cumulative hazard).
-- `dη_exit = D_exit β` already on the age scale.
+- Reparameterise the derivative to maintain non-negativity: store an unconstrained vector `γ` and evaluate
+  `dη_exit = softplus(D_exit γ) + ε_pos` on the age scale with a fixed `ε_pos ≈ 1e-10`.
 - Target event indicator `d = event_target`, sample weight `w = sample_weight`.
 
 ### 5.2 Log-likelihood
 For subject `i`:
 ```
-ℓ_i = w_i [ d_i (η_exit_i + log(dη_exit_i)) - ΔH_i ].
+ℓ_i = w_i [ d_i (η_exit_i + log(max(dη_exit_i, ε_log))) - ΔH_i ].
 ```
+Use `ε_log ≈ 1e-12` to guarantee the log term remains finite even before the monotonicity safeguards converge.
 Competing and censored records have `d_i = 0` but still subtract `ΔH_i`. There is no auxiliary risk set.
 
 ### 5.3 Score and Hessian
 - Define `x_exit` and `x_entry` as the full design rows (baseline + time-varying + static covariates).
-- Let `x̃_exit = x_exit + D_exit / dη_exit` where the division is elementwise after broadcasting the scalar derivative.
+- Let `x̃_exit = x_exit + D_exit / dη_exit` where the division is elementwise after broadcasting the scalar derivative. The
+  `max(dη_exit_i, ε_log)` guard is shared with the log-likelihood to avoid division by a vanishing derivative.
 - Score contribution:
 ```
 U += w_i [ d_i x̃_exit - H_exit_i x_exit + H_entry_i x_entry ].
@@ -129,8 +132,13 @@ H += w_i [ d_i x̃_exit^T x̃_exit + H_exit_i x_exit^T x_exit + H_entry_i x_entr
 - Devianee `D = -2 Σ_i ℓ_i` feeds REML/LAML.
 
 ### 5.4 Monotonicity penalty
-- Add a soft inequality penalty to discourage negative `dη_exit`. Evaluate `dη` on a dense grid of ages (e.g., 200 points across training support). Accumulate `penalty += λ_soft Σ softplus(-dη_grid)` with a small weight (`λ_soft ≈ 1e-4`).
-- Add the barrier Hessian/gradient to the working state like any other smoothness penalty. Remove any ad-hoc derivative clamping.
+- Combine the derivative reparameterisation with a structural monotonic basis: represent the baseline derivative with a
+  monotone I-spline (`BasisDescriptor::MonotoneSpline`) whose coefficients are constrained to be non-negative via the shared
+  `softplus` transform.
+- Retain a secondary soft barrier on the dense age grid to suppress numerical drift, but increase the weight to `λ_soft ≈ 1e-2`
+  so violations are corrected decisively.
+- Accumulate `penalty += λ_soft Σ softplus(-dη_grid)` and add the barrier Hessian/gradient to the working state like any other
+  smoothness penalty. Remove any ad-hoc derivative clamping; the reparameterisation and penalties provide the enforcement.
 
 ## 6. REML / smoothing integration
 - The outer REML loop is unchanged. It now receives `WorkingState` with dense Hessians when the survival family is active.
@@ -195,6 +203,9 @@ fn conditional_absolute_risk(t0: f64, t1: f64, covariates: &Covariates, cif_comp
   - deviance decreases monotonically under PIRLS iterations;
   - left-truncation: confirm `ΔH` equals the difference of endpoint evaluations;
   - prediction monotonicity in horizon (risk between `t0` and `t1` is non-negative and increases with `t1`).
+  - derivative safeguard: construct fixtures whose unconstrained derivative would be negative, confirm the `softplus`
+    reparameterisation keeps `dη_exit ≥ ε_pos`, and verify the `log(max(dη_exit, ε_log))` guard remains finite during
+    optimisation.
 - Grid diagnostic: monitor the fraction of grid ages where the soft barrier activates. If it exceeds a small threshold (e.g., 5%), emit a warning suggesting more knots or stronger smoothing.
 - Compare with reference tooling (`rstpm2` or `flexsurv`) on CIFs at named ages and Brier scores with/without calibration.
 - Remove benchmarks centered on risk-set algebra or quadrature.


### PR DESCRIPTION
## Summary
- reparameterise the exit derivative to stay positive and guard the log term with an epsilon
- upgrade monotonicity enforcement via a monotone spline structure and stronger soft barrier weighting
- extend the testing plan to cover scenarios where derivatives would otherwise go negative

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690164f5f654832ea759c069b9591d48