### PR TITLE
Add inertia helper for survival Hessian factors

### DIFF
--- a/calibrate/survival.rs
+++ b/calibrate/survival.rs
@@ -863,6 +863,22 @@ pub enum HessianFactor {
     },
 }
 
+impl HessianFactor {
+    /// Return the inertia (negative, zero, positive eigenvalue counts) implied by the
+    /// stored factorization. This is primarily useful for diagnostics that need to
+    /// understand how many directions of negative curvature were encountered while
+    /// solving the penalized system.
+    pub fn inertia(&self) -> (usize, usize, usize) {
+        match self {
+            HessianFactor::Observed { inertia, .. } => *inertia,
+            HessianFactor::Expected { cholesky_factor } => {
+                let dim = cholesky_factor.nrows();
+                (0, 0, dim)
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SurvivalModelArtifacts {
     pub coefficients: Array1<f64>,
@@ -1739,5 +1755,20 @@ mod tests {
         let mismatched_covs = Array1::<f64>::zeros(static_names.len() + 1);
         let err = cumulative_hazard(60.0, &mismatched_covs, &artifacts).unwrap_err();
         assert!(matches!(err, SurvivalError::CovariateDimensionMismatch));
+    }
+
+    #[test]
+    fn hessian_factor_reports_inertia() {
+        let observed = HessianFactor::Observed {
+            ldlt_factor: Array2::zeros((2, 2)),
+            permutation: vec![0, 1],
+            inertia: (1, 0, 1),
+        };
+        assert_eq!(observed.inertia(), (1, 0, 1));
+
+        let expected = HessianFactor::Expected {
+            cholesky_factor: Array2::eye(3),
+        };
+        assert_eq!(expected.inertia(), (0, 0, 3));
     }
 }


### PR DESCRIPTION
## Summary
- add an inertia accessor on `HessianFactor` so callers can inspect curvature counts stored with the factorization
- cover the new helper with a regression test that exercises both observed and expected-factor variants

## Testing
- cargo test hessian_factor_reports_inertia --lib *(aborted during dependency fetch)*

------
https://chatgpt.com/codex/tasks/task_e_6902bc18d398832e9430f56cd21d9a62