### PR TITLE
Add survival-aware model family and shared PIRLS working model

### DIFF
--- a/calibrate/construction.rs
+++ b/calibrate/construction.rs
@@ -2,7 +2,7 @@ use crate::calibrate::basis::{self, create_bspline_basis};
 use crate::calibrate::data::TrainingData;
 use crate::calibrate::estimate::EstimationError;
 use crate::calibrate::faer_ndarray::{FaerEigh, FaerLinalgError, FaerSvd};
-use crate::calibrate::model::{InteractionPenaltyKind, ModelConfig};
+use crate::calibrate::model::{InteractionPenaltyKind, LinkFunction, ModelConfig, ModelFamily};
 use faer::linalg::matmul::matmul;
 use faer::{Accum, Mat, MatRef, Par, Side};
 use ndarray::Zip;
@@ -2692,7 +2692,7 @@ mod tests {
         };
 
         ModelConfig {
-            link_function: LinkFunction::Logit,
+            model_family: ModelFamily::Gam(LinkFunction::Logit),
             penalty_order: 2,
             convergence_tolerance: 1e-6,
             max_iterations: 15,
@@ -2801,7 +2801,7 @@ mod tests {
             .collect();
 
         let config = ModelConfig {
-            link_function: LinkFunction::Identity,
+            model_family: ModelFamily::Gam(LinkFunction::Identity),
             penalty_order: 2,
             convergence_tolerance: 1e-6,
             max_iterations: 100,
@@ -3295,7 +3295,7 @@ mod tests {
             basis_config: pc_basis,
         };
         ModelConfig {
-            link_function: LinkFunction::Identity,
+            model_family: ModelFamily::Gam(LinkFunction::Identity),
             penalty_order,
             convergence_tolerance: 1e-6,
             max_iterations: 100,

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -12,7 +12,9 @@ use std::process;
 use gnomon::calibrate::data::{load_prediction_data, load_training_data};
 use gnomon::calibrate::estimate::train_model;
 use gnomon::calibrate::model::BasisConfig;
-use gnomon::calibrate::model::{InteractionPenaltyKind, LinkFunction, ModelConfig, TrainedModel};
+use gnomon::calibrate::model::{
+    InteractionPenaltyKind, LinkFunction, ModelConfig, ModelFamily, TrainedModel,
+};
 use gnomon::map::main as map_cli;
 use gnomon::map::{DEFAULT_LD_WINDOW, LdWindow};
 
@@ -142,7 +144,7 @@ pub fn train(args: TrainArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     // Create final model configuration
     let config = ModelConfig {
-        link_function,
+        model_family: ModelFamily::Gam(link_function),
         penalty_order: args.penalty_order,
         convergence_tolerance: args.convergence_tolerance,
         max_iterations: args.max_iterations,
@@ -216,7 +218,7 @@ pub fn infer(args: InferArgs) -> Result<(), Box<dyn std::error::Error>> {
         &eta,
         &mean,
         se_eta_opt.as_ref(),
-        model.config.link_function,
+        model.config.link_function(),
         calibrated_mean_opt.as_ref(),
         output_path,
     )?;


### PR DESCRIPTION
## Summary
- add a `ModelFamily` enum with a survival variant and migrate configuration/serialization to use it while preserving legacy link-only files
- update CLI, construction, and estimation paths to access link functions through the new family abstraction
- move the shared PIRLS `WorkingModel`/`WorkingState` types into the solver module and wire the survival implementation to the new trait

## Testing
- `cargo fmt`
- `cargo check --quiet` *(aborted after an extended dependency build to avoid exceeding execution time)*

------
https://chatgpt.com/codex/tasks/task_e_6902bc1050bc832e863d52239017e527