### PR TITLE
Add covariate views and companion CIF helpers

### DIFF
--- a/calibrate/survival_data.rs
+++ b/calibrate/survival_data.rs
@@ -1,5 +1,5 @@
 use crate::calibrate::survival::{
-    AgeTransform, SurvivalError, SurvivalPredictionInputs, SurvivalTrainingData,
+    AgeTransform, CovariateViews, SurvivalError, SurvivalPredictionInputs, SurvivalTrainingData,
     validate_survival_inputs,
 };
 use ndarray::{Array1, Array2};
@@ -70,7 +70,12 @@ impl SurvivalPredictionData {
             event_target: self.event_target.view(),
             event_competing: self.event_competing.view(),
             sample_weight: self.sample_weight.view(),
-            covariates: self.covariates.view(),
+            covariates: CovariateViews {
+                pgs: self.pgs.view(),
+                sex: self.sex.view(),
+                pcs: self.pcs.view(),
+                static_covariates: self.covariates.view(),
+            },
         }
     }
 }
@@ -399,7 +404,8 @@ mod tests {
         let prediction = load_survival_prediction_data(file.path().to_str().unwrap(), 2)
             .expect("load prediction");
         let inputs = prediction.as_inputs();
-        assert_eq!(inputs.covariates.ncols(), 4);
+        assert_eq!(inputs.covariates.static_covariates.ncols(), 4);
+        assert_eq!(inputs.covariates.pcs.ncols(), 2);
         assert_eq!(inputs.age_exit.len(), 3);
     }
 


### PR DESCRIPTION
## Summary
- introduce a `CovariateViews` wrapper so `SurvivalPredictionInputs` exposes structured covariate slices
- add competing-CIF helper functions that resolve `CompanionModelHandle`s or honor explicit user inputs
- extend documentation and tests to describe denominator guarding and companion CIF fallbacks

## Testing
- `cargo fmt`
- `cargo test companion_cif_resolves_handles_and_fallbacks` *(fails: repository currently lacks `validate_survival_inputs` and has unused import guards outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_6902c861d8e8832ebec0a4b245bfdd16