### PR TITLE
Update survival plan diagnostics

### DIFF
--- a/plan/survival.md
+++ b/plan/survival.md
@@ -205,14 +205,15 @@ fn conditional_absolute_risk(t0: f64, t1: f64, covariates: &Covariates, cif_comp
 
 ## 9. Testing and diagnostics
 - Unit tests:
-  - gradient/Hessian correctness via finite differences on small synthetic data;
+  - gradient/Hessian correctness, using complex-step derivatives for the log-derivative term and finite differences elsewhere on small synthetic data;
   - deviance decreases monotonically under PIRLS iterations;
-  - left-truncation: confirm `ΔH` equals the difference of endpoint evaluations;
+  - left-truncation: confirm `ΔH` equals the difference of endpoint evaluations and that the LDLᵀ factorization recovers the expected inertia when truncation removes early events;
   - prediction monotonicity in horizon (risk between `t0` and `t1` is non-negative and increases with `t1`).
 - Grid diagnostic: monitor the fraction of grid ages where the soft barrier activates. If it exceeds a small threshold (e.g., 5%), emit a warning suggesting more knots or stronger smoothing.
 - Compare with reference tooling (`rstpm2` or `flexsurv`) on CIFs at named ages and Brier scores with/without calibration.
 - Add weighted evaluation tests that verify frequency-weighted metrics (e.g., log-likelihood, Brier score) against a trusted reference implementation so future changes preserve the intended weighting semantics.
 - Remove benchmarks centered on risk-set algebra or quadrature.
+- Add left-truncation diagnostics that stress LDLᵀ inertia: synthesize censored cohorts where entry times force alternating event status so the stabilized factorization must pivot and record signature changes, verifying logging and metrics when inertia deviates from the SPD baseline.
 
 ## 10. Implementation roadmap
 1. **Model family plumbing**: add survival variant to `ModelFamily`, update CLI flags, and ensure serialization handles the new branch.


### PR DESCRIPTION
## Summary
- require complex-step derivatives when validating the log-derivative term in the survival gradient/Hessian tests
- extend the survival testing plan with LDLᵀ inertia diagnostics under left truncation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69017dfe66e0832eb1d1689d60844e41