### PR TITLE
Clarify conditional risk documentation around F_competing_t0

### DIFF
--- a/plan/survival.md
+++ b/plan/survival.md
@@ -174,9 +174,9 @@ pub struct SurvivalModelArtifacts {
 ```
 CIF_target(t) = 1 - exp(-H(t)).
 ΔF = CIF_target(t1) - CIF_target(t0).
-F_competing_t0` supplied externally (see below).
 conditional_risk = ΔF / max(ε, 1 - CIF_target(t0) - F_competing_t0).
 ```
+- `F_competing_t0` is supplied externally (see §7.3).
 - Default `ε = 1e-12` to maintain numeric stability.
 - No quadrature or Gauss–Kronrod rules are invoked; endpoint evaluation is exact under RP.
 


### PR DESCRIPTION
## Summary
- clarify the conditional risk section so the F_competing_t0 description sits outside the fenced block for clean rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690183425328832ebeb919b603707ed6