### PR TITLE
Handle survival model families safely

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -703,6 +703,12 @@ pub enum EstimationError {
 
     #[error("Prediction error")]
     PredictionError,
+
+    #[error("Model family '{family}' is not supported for {operation}.")]
+    UnsupportedModelFamily {
+        family: &'static str,
+        operation: &'static str,
+    },
 }
 
 // Ensure Debug prints with actual line breaks by delegating to Display
@@ -717,6 +723,13 @@ pub fn train_model(
     data: &TrainingData,
     config: &ModelConfig,
 ) -> Result<TrainedModel, EstimationError> {
+    if matches!(config.model_family, ModelFamily::Survival(_)) {
+        return Err(EstimationError::UnsupportedModelFamily {
+            family: "survival",
+            operation: "training",
+        });
+    }
+
     basis::clear_basis_cache();
 
     log::info!(


### PR DESCRIPTION
## Summary
- return a clear error when attempting to train survival model families with the GAM estimator
- guard prediction and calibration paths so survival configs produce an unsupported-model error instead of panicking
- update the CLI inference flow to surface the unsupported survival model error when saving predictions

## Testing
- cargo fmt
- cargo check *(aborted after prolonged dependency compilation)*

------
https://chatgpt.com/codex/tasks/task_e_6902c67171f0832ea40576fabaf0296f