### PR TITLE
Refactor working model trait integration

### DIFF
--- a/calibrate/pirls.rs
+++ b/calibrate/pirls.rs
@@ -15,9 +15,7 @@ use ndarray::{Array1, Array2, ArrayView1, ArrayView2, Axis};
 use std::time::{Duration, Instant};
 
 pub trait WorkingModel {
-    type Error;
-
-    fn update(&mut self, beta: &Array1<f64>) -> Result<WorkingState, Self::Error>;
+    fn update(&mut self, beta: &Array1<f64>) -> Result<WorkingState, EstimationError>;
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- expose a unified `pirls::WorkingModel` trait that reports `EstimationError`
- reuse the shared working-model types inside the survival implementation and map validation failures into estimation errors

## Testing
- cargo fmt


------
https://chatgpt.com/codex/tasks/task_e_6902c8695890832e94caec34c045061b