### PR TITLE
Add survival model training pipeline

### DIFF
--- a/calibrate/construction.rs
+++ b/calibrate/construction.rs
@@ -2,7 +2,7 @@ use crate::calibrate::basis::{self, create_bspline_basis};
 use crate::calibrate::data::TrainingData;
 use crate::calibrate::estimate::EstimationError;
 use crate::calibrate::faer_ndarray::{FaerEigh, FaerLinalgError, FaerSvd};
-use crate::calibrate::model::{InteractionPenaltyKind, LinkFunction, ModelConfig, ModelFamily};
+use crate::calibrate::model::{InteractionPenaltyKind, ModelConfig};
 use faer::linalg::matmul::matmul;
 use faer::{Accum, Mat, MatRef, Par, Side};
 use ndarray::Zip;
@@ -2385,8 +2385,8 @@ mod tests {
     use crate::calibrate::data::TrainingData;
     use crate::calibrate::estimate::train_model;
     use crate::calibrate::model::{
-        BasisConfig, InteractionPenaltyKind, LinkFunction, ModelConfig, PrincipalComponentConfig,
-        internal_construct_design_matrix, internal_flatten_coefficients,
+        BasisConfig, InteractionPenaltyKind, LinkFunction, ModelConfig, ModelFamily,
+        PrincipalComponentConfig, internal_construct_design_matrix, internal_flatten_coefficients,
     };
     use approx::assert_abs_diff_eq;
     use ndarray::s;
@@ -2714,6 +2714,7 @@ mod tests {
             pc_null_transforms: HashMap::new(),
             interaction_centering_means: HashMap::new(),
             interaction_orth_alpha: HashMap::new(),
+            survival: None,
         }
     }
 
@@ -2819,6 +2820,7 @@ mod tests {
             pc_null_transforms: HashMap::new(),
             interaction_centering_means: HashMap::new(),
             interaction_orth_alpha: HashMap::new(),
+            survival: None,
         };
 
         (data, config)
@@ -3221,6 +3223,7 @@ mod tests {
             penalized_hessian: None,
             scale: None,
             calibrator: None,
+            survival: None,
         };
 
         let preds_via_predict = model
@@ -3313,6 +3316,7 @@ mod tests {
             pc_null_transforms: HashMap::new(),
             interaction_centering_means: HashMap::new(),
             interaction_orth_alpha: HashMap::new(),
+            survival: None,
         }
     }
 

--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -38,8 +38,17 @@ use crate::calibrate::construction::{
 };
 use crate::calibrate::data::TrainingData;
 use crate::calibrate::hull::build_peeled_hull;
-use crate::calibrate::model::{LinkFunction, ModelConfig, ModelFamily, TrainedModel};
+use crate::calibrate::model::{
+    LinkFunction, MappedCoefficients, ModelConfig, ModelFamily, TrainedModel,
+};
 use crate::calibrate::pirls::{self, PirlsResult};
