### PR TITLE
Support survival calibrator features

### DIFF
--- a/calibrate/calibrator.rs
+++ b/calibrate/calibrator.rs
@@ -119,6 +119,15 @@ pub struct CalibratorModel {
 
     // Optional Gaussian scale
     pub scale: Option<f64>,
+    /// Calibration inherits the frequency-weight assumption from training. Persist the flag so
+    /// downstream consumers do not reinterpret the coefficients under inverse-probability
+    /// weighting without re-fitting the calibrator.
+    #[serde(default = "default_true")]
+    pub assumes_frequency_weights: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// Internal schema returned when building the calibrator design
@@ -4676,6 +4685,7 @@ mod tests {
             column_spans: schema.column_spans,
             pred_param_range: schema.pred_param_range.clone(),
             scale: None, // Not used for logistic regression
+            assumes_frequency_weights: true,
         };
 
         // Get calibrated predictions
@@ -4843,6 +4853,7 @@ mod tests {
                 column_spans: schema.column_spans,
                 pred_param_range: schema.pred_param_range.clone(),
                 scale: None,
+                assumes_frequency_weights: true,
             };
 
             let cal_probs = predict_calibrator(
@@ -5007,6 +5018,7 @@ mod tests {
             column_spans: schema.column_spans.clone(),
             pred_param_range: schema.pred_param_range.clone(),
             scale: None,
+            assumes_frequency_weights: true,
         };
         let cal_probs = predict_calibrator(
             &cal_model,
@@ -5166,6 +5178,7 @@ mod tests {
             column_spans: schema.column_spans,
             pred_param_range: schema.pred_param_range.clone(),
             scale: None, // Not used for logistic regression
+            assumes_frequency_weights: true,
         };
 
         // Get calibrated predictions
@@ -5534,6 +5547,7 @@ mod tests {
             column_spans: schema.column_spans,
             pred_param_range: schema.pred_param_range.clone(),
             scale: Some(scale),
+            assumes_frequency_weights: true,
         };
 
         let cal_preds = predict_calibrator(
@@ -5824,6 +5838,7 @@ mod tests {
             column_spans: schema.column_spans,
             pred_param_range: schema.pred_param_range.clone(),
             scale: None,
+            assumes_frequency_weights: true,
         };
 
         // Create new test data with similar characteristics but different values
@@ -5933,6 +5948,7 @@ mod tests {
             column_spans: schema.column_spans.clone(),
             pred_param_range: schema.pred_param_range.clone(),
             scale: None,
+            assumes_frequency_weights: true,
         };
 
         // Generate predictions with original model
@@ -7228,6 +7244,7 @@ mod tests {
             column_spans: schema.column_spans,
             pred_param_range: schema.pred_param_range.clone(),
             scale: None,
+            assumes_frequency_weights: true,
         };
 
         let cal_probs = predict_calibrator(

--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -1464,6 +1464,7 @@ pub fn train_model(
                 } else {
                     None
                 },
+                assumes_frequency_weights: true,
             };
 
             // Detailed one-time summary after calibration ends

--- a/calibrate/survival.rs
+++ b/calibrate/survival.rs
@@ -1,7 +1,9 @@
 use crate::calibrate::basis::{
     BasisError, create_bspline_basis_with_knots, create_difference_penalty_matrix,
 };
-use crate::calibrate::faer_ndarray::FaerSvd;
+use crate::calibrate::faer_ndarray::{FaerArrayView, FaerColView, FaerSvd};
+use faer::Side;
+use faer::linalg::solvers::{Ldlt as FaerLdlt, Llt as FaerLlt, Solve as FaerSolve};
 use log::warn;
 use ndarray::prelude::*;
 use ndarray::{ArrayBase, Data, Ix1, Zip, concatenate};
@@ -43,6 +45,10 @@ pub enum SurvivalError {
     DesignDimensionMismatch,
     #[error("basis evaluation failed: {0}")]
     Basis(#[from] BasisError),
+    #[error("delta-method variance computation failed: {0}")]
+    DeltaMethod(String),
+    #[error("calibrator inputs must have {expected} observations, got {provided}")]
+    CalibratorInputLengthMismatch { expected: usize, provided: usize },
 }
 
 /// Working model abstraction shared between GAM and survival implementations.
@@ -944,33 +950,94 @@ pub fn conditional_absolute_risk(
 
 /// Calibrator feature extraction for survival predictions.
 pub fn survival_calibrator_features(
-    predictions: &Array1<f64>,
-    standard_errors: &Array1<f64>,
+    risks: &Array1<f64>,
+    jacobians: &Array2<f64>,
+    hessian_factor: Option<&HessianFactor>,
     leverage: Option<&Array1<f64>>,
-) -> Array2<f64> {
-    let n = predictions.len();
-    let leverage_len_ok = leverage.map_or(true, |l| l.len() == n);
-    assert!(
-        leverage_len_ok,
-        "leverage vector must match prediction length"
-    );
-    let mut features = Array2::<f64>::zeros((n, if leverage.is_some() { 3 } else { 2 }));
-    match leverage {
-        Some(lev) => {
-            for i in 0..n {
-                features[[i, 0]] = predictions[i].logit();
-                features[[i, 1]] = standard_errors[i];
-                features[[i, 2]] = lev[i];
-            }
-        }
-        None => {
-            for i in 0..n {
-                features[[i, 0]] = predictions[i].logit();
-                features[[i, 1]] = standard_errors[i];
-            }
+) -> Result<Array2<f64>, SurvivalError> {
+    let n = risks.len();
+    if jacobians.nrows() != n {
+        return Err(SurvivalError::CalibratorInputLengthMismatch {
+            expected: n,
+            provided: jacobians.nrows(),
+        });
+    }
+    if let Some(lev) = leverage {
+        if lev.len() != n {
+            return Err(SurvivalError::CalibratorInputLengthMismatch {
+                expected: n,
+                provided: lev.len(),
+            });
         }
     }
-    features
+
+    if let Some(factor) = hessian_factor {
+        let expected_dim = match factor {
+            HessianFactor::Observed { ldlt_factor, .. } => ldlt_factor.nrows(),
+            HessianFactor::Expected { cholesky_factor } => cholesky_factor.nrows(),
+        };
+        if jacobians.ncols() != expected_dim {
+            return Err(SurvivalError::CalibratorInputLengthMismatch {
+                expected: expected_dim,
+                provided: jacobians.ncols(),
+            });
+        }
+    }
+
+    let mut se_logit = Array1::<f64>::zeros(n);
+    if let Some(factor) = hessian_factor {
+        for (row_idx, jac_row) in jacobians.rows().into_iter().enumerate() {
+            let risk = risks[row_idx].clamp(1e-12, 1.0 - 1e-12);
+            let denom = (risk * (1.0 - risk)).max(1e-12);
+            let grad_logit = jac_row.to_owned().mapv(|v| v / denom);
+            let variance = delta_quadratic_form(factor, &grad_logit)?;
+            se_logit[row_idx] = variance.max(0.0).sqrt();
+        }
+    }
+
+    let cols = if leverage.is_some() { 3 } else { 2 };
+    let mut features = Array2::<f64>::zeros((n, cols));
+    for i in 0..n {
+        let risk = risks[i].clamp(1e-12, 1.0 - 1e-12);
+        features[[i, 0]] = risk.logit();
+        features[[i, 1]] = se_logit[i];
+        if let Some(lev) = leverage {
+            features[[i, 2]] = lev[i].clamp(0.0, 0.999);
+        }
+    }
+    Ok(features)
+}
+
+fn delta_quadratic_form(factor: &HessianFactor, grad: &Array1<f64>) -> Result<f64, SurvivalError> {
+    match factor {
+        HessianFactor::Observed { ldlt_factor, .. } => {
+            let view = FaerArrayView::new(ldlt_factor);
+            let solver = FaerLdlt::new(view.as_ref(), Side::Lower)
+                .map_err(|err| SurvivalError::DeltaMethod(format!("LDLT solve failed: {err:?}")))?;
+            let grad_view = FaerColView::new(grad);
+            let solved = solver.solve(grad_view.as_ref());
+            let solved_view = solved.as_ref();
+            let mut accum = 0.0;
+            for (idx, value) in grad.iter().enumerate() {
+                accum += value * solved_view[(idx, 0)];
+            }
+            Ok(accum)
+        }
+        HessianFactor::Expected { cholesky_factor } => {
+            let view = FaerArrayView::new(cholesky_factor);
+            let solver = FaerLlt::new(view.as_ref(), Side::Lower).map_err(|err| {
+                SurvivalError::DeltaMethod(format!("Cholesky solve failed: {err:?}"))
+            })?;
+            let grad_view = FaerColView::new(grad);
+            let solved = solver.solve(grad_view.as_ref());
+            let solved_view = solved.as_ref();
+            let mut accum = 0.0;
+            for (idx, value) in grad.iter().enumerate() {
+                accum += value * solved_view[(idx, 0)];
+            }
+            Ok(accum)
+        }
+    }
 }
 
 trait LogitExt {
@@ -1100,6 +1167,33 @@ mod tests {
         assert!(cif1 >= cif0 - 1e-9);
         let risk = conditional_absolute_risk(55.0, 60.0, &covs, 0.0, &artifacts).unwrap();
         assert!(risk >= -1e-9);
+    }
+
+    #[test]
+    fn survival_calibrator_features_compute_logit_and_se() {
+        let risks = array![0.2, 0.7];
+        let jacobians = array![[0.1, 0.0], [0.0, 0.2]];
+        let hessian = HessianFactor::Expected {
+            cholesky_factor: Array2::<f64>::eye(2),
+        };
+        let leverage = array![1.2, -0.5];
+
+        let features =
+            survival_calibrator_features(&risks, &jacobians, Some(&hessian), Some(&leverage))
+                .expect("feature extraction");
+
+        assert_eq!(features.ncols(), 3);
+        assert_eq!(features.nrows(), 2);
+        assert_abs_diff_eq!(features[[0, 0]], risks[0].logit(), epsilon = 1e-12);
+        assert_abs_diff_eq!(features[[1, 0]], risks[1].logit(), epsilon = 1e-12);
+
+        let expected_se0 = 0.1 / (risks[0] * (1.0 - risks[0]));
+        let expected_se1 = 0.2 / (risks[1] * (1.0 - risks[1]));
+        assert_abs_diff_eq!(features[[0, 1]], expected_se0, epsilon = 1e-12);
+        assert_abs_diff_eq!(features[[1, 1]], expected_se1, epsilon = 1e-12);
+
+        assert_abs_diff_eq!(features[[0, 2]], 0.999, epsilon = 1e-12);
+        assert_abs_diff_eq!(features[[1, 2]], 0.0, epsilon = 1e-12);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- persist an `assumes_frequency_weights` flag with each saved calibrator model and propagate it from training
- add survival-specific calibrator feature generation that logit-transforms risks, clips leverage, and derives delta-method standard errors from stored Hessian factors
- extend survival error reporting and tests to cover the new feature extraction logic

## Testing
- `cargo fmt`
- `cargo test` *(fails: interrupted due to large dependency download in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6902bc180fbc832e84c8d55d16ba4a11