+use crate::calibrate::survival::WorkingModel;
+use crate::calibrate::survival::{
+    BasisDescriptor, ColumnRange, CovariateLayout, HessianFactor, LdltFactor, PenaltyDescriptor,
+    PermutationDescriptor, SurvivalLayout, SurvivalModelArtifacts, SurvivalTrainingData,
+    ValueRange, WorkingModelSurvival, WorkingState, build_survival_layout,
+};
+use crate::calibrate::survival_data::SurvivalTrainingBundle;
 
 fn log_basis_cache_stats(context: &str) {
     let stats = basis::basis_cache_stats();
@@ -61,7 +70,9 @@ fn log_basis_cache_stats(context: &str) {
 // Ndarray and faer linear algebra helpers
 use ndarray::{Array1, Array2, ArrayView1, ArrayView2, ArrayViewMut1, Axis, s};
 // faer: high-performance dense solvers
-use crate::calibrate::faer_ndarray::{FaerArrayView, FaerCholesky, FaerEigh, FaerLinalgError};
+use crate::calibrate::faer_ndarray::{
+    FaerArrayView, FaerCholesky, FaerColView, FaerEigh, FaerLinalgError, ldlt_rook,
+};
 use faer::Mat as FaerMat;
 use faer::Side;
 use faer::linalg::solvers::{
@@ -631,6 +642,9 @@ pub enum EstimationError {
     #[error("Underlying basis function generation failed: {0}")]
     BasisError(#[from] crate::calibrate::basis::BasisError),
 
+    #[error("Survival working model error: {0}")]
+    Survival(#[from] crate::calibrate::survival::SurvivalError),
+
     #[error("A linear system solve failed. The penalized Hessian may be singular. Error: {0}")]
     LinearSystemSolveFailed(FaerLinalgError),
 
@@ -870,6 +884,7 @@ pub fn train_model(
             penalized_hessian: Some(penalized_hessian_orig),
             scale: Some(scale_val),
             calibrator: None,
+            survival: None,
         };
 
         trained_model
@@ -1535,6 +1550,7 @@ pub fn train_model(
         penalized_hessian: Some(penalized_hessian_orig),
         scale: Some(scale_val),
         calibrator: calibrator_opt,
+        survival: None,
     };
 
     trained_model
@@ -8498,6 +8514,304 @@ fn test_indefinite_hessian_detection_and_retreat() {
     }
 
     println!("=== INDEFINITE HESSIAN DETECTION TEST COMPLETED ===");
+}
+
+fn compute_log_range(log_entry: &Array1<f64>, log_exit: &Array1<f64>) -> (f64, f64) {
+    let mut min_val = f64::INFINITY;
+    let mut max_val = f64::NEG_INFINITY;
+    for &value in log_entry.iter().chain(log_exit.iter()) {
+        if value < min_val {
+            min_val = value;
+        }
+        if value > max_val {
+            max_val = value;
+        }
+    }
+    if !min_val.is_finite() || !max_val.is_finite() {
+        (0.0, 0.0)
+    } else {
+        (min_val, max_val)
+    }
+}
+
+fn compute_value_range(values: ArrayView1<'_, f64>) -> ValueRange {
+    if values.is_empty() {
+        return ValueRange { min: 0.0, max: 0.0 };
+    }
+    let mut min_val = f64::INFINITY;
+    let mut max_val = f64::NEG_INFINITY;
+    for &value in values.iter() {
+        if value < min_val {
+            min_val = value;
+        }
+        if value > max_val {
+            max_val = value;
+        }
+    }
+    if !min_val.is_finite() || !max_val.is_finite() {
+        ValueRange { min: 0.0, max: 0.0 }
+    } else {
+        ValueRange {
+            min: min_val,
+            max: max_val,
+        }
+    }
+}
+
+fn covariate_layout_from_data(data: &SurvivalTrainingData) -> CovariateLayout {
+    let mut column_names = Vec::with_capacity(2 + data.pcs.ncols());
+    column_names.push("pgs".to_string());
+    column_names.push("sex".to_string());
+    for idx in 0..data.pcs.ncols() {
+        column_names.push(format!("pc{}", idx + 1));
+    }
+
+    let mut ranges = Vec::with_capacity(column_names.len());
+    ranges.push(compute_value_range(data.pgs.view()));
+    ranges.push(compute_value_range(data.sex.view()));
+    for idx in 0..data.pcs.ncols() {
+        ranges.push(compute_value_range(data.pcs.column(idx)));
+    }
+
+    CovariateLayout {
+        column_names,
+        ranges,
+    }
+}
+
+fn penalty_descriptors_from_layout(
+    layout: &SurvivalLayout,
+    order: usize,
+) -> Vec<PenaltyDescriptor> {
+    layout
+        .penalties
+        .blocks
+        .iter()
+        .map(|block| PenaltyDescriptor {
+            order,
+            lambda: block.lambda,
+            matrix: block.matrix.clone(),
+            column_range: ColumnRange::new(block.range.start, block.range.end),
+        })
+        .collect()
+}
+
+fn make_hessian_factor(hessian: &Array2<f64>) -> Option<HessianFactor> {
+    match ldlt_rook(hessian) {
+        Ok((lower, diag, subdiag, forward, inverse, inertia)) => Some(HessianFactor::Observed {
+            factor: LdltFactor {
+                lower,
+                diag,
+                subdiag,
+            },
+            permutation: PermutationDescriptor { forward, inverse },
+            inertia,
+        }),
+        Err(_) => None,
+    }
+}
+
+fn build_survival_artifacts(
+    layout: &SurvivalLayout,
+    beta: &Array1<f64>,
+    data: &SurvivalTrainingData,
+    basis: &BasisDescriptor,
+    penalty_order: usize,
+    hessian: &Array2<f64>,
+) -> SurvivalModelArtifacts {
+    SurvivalModelArtifacts {
+        coefficients: beta.clone(),
+        age_basis: basis.clone(),
+        time_varying_basis: None,
+        static_covariate_layout: covariate_layout_from_data(data),
+        penalties: penalty_descriptors_from_layout(layout, penalty_order),
+        age_transform: layout.age_transform,
+        reference_constraint: layout.reference_constraint.clone(),
+        interaction_metadata: Vec::new(),
+        companion_models: Vec::new(),
+        hessian_factor: make_hessian_factor(hessian),
+    }
+}
+
+fn fit_survival_newton(
+    model: &mut WorkingModelSurvival,
+    max_iterations: usize,
+    tolerance: f64,
+) -> Result<(Array1<f64>, Array2<f64>, WorkingState), EstimationError> {
+    let p = model.layout.combined_exit.ncols();
+    let mut beta = Array1::<f64>::zeros(p);
+    let mut state = model.update(&beta)?;
+    let mut iteration = 0usize;
+    let tol = tolerance.max(1e-12);
+
+    enum SolverFactor {
+        Llt(FaerLlt<f64>),
+        Ldlt(FaerLdlt<f64>),
+    }
+
+    impl SolverFactor {
+        fn solve(&self, rhs: faer::MatRef<'_, f64>) -> FaerMat<f64> {
+            match self {
+                SolverFactor::Llt(f) => f.solve(rhs),
+                SolverFactor::Ldlt(f) => f.solve(rhs),
+            }
+        }
+    }
+
+    loop {
+        let grad_norm = state.gradient.iter().map(|v| v * v).sum::<f64>().sqrt();
+        if grad_norm <= tol {
+            break;
+        }
+
+        if iteration >= max_iterations {
+            return Err(EstimationError::PirlsDidNotConverge {
+                max_iterations,
+                last_change: grad_norm,
+            });
+        }
+
+        let h_view = FaerArrayView::new(&state.hessian);
+        let solver = if let Ok(factor) = FaerLlt::new(h_view.as_ref(), Side::Lower) {
+            SolverFactor::Llt(factor)
+        } else {
+            let ldlt = FaerLdlt::new(h_view.as_ref(), Side::Lower)
+                .map_err(|err| EstimationError::LinearSystemSolveFailed(FaerLinalgError::Ldlt(err)))?;
+            SolverFactor::Ldlt(ldlt)
+        };
+
+        let grad_view = FaerColView::new(&state.gradient);
+        let delta_mat = solver.solve(grad_view.as_ref());
+        let mut delta = Array1::<f64>::zeros(p);
+        for i in 0..p {
+            delta[i] = delta_mat[(i, 0)];
+        }
+
+        let mut step_scale = 1.0;
+        let mut accepted_state = None;
+        let mut candidate_beta = beta.clone();
+        for _ in 0..16 {
+            let scaled = delta.mapv(|v| v * step_scale);
+            candidate_beta = beta.clone() - &scaled;
+            match model.update(&candidate_beta) {
+                Ok(next_state) => {
+                    if next_state.deviance <= state.deviance + 1e-9 {
+                        accepted_state = Some(next_state);
+                        break;
+                    }
+                }
+                Err(err) => return Err(err.into()),
+            }
+            step_scale *= 0.5;
+        }
+
+        let Some(next_state) = accepted_state else {
+            return Err(EstimationError::PirlsDidNotConverge {
+                max_iterations,
+                last_change: grad_norm,
+            });
+        };
+
+        beta = candidate_beta;
+        state = next_state;
+        iteration += 1;
+    }
+
+    let final_hessian = state.hessian.clone();
+    Ok((beta, final_hessian, state))
+}
+
+pub fn train_survival_model(
+    bundle: &SurvivalTrainingBundle,
+    config: &ModelConfig,
+) -> Result<TrainedModel, EstimationError> {
+    basis::clear_basis_cache();
+
+    let spec = match &config.model_family {
+        ModelFamily::Survival(spec) => spec.clone(),
+        _ => {
+            return Err(EstimationError::InvalidSpecification(
+                "train_survival_model requires ModelFamily::Survival".to_string(),
+            ));
+        }
+    };
+
+    let survival_cfg = config.survival.as_ref().ok_or_else(|| {
+        EstimationError::InvalidSpecification(
+            "survival configuration missing baseline settings".to_string(),
+        )
+    })?;
+
+    let log_entry = bundle
+        .age_transform
+        .transform_array(&bundle.data.age_entry)?;
+    let log_exit = bundle
+        .age_transform
+        .transform_array(&bundle.data.age_exit)?;
+    let (log_min, mut log_max) = compute_log_range(&log_entry, &log_exit);
+    if (log_max - log_min).abs() < 1e-8 {
+        log_max = log_min + 1e-3;
+    }
+
+    let (_, knot_vector) = basis::create_bspline_basis(
+        log_exit.view(),
+        (log_min, log_max),
+        survival_cfg.baseline_basis.num_knots,
+        survival_cfg.baseline_basis.degree,
+    )?;
+    let basis_descriptor = BasisDescriptor {
+        knot_vector,
+        degree: survival_cfg.baseline_basis.degree,
+    };
+
+    let (layout, mut monotonicity) = build_survival_layout(
+        &bundle.data,
+        &basis_descriptor,
+        survival_cfg.guard_delta,
+        config.penalty_order,
+        survival_cfg.initial_lambda,
+        survival_cfg.monotonic_grid_size,
+    )?;
+    monotonicity.lambda = survival_cfg.monotonic_lambda;
+
+    let mut working_model = WorkingModelSurvival::new(layout, &bundle.data, monotonicity, spec)?;
+
+    let (beta, hessian, _) = fit_survival_newton(
+        &mut working_model,
+        config.max_iterations,
+        config.convergence_tolerance,
+    )?;
+    let artifacts = build_survival_artifacts(
+        &working_model.layout,
+        &beta,
+        &bundle.data,
+        &basis_descriptor,
+        config.penalty_order,
+        &hessian,
+    );
+
+    let lambdas: Vec<f64> = working_model
+        .layout
+        .penalties
+        .blocks
+        .iter()
+        .map(|block| block.lambda)
+        .collect();
+
+    let trained = TrainedModel {
+        config: config.clone(),
+        coefficients: MappedCoefficients::default(),
+        lambdas,
+        hull: None,
+        penalized_hessian: Some(hessian),
+        scale: None,
+        calibrator: None,
+        survival: Some(artifacts),
+    };
+
+    log_basis_cache_stats("train_survival_model");
+
+    Ok(trained)
 }
 
 // Implement From<EstimationError> for String to allow using ? in functions returning Result<_, String>

--- a/calibrate/faer_ndarray.rs
+++ b/calibrate/faer_ndarray.rs
@@ -17,6 +17,8 @@ pub enum FaerLinalgError {
     SelfAdjointEigen(solvers::EvdError),
     #[error("Cholesky factorization failed: {0:?}")]
     Cholesky(solvers::LltError),
+    #[error("LDLT factorization failed: {0:?}")]
+    Ldlt(solvers::LdltError),
 }
 
 #[inline]

--- a/calibrate/model.rs
+++ b/calibrate/model.rs
@@ -2,7 +2,7 @@ use crate::calibrate::basis::{self};
 use crate::calibrate::construction::ModelLayout;
 use crate::calibrate::estimate::EstimationError;
 use crate::calibrate::hull::PeeledHull;
-use crate::calibrate::survival::SurvivalSpec;
+use crate::calibrate::survival::{SurvivalModelArtifacts, SurvivalSpec};
 use ndarray::{Array1, Array2, ArrayView1, ArrayView2, Axis, s};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -85,6 +85,15 @@ pub struct PrincipalComponentConfig {
     pub range: (f64, f64),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SurvivalModelConfig {
+    pub baseline_basis: BasisConfig,
+    pub guard_delta: f64,
+    pub initial_lambda: f64,
+    pub monotonic_grid_size: usize,
+    pub monotonic_lambda: f64,
+}
+
 /// Holds the transformation matrix for a sum-to-zero constraint.
 /// This is serializable so it can be saved to the TOML file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -139,6 +148,8 @@ pub struct ModelConfig {
     /// Null-space transformation matrices for PC main effects (unpenalized part).
     /// Maps PC name to Z_null (columns span the penalty null space after dropping intercept).
     pub pc_null_transforms: HashMap<String, Array2<f64>>,
+    #[serde(default)]
+    pub survival: Option<SurvivalModelConfig>,
 }
 
 impl ModelConfig {
@@ -172,6 +183,7 @@ impl ModelConfig {
             interaction_centering_means: HashMap::new(),
             interaction_orth_alpha: HashMap::new(),
             pc_null_transforms: HashMap::new(),
+            survival: None,
         }
     }
 
@@ -217,6 +229,8 @@ struct ModelConfigSerde {
     interaction_centering_means: HashMap<String, Array1<f64>>,
     interaction_orth_alpha: HashMap<String, Array2<f64>>,
     pc_null_transforms: HashMap<String, Array2<f64>>,
+    #[serde(default)]
+    survival: Option<SurvivalModelConfig>,
 }
 
 impl From<ModelConfigSerde> for ModelConfig {
@@ -241,6 +255,7 @@ impl From<ModelConfigSerde> for ModelConfig {
             interaction_centering_means,
             interaction_orth_alpha,
             pc_null_transforms,
+            survival,
         } = helper;
 
         let model_family = model_family
@@ -266,6 +281,7 @@ impl From<ModelConfigSerde> for ModelConfig {
             interaction_centering_means,
             interaction_orth_alpha,
             pc_null_transforms,
+            survival,
         }
     }
 }
@@ -291,6 +307,7 @@ impl From<ModelConfig> for ModelConfigSerde {
             interaction_centering_means,
             interaction_orth_alpha,
             pc_null_transforms,
+            survival,
         } = config;
 
         let legacy_link = match &model_family {
@@ -318,6 +335,7 @@ impl From<ModelConfig> for ModelConfigSerde {
             interaction_centering_means,
             interaction_orth_alpha,
             pc_null_transforms,
+            survival,
         }
     }
 }
@@ -334,6 +352,16 @@ pub struct MappedCoefficients {
     pub interaction_effects: HashMap<String, Vec<f64>>,
 }
 
+impl Default for MappedCoefficients {
+    fn default() -> Self {
+        Self {
+            intercept: 0.0,
+            main_effects: MainEffects::default(),
+            interaction_effects: HashMap::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MainEffects {
     /// Coefficient for the main effect of sex (binary indicator).
@@ -345,11 +373,22 @@ pub struct MainEffects {
     pub pcs: HashMap<String, Vec<f64>>,
 }
 
+impl Default for MainEffects {
+    fn default() -> Self {
+        Self {
+            sex: 0.0,
+            pgs: Vec::new(),
+            pcs: HashMap::new(),
+        }
+    }
+}
+
 /// The top-level, self-contained, trained model artifact.
 /// This is the structure that gets saved to and loaded from a file.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TrainedModel {
     pub config: ModelConfig,
+    #[serde(default)]
     pub coefficients: MappedCoefficients,
     /// Estimated smoothing parameters from REML
     pub lambdas: Vec<f64>,
@@ -366,6 +405,9 @@ pub struct TrainedModel {
     /// Optional post-fit calibrator model
     #[serde(default)]
     pub calibrator: Option<crate::calibrate::calibrator::CalibratorModel>,
+    /// Optional survival-specific artifacts (present when training survival models).
+    #[serde(default)]
+    pub survival: Option<SurvivalModelArtifacts>,
 }
 
 /// Custom error type for model loading, saving, and prediction.
@@ -401,6 +443,9 @@ pub enum ModelError {
 
     #[error("Estimation error: {0}")]
     EstimationError(#[from] crate::calibrate::estimate::EstimationError),
+
+    #[error("Operation '{0}' is not supported for survival model family.")]
+    UnsupportedForSurvival(&'static str),
 }
 
 impl TrainedModel {
@@ -420,6 +465,9 @@ impl TrainedModel {
         ),
         ModelError,
     > {
+        if matches!(self.config.model_family, ModelFamily::Survival(_)) {
+            return Err(ModelError::UnsupportedForSurvival("predict_detailed"));
+        }
         // --- Validate inputs ---
         if pcs_new.ncols() != self.config.pc_configs.len() {
             return Err(ModelError::MismatchedPcCount {
@@ -523,6 +571,9 @@ impl TrainedModel {
         sex_new: ArrayView1<f64>,
         pcs_new: ArrayView2<f64>,
     ) -> Result<Array1<f64>, ModelError> {
+        if matches!(self.config.model_family, ModelFamily::Survival(_)) {
+            return Err(ModelError::UnsupportedForSurvival("predict"));
+        }
         // Restore original behavior via detailed path: PHC -> design rebuild -> inverse link
         let (_, mean, _, _) = self.predict_detailed(p_new, sex_new, pcs_new)?;
         Ok(mean)
@@ -536,6 +587,9 @@ impl TrainedModel {
         sex_new: ArrayView1<f64>,
         pcs_new: ArrayView2<f64>,
     ) -> Result<Array1<f64>, ModelError> {
+        if matches!(self.config.model_family, ModelFamily::Survival(_)) {
+            return Err(ModelError::UnsupportedForSurvival("predict_calibrated"));
+        }
         // Stage: Compute baseline predictions
         let baseline = self.predict(p_new, sex_new, pcs_new)?;
         // Stage: If no calibrator is present, error loudly (no silent fallback)
@@ -572,6 +626,9 @@ impl TrainedModel {
         sex_new: ArrayView1<f64>,
         pcs_new: ArrayView2<f64>,
     ) -> Result<Array1<f64>, ModelError> {
+        if matches!(self.config.model_family, ModelFamily::Survival(_)) {
+            return Err(ModelError::UnsupportedForSurvival("predict_linear"));
+        }
         if pcs_new.ncols() != self.config.pc_configs.len() {
             return Err(ModelError::MismatchedPcCount {
                 found: pcs_new.ncols(),
@@ -630,6 +687,11 @@ impl TrainedModel {
     }
 
     fn rebuild_layout_from_config(&self) -> Result<ModelLayout, ModelError> {
+        if matches!(self.config.model_family, ModelFamily::Survival(_)) {
+            return Err(ModelError::UnsupportedForSurvival(
+                "rebuild_layout_from_config",
+            ));
+        }
         let mut pc_null_ncols = Vec::with_capacity(self.config.pc_configs.len());
         let mut pc_range_ncols = Vec::with_capacity(self.config.pc_configs.len());
         let mut pc_int_ncols = Vec::with_capacity(self.config.pc_configs.len());
@@ -693,6 +755,9 @@ impl TrainedModel {
     }
 
     fn assert_layout_consistency_from_config(&self) -> Result<(), ModelError> {
+        if matches!(self.config.model_family, ModelFamily::Survival(_)) {
+            return Ok(());
+        }
         let layout = self.rebuild_layout_from_config()?;
         self.assert_layout_consistency_with_layout(&layout)?;
         Ok(())
@@ -702,6 +767,9 @@ impl TrainedModel {
         &self,
         layout: &ModelLayout,
     ) -> Result<(), ModelError> {
+        if matches!(self.config.model_family, ModelFamily::Survival(_)) {
+            return Ok(());
+        }
         assert_eq!(
             self.lambdas.len(),
             layout.num_penalties,
@@ -1355,6 +1423,7 @@ mod tests {
                 pc_null_transforms: HashMap::new(),
                 interaction_centering_means: HashMap::new(),
                 interaction_orth_alpha: HashMap::new(),
+                survival: None,
             },
             coefficients: MappedCoefficients {
                 intercept: 0.5, // Added an intercept for a more complete test
@@ -1371,6 +1440,7 @@ mod tests {
             penalized_hessian: None,
             scale: None,
             calibrator: None,
+            survival: None,
         };
 
         // --- Define Test Points ---
@@ -1446,6 +1516,7 @@ mod tests {
                 pc_null_transforms: HashMap::new(),
                 interaction_centering_means: HashMap::new(),
                 interaction_orth_alpha: HashMap::new(),
+                survival: None,
             },
             coefficients: MappedCoefficients {
                 intercept: 0.0,
@@ -1461,6 +1532,7 @@ mod tests {
             penalized_hessian: None,
             scale: None,
             calibrator: None,
+            survival: None,
         };
 
         // Test with mismatched PC dimensions (model expects 1 PC, but we provide 2)
@@ -1704,6 +1776,7 @@ mod tests {
                 pc_null_transforms: pc_null_transforms.clone(),
                 interaction_centering_means: interaction_centering_means.clone(),
                 interaction_orth_alpha: interaction_orth_alpha.clone(),
+                survival: None,
             },
             coefficients: MappedCoefficients {
                 intercept: 0.5,
@@ -1772,6 +1845,7 @@ mod tests {
             penalized_hessian: None,
             scale: None,
             calibrator: None,
+            survival: None,
         };
 
         // Create a temporary file for testing

--- a/calibrate/pirls.rs
+++ b/calibrate/pirls.rs
@@ -4,7 +4,7 @@ use crate::calibrate::faer_ndarray::{
     FaerArrayView, FaerCholesky, FaerColView, FaerEigh, array1_to_col_mat_mut, array2_to_mat_mut,
     hash_array2,
 };
-use crate::calibrate::model::{LinkFunction, ModelConfig, ModelFamily};
+use crate::calibrate::model::{LinkFunction, ModelConfig};
 use faer::linalg::matmul::matmul;
 use faer::linalg::solvers::{
     Lblt as FaerLblt, Ldlt as FaerLdlt, Llt as FaerLlt, Solve as FaerSolve,
@@ -2497,7 +2497,9 @@ mod tests {
         build_design_and_penalty_matrices, compute_penalty_square_roots,
     };
     use crate::calibrate::data::TrainingData;
-    use crate::calibrate::model::{BasisConfig, InteractionPenaltyKind, map_coefficients};
+    use crate::calibrate::model::{
+        BasisConfig, InteractionPenaltyKind, ModelFamily, map_coefficients,
+    };
     use approx::assert_abs_diff_eq;
     use ndarray::{Array1, Array2, arr1, arr2};
     use rand::rngs::StdRng;
@@ -2628,6 +2630,7 @@ mod tests {
             pc_null_transforms: HashMap::new(),
             interaction_centering_means: HashMap::new(),
             interaction_orth_alpha: HashMap::new(),
+            survival: None,
         };
 
         // --- Run the fit ---
@@ -3062,6 +3065,7 @@ mod tests {
             pc_null_transforms: HashMap::new(),
             interaction_centering_means: HashMap::new(),
             interaction_orth_alpha: HashMap::new(),
+            survival: None,
         };
 
         // Test with lambda values that match the working test pattern
@@ -3193,6 +3197,7 @@ mod tests {
             pc_null_transforms: HashMap::new(),
             interaction_centering_means: HashMap::new(),
             interaction_orth_alpha: HashMap::new(),
+            survival: None,
         };
 
         // === PHASE 4: Prepare inputs for the target function ===
@@ -3326,6 +3331,7 @@ mod tests {
             pc_null_transforms: HashMap::new(),
             interaction_centering_means: HashMap::new(),
             interaction_orth_alpha: HashMap::new(),
+            survival: None,
         };
 
         // === Set up inputs using helper ===

--- a/calibrate/survival.rs
+++ b/calibrate/survival.rs
@@ -347,6 +347,71 @@ impl SurvivalTrainingData {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn validate_survival_inputs(
+    age_entry: ArrayView1<'_, f64>,
+    age_exit: ArrayView1<'_, f64>,
+    event_target: ArrayView1<'_, u8>,
+    event_competing: ArrayView1<'_, u8>,
+    sample_weight: ArrayView1<'_, f64>,
+    pgs: ArrayView1<'_, f64>,
+    sex: ArrayView1<'_, f64>,
+    pcs: ArrayView2<'_, f64>,
+) -> Result<(), SurvivalError> {
+    let n = age_entry.len();
+    if n == 0 {
+        return Err(SurvivalError::EmptyAgeVector);
+    }
+    if age_exit.len() != n
+        || event_target.len() != n
+        || event_competing.len() != n
+        || sample_weight.len() != n
+        || pgs.len() != n
+        || sex.len() != n
+        || pcs.nrows() != n
+    {
+        return Err(SurvivalError::CovariateDimensionMismatch);
+    }
+
+    for idx in 0..n {
+        let entry = age_entry[idx];
+        let exit = age_exit[idx];
+        if !entry.is_finite() || !exit.is_finite() {
+            return Err(SurvivalError::NonFiniteAge);
+        }
+        if !(entry < exit) {
+            return Err(SurvivalError::InvalidAgeOrder);
+        }
+
+        let target = event_target[idx];
+        let competing = event_competing[idx];
+        if target > 1 || competing > 1 {
+            return Err(SurvivalError::InvalidEventFlag);
+        }
+        if target == 1 && competing == 1 {
+            return Err(SurvivalError::ConflictingEvents);
+        }
+
+        let weight = sample_weight[idx];
+        if !weight.is_finite() || weight < 0.0 {
+            return Err(SurvivalError::InvalidSampleWeight);
+        }
+
+        if !pgs[idx].is_finite() || !sex[idx].is_finite() {
+            return Err(SurvivalError::NonFiniteCovariate);
+        }
+
+        for col in 0..pcs.ncols() {
+            let value = pcs[(idx, col)];
+            if !value.is_finite() {
+                return Err(SurvivalError::NonFiniteCovariate);
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Guard that constrains the baseline spline at the chosen reference point.
 fn make_reference_constraint(
     knot_vector: ArrayView1<f64>,
@@ -1086,7 +1151,7 @@ fn apply_monotonicity_penalty(
 }
 
 /// Serialized representation of an LDLᵀ factor with Bunch–Kaufman pivoting.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LdltFactor {
     pub lower: Array2<f64>,
     pub diag: Array1<f64>,
@@ -1094,7 +1159,7 @@ pub struct LdltFactor {
 }
 
 /// Serialized permutation metadata captured during factorization.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PermutationDescriptor {
     pub forward: Vec<usize>,
     pub inverse: Vec<usize>,
@@ -1114,7 +1179,7 @@ pub enum HessianFactor {
 }
 
 /// Serialized Cholesky factor for SPD approximations.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CholeskyFactor {
     pub lower: Array2<f64>,
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -3,23 +3,36 @@
 #![deny(unused_imports)]
 #![deny(clippy::no_effect_underscore_binding)]
 
-use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use ndarray::{Array1, ArrayView1};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process;
 
 use gnomon::calibrate::data::{load_prediction_data, load_training_data};
-use gnomon::calibrate::estimate::train_model;
+use gnomon::calibrate::estimate::{train_model, train_survival_model};
 use gnomon::calibrate::model::BasisConfig;
 use gnomon::calibrate::model::{
-    InteractionPenaltyKind, LinkFunction, ModelConfig, ModelFamily, TrainedModel,
+    InteractionPenaltyKind, LinkFunction, ModelConfig, ModelFamily, SurvivalModelConfig,
+    TrainedModel,
 };
+use gnomon::calibrate::survival::SurvivalSpec;
+use gnomon::calibrate::survival_data::load_survival_training_data;
 use gnomon::map::main as map_cli;
 use gnomon::map::{DEFAULT_LD_WINDOW, LdWindow};
+use std::collections::HashMap;
+
+#[derive(Clone, ValueEnum)]
+pub enum ModelFamilyCli {
+    Gam,
+    Survival,
+}
 
 #[derive(Args)]
 pub struct TrainArgs {
+    #[arg(long, value_enum, default_value_t = ModelFamilyCli::Gam)]
+    pub model_family: ModelFamilyCli,
+
     /// Path to training TSV file with phenotype,score,PC1,PC2,... columns
     pub training_data: String,
 
@@ -66,6 +79,46 @@ pub struct TrainArgs {
     /// Disable the optional post-process calibration layer (enabled by default)
     #[arg(long)]
     pub no_calibration: bool,
+
+    /// Guard delta for the survival age transform
+    #[arg(long, default_value = "0.1")]
+    pub survival_guard_delta: f64,
+
+    /// Number of internal knots for the survival baseline spline
+    #[arg(long, default_value = "6")]
+    pub survival_baseline_knots: usize,
+
+    /// Degree for the survival baseline spline
+    #[arg(long, default_value = "3")]
+    pub survival_baseline_degree: usize,
+
+    /// Initial smoothing parameter for the survival baseline spline
+    #[arg(long, default_value = "1.0")]
+    pub survival_initial_lambda: f64,
+
+    /// Grid size for the survival monotonicity penalty
+    #[arg(long, default_value = "64")]
+    pub survival_monotonic_grid: usize,
+
+    /// Weight of the survival monotonicity barrier
+    #[arg(long, default_value = "0.0001")]
+    pub survival_monotonic_lambda: f64,
+
+    /// Derivative guard threshold used inside the survival likelihood
+    #[arg(long, default_value = "1e-8")]
+    pub survival_derivative_guard: f64,
+
+    /// Soft barrier weight discouraging negative derivatives in survival models
+    #[arg(long, default_value = "0.0001")]
+    pub survival_barrier_weight: f64,
+
+    /// Soft barrier scale controlling derivative penalties in survival models
+    #[arg(long, default_value = "1.0")]
+    pub survival_barrier_scale: f64,
+
+    /// Use expected information instead of observed Hessian when fitting survival models
+    #[arg(long)]
+    pub survival_expected_information: bool,
 }
 
 #[derive(Args)]
@@ -83,8 +136,6 @@ pub struct InferArgs {
 }
 
 pub fn train(args: TrainArgs) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Loading training data from: {}", args.training_data);
-
     gnomon::calibrate::model::set_calibrator_enabled(!args.no_calibration);
     if args.no_calibration {
         println!("Post-process calibration disabled via --no-calibration flag.");
@@ -92,86 +143,145 @@ pub fn train(args: TrainArgs) -> Result<(), Box<dyn std::error::Error>> {
         println!("Post-process calibration enabled (default).");
     }
 
-    // Load training data
-    let data = load_training_data(&args.training_data, args.num_pcs)?;
-    println!(
-        "Loaded {} samples with {} PCs",
-        data.y.len(),
-        data.pcs.ncols()
-    );
+    match args.model_family {
+        ModelFamilyCli::Gam => {
+            println!("Loading training data from: {}", args.training_data);
+            let data = load_training_data(&args.training_data, args.num_pcs)?;
+            println!(
+                "Loaded {} samples with {} PCs",
+                data.y.len(),
+                data.pcs.ncols()
+            );
 
-    // Auto-detect link function based on phenotype
-    let link_function = detect_link_function(&data.y);
-    println!("Auto-detected link function: {link_function:?}");
+            let link_function = detect_link_function(&data.y);
+            println!("Auto-detected link function: {link_function:?}");
 
-    // Calculate data ranges for basis construction
-    let pgs_range = calculate_range(data.p.view());
-    let pc_ranges: Vec<(f64, f64)> = (0..data.pcs.ncols())
-        .map(|i| calculate_range(data.pcs.column(i)))
-        .collect();
+            let pgs_range = calculate_range(data.p.view());
+            let pc_ranges: Vec<(f64, f64)> = (0..data.pcs.ncols())
+                .map(|i| calculate_range(data.pcs.column(i)))
+                .collect();
 
-    println!("PGS range: ({:.3}, {:.3})", pgs_range.0, pgs_range.1);
-    println!(
-        "PC ranges: {}",
-        pc_ranges
-            .iter()
-            .enumerate()
-            .map(|(i, &(min, max))| format!("PC{}: ({:.3}, {:.3})", i + 1, min, max))
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
+            println!("PGS range: ({:.3}, {:.3})", pgs_range.0, pgs_range.1);
+            println!(
+                "PC ranges: {}",
+                pc_ranges
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &(min, max))| format!("PC{}: ({:.3}, {:.3})", i + 1, min, max))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
 
-    // Create basis configurations
-    let pgs_basis_config = BasisConfig {
-        num_knots: args.pgs_knots,
-        degree: args.pgs_degree,
-    };
+            let pgs_basis_config = BasisConfig {
+                num_knots: args.pgs_knots,
+                degree: args.pgs_degree,
+            };
 
-    // Create PC configs with names, ranges, and basis configs
-    let pc_configs = (0..args.num_pcs)
-        .map(|i| gnomon::calibrate::model::PrincipalComponentConfig {
-            name: format!("PC{}", i + 1),
-            basis_config: BasisConfig {
-                num_knots: args.pc_knots,
-                degree: args.pc_degree,
-            },
-            range: pc_ranges[i],
-        })
-        .collect();
+            let pc_configs = (0..args.num_pcs)
+                .map(|i| gnomon::calibrate::model::PrincipalComponentConfig {
+                    name: format!("PC{}", i + 1),
+                    basis_config: BasisConfig {
+                        num_knots: args.pc_knots,
+                        degree: args.pc_degree,
+                    },
+                    range: pc_ranges[i],
+                })
+                .collect();
 
-    // Lambda values are now estimated automatically via REML
-    println!("Training model with REML estimation of smoothing parameters");
+            println!("Training model with REML estimation of smoothing parameters");
+            let config = ModelConfig {
+                model_family: ModelFamily::Gam(link_function),
+                penalty_order: args.penalty_order,
+                convergence_tolerance: args.convergence_tolerance,
+                max_iterations: args.max_iterations,
+                reml_convergence_tolerance: args.reml_convergence_tolerance,
+                reml_max_iterations: args.reml_max_iterations,
+                firth_bias_reduction: false,
+                reml_parallel_threshold: gnomon::calibrate::model::default_reml_parallel_threshold(
+                ),
+                pgs_basis_config,
+                pc_configs,
+                pgs_range,
+                interaction_penalty: InteractionPenaltyKind::Anisotropic,
+                sum_to_zero_constraints: HashMap::new(),
+                knot_vectors: HashMap::new(),
+                range_transforms: HashMap::new(),
+                interaction_centering_means: HashMap::new(),
+                interaction_orth_alpha: HashMap::new(),
+                pc_null_transforms: HashMap::new(),
+                survival: None,
+            };
 
-    // Create final model configuration
-    let config = ModelConfig {
-        model_family: ModelFamily::Gam(link_function),
-        penalty_order: args.penalty_order,
-        convergence_tolerance: args.convergence_tolerance,
-        max_iterations: args.max_iterations,
-        reml_convergence_tolerance: args.reml_convergence_tolerance,
-        reml_max_iterations: args.reml_max_iterations,
-        firth_bias_reduction: false,
-        reml_parallel_threshold: gnomon::calibrate::model::default_reml_parallel_threshold(),
-        pgs_basis_config,
-        pc_configs,
-        pgs_range,
-        interaction_penalty: InteractionPenaltyKind::Anisotropic,
-        sum_to_zero_constraints: std::collections::HashMap::new(),
-        knot_vectors: std::collections::HashMap::new(),
-        range_transforms: std::collections::HashMap::new(),
-        interaction_centering_means: std::collections::HashMap::new(),
-        interaction_orth_alpha: std::collections::HashMap::new(),
-        pc_null_transforms: std::collections::HashMap::new(),
-    };
+            println!("Training final model...");
+            let trained_model = train_model(&data, &config)?;
+            trained_model.save("model.toml")?;
+            println!("Model saved to: model.toml");
+        }
+        ModelFamilyCli::Survival => {
+            println!(
+                "Loading survival training data from: {}",
+                args.training_data
+            );
+            let bundle = load_survival_training_data(
+                &args.training_data,
+                args.num_pcs,
+                args.survival_guard_delta,
+            )?;
+            println!(
+                "Loaded {} samples with {} PCs",
+                bundle.data.age_entry.len(),
+                bundle.data.pcs.ncols()
+            );
 
-    // Train the final model
-    println!("Training final model...");
-    let trained_model = train_model(&data, &config)?;
+            let mut spec = SurvivalSpec::default();
+            spec.derivative_guard = args.survival_derivative_guard;
+            spec.barrier_weight = args.survival_barrier_weight;
+            spec.barrier_scale = args.survival_barrier_scale;
+            spec.use_expected_information = args.survival_expected_information;
 
-    // Save model to hardcoded output path
-    let output_path = "model.toml";
-    trained_model.save(output_path)?;
-    println!("Model saved to: {output_path}");
+            let survival_config = SurvivalModelConfig {
+                baseline_basis: BasisConfig {
+                    num_knots: args.survival_baseline_knots,
+                    degree: args.survival_baseline_degree,
+                },
+                guard_delta: args.survival_guard_delta,
+                initial_lambda: args.survival_initial_lambda,
+                monotonic_grid_size: args.survival_monotonic_grid,
+                monotonic_lambda: args.survival_monotonic_lambda,
+            };
+
+            let config = ModelConfig {
+                model_family: ModelFamily::Survival(spec),
+                penalty_order: args.penalty_order,
+                convergence_tolerance: args.convergence_tolerance,
+                max_iterations: args.max_iterations,
+                reml_convergence_tolerance: args.reml_convergence_tolerance,
+                reml_max_iterations: args.reml_max_iterations,
+                firth_bias_reduction: false,
+                reml_parallel_threshold: gnomon::calibrate::model::default_reml_parallel_threshold(
+                ),
+                pgs_basis_config: BasisConfig {
+                    num_knots: 0,
+                    degree: 0,
+                },
+                pc_configs: Vec::new(),
+                pgs_range: (0.0, 0.0),
+                interaction_penalty: InteractionPenaltyKind::Anisotropic,
+                sum_to_zero_constraints: HashMap::new(),
+                knot_vectors: HashMap::new(),
+                range_transforms: HashMap::new(),
+                interaction_centering_means: HashMap::new(),
+                interaction_orth_alpha: HashMap::new(),
+                pc_null_transforms: HashMap::new(),
+                survival: Some(survival_config),
+            };
+
+            println!("Training survival model...");
+            let trained_model = train_survival_model(&bundle, &config)?;
+            trained_model.save("model.toml")?;
+            println!("Model saved to: model.toml");
+        }
+    }
 
     Ok(())
 }
@@ -181,6 +291,10 @@ pub fn infer(args: InferArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     // Load trained model
     let model = TrainedModel::load(&args.model)?;
+    if matches!(model.config.model_family, ModelFamily::Survival(_)) {
+        println!("Loaded survival model. CLI inference for survival models is not yet supported.");
+        return Ok(());
+    }
     let num_pcs = model.config.pc_configs.len();
 
     println!("Model expects {num_pcs} PCs");


### PR DESCRIPTION
## Summary
- extend the CLI to drive survival training configuration and block unsupported survival inference
- implement the survival Newton solver, artifact builders, and hook them into `train_survival_model`
- persist survival configuration/artifacts on `ModelConfig` and `TrainedModel`, updating loaders and validators

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6902c8669308832eb49776218399f0f0