### PR TITLE
Handle optional survival covariate blocks

### DIFF
--- a/calibrate/survival_data.rs
+++ b/calibrate/survival_data.rs
@@ -1,10 +1,10 @@
 use crate::calibrate::survival::{
-    AgeTransform, SurvivalError, SurvivalPredictionInputs, SurvivalTrainingData,
+    AgeTransform, CovariateViews, SurvivalError, SurvivalPredictionInputs, SurvivalTrainingData,
     validate_survival_inputs,
 };
 use ndarray::{Array1, Array2};
 use polars::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::path::Path;
 use thiserror::Error;
@@ -58,7 +58,8 @@ pub struct SurvivalPredictionData {
     pub pgs: Array1<f64>,
     pub sex: Array1<f64>,
     pub pcs: Array2<f64>,
-    pub covariates: Array2<f64>,
+    pub extra_static_covariates: Array2<f64>,
+    pub extra_static_names: Vec<String>,
 }
 
 impl SurvivalPredictionData {
@@ -70,7 +71,12 @@ impl SurvivalPredictionData {
             event_target: self.event_target.view(),
             event_competing: self.event_competing.view(),
             sample_weight: self.sample_weight.view(),
-            covariates: self.covariates.view(),
+            covariates: CovariateViews {
+                pgs: self.pgs.view(),
+                sex: self.sex.view(),
+                pcs: self.pcs.view(),
+                static_covariates: self.extra_static_covariates.view(),
+            },
         }
     }
 }
@@ -92,6 +98,7 @@ pub fn load_survival_training_data(
         arrays.pgs.view(),
         arrays.sex.view(),
         arrays.pcs.view(),
+        arrays.extra_static_covariates.view(),
     )?;
 
     let age_transform = AgeTransform::from_training(&arrays.age_entry, guard_delta)?;
@@ -106,6 +113,8 @@ pub fn load_survival_training_data(
             pgs: arrays.pgs,
             sex: arrays.sex,
             pcs: arrays.pcs,
+            extra_static_covariates: arrays.extra_static_covariates,
+            extra_static_names: arrays.extra_static_names,
         },
         age_transform,
     })
@@ -128,9 +137,8 @@ pub fn load_survival_prediction_data(
         arrays.pgs.view(),
         arrays.sex.view(),
         arrays.pcs.view(),
+        arrays.extra_static_covariates.view(),
     )?;
-
-    let covariates = assemble_covariate_matrix(&arrays.pgs, &arrays.sex, &arrays.pcs);
 
     Ok(SurvivalPredictionData {
         age_entry: arrays.age_entry,
@@ -141,7 +149,8 @@ pub fn load_survival_prediction_data(
         pgs: arrays.pgs,
         sex: arrays.sex,
         pcs: arrays.pcs,
-        covariates,
+        extra_static_covariates: arrays.extra_static_covariates,
+        extra_static_names: arrays.extra_static_names,
     })
 }
 
@@ -155,6 +164,8 @@ struct SurvivalArrays {
     pgs: Array1<f64>,
     sex: Array1<f64>,
     pcs: Array2<f64>,
+    extra_static_covariates: Array2<f64>,
+    extra_static_names: Vec<String>,
 }
 
 fn read_survival_arrays(path: &str, num_pcs: usize) -> Result<SurvivalArrays, SurvivalDataError> {
@@ -164,13 +175,32 @@ fn read_survival_arrays(path: &str, num_pcs: usize) -> Result<SurvivalArrays, Su
             .into_iter()
             .map(|name| name.as_str().to_string()),
     );
+    let mut used_columns = HashSet::new();
 
     let age_entry = extract_f64_column(&df, &name_map, "age_entry")?;
+    if let Some(actual) = name_map.get("age_entry") {
+        used_columns.insert(actual.clone());
+    }
     let age_exit = extract_f64_column(&df, &name_map, "age_exit")?;
+    if let Some(actual) = name_map.get("age_exit") {
+        used_columns.insert(actual.clone());
+    }
     let event_target = extract_u8_column(&df, &name_map, "event_target")?;
+    if let Some(actual) = name_map.get("event_target") {
+        used_columns.insert(actual.clone());
+    }
     let event_competing = extract_u8_column(&df, &name_map, "event_competing")?;
+    if let Some(actual) = name_map.get("event_competing") {
+        used_columns.insert(actual.clone());
+    }
     let pgs = extract_f64_column(&df, &name_map, "pgs")?;
+    if let Some(actual) = name_map.get("pgs") {
+        used_columns.insert(actual.clone());
+    }
     let sex = extract_f64_column(&df, &name_map, "sex")?;
+    if let Some(actual) = name_map.get("sex") {
+        used_columns.insert(actual.clone());
+    }
 
     let n = age_entry.len();
     let sample_weight = if let Some(name) = name_map.get("sample_weight") {
@@ -182,6 +212,7 @@ fn read_survival_arrays(path: &str, num_pcs: usize) -> Result<SurvivalArrays, Su
                 found: weights.len(),
             });
         }
+        used_columns.insert(name.clone());
         weights
     } else {
         Array1::from_elem(n, 1.0)
@@ -202,12 +233,51 @@ fn read_survival_arrays(path: &str, num_pcs: usize) -> Result<SurvivalArrays, Su
                 found: values.len(),
             });
         }
+        if let Some(actual) = name_map.get(&key.to_ascii_lowercase()) {
+            used_columns.insert(actual.clone());
+        }
         pc_columns.push(values);
     }
 
     let mut pcs = Array2::<f64>::zeros((n, num_pcs));
     for (j, column) in pc_columns.into_iter().enumerate() {
         pcs.column_mut(j).assign(&column);
+    }
+
+    let mut extra_names = Vec::new();
+    let mut extra_columns = Vec::new();
+    for original in df.get_column_names() {
+        if used_columns.contains(original) {
+            continue;
+        }
+        let series = df
+            .column(original)
+            .map_err(|_| SurvivalDataError::ColumnNotFound(original.clone()))?;
+        let casted = match series.cast(&DataType::Float64) {
+            Ok(values) => values,
+            Err(_) => continue,
+        };
+        let values = casted.f64().expect("casted to f64");
+        if values.null_count() > 0 {
+            return Err(SurvivalDataError::MissingValues(original.clone()));
+        }
+        if values.len() != n {
+            return Err(SurvivalDataError::LengthMismatch {
+                column_name: original.clone(),
+                expected: n,
+                found: values.len(),
+            });
+        }
+        let column = Array1::from_iter(values.into_no_null_iter());
+        extra_names.push(original.clone());
+        extra_columns.push(column);
+        used_columns.insert(original.clone());
+    }
+
+    let extra_width = extra_columns.len();
+    let mut extra_static = Array2::<f64>::zeros((n, extra_width));
+    for (idx, column) in extra_columns.into_iter().enumerate() {
+        extra_static.column_mut(idx).assign(&column);
     }
 
     Ok(SurvivalArrays {
@@ -219,6 +289,8 @@ fn read_survival_arrays(path: &str, num_pcs: usize) -> Result<SurvivalArrays, Su
         pgs,
         sex,
         pcs,
+        extra_static_covariates: extra_static,
+        extra_static_names: extra_names,
     })
 }
 
@@ -328,22 +400,6 @@ fn extract_u8_column(
     Ok(result)
 }
 
-fn assemble_covariate_matrix(
-    pgs: &Array1<f64>,
-    sex: &Array1<f64>,
-    pcs: &Array2<f64>,
-) -> Array2<f64> {
-    let n = pgs.len();
-    let mut matrix = Array2::<f64>::zeros((n, 2 + pcs.ncols()));
-    matrix.column_mut(0).assign(pgs);
-    matrix.column_mut(1).assign(sex);
-    for j in 0..pcs.ncols() {
-        let column = pcs.column(j);
-        matrix.column_mut(2 + j).assign(&column);
-    }
-    matrix
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -361,6 +417,7 @@ mod tests {
             Series::new("sex".into(), vec![0.0, 1.0, 0.0]).into(),
             Series::new("pc1".into(), vec![0.5, 0.6, 0.7]).into(),
             Series::new("pc2".into(), vec![1.5, 1.6, 1.7]).into(),
+            Series::new("bmi".into(), vec![22.0, 23.5, 24.1]).into(),
         ])
         .expect("construct sample dataframe")
     }
@@ -393,6 +450,8 @@ mod tests {
         assert_eq!(bundle.data.age_entry.len(), 3);
         assert_eq!(bundle.age_transform.minimum_age, 50.0);
         assert_eq!(bundle.data.sample_weight[1], 2.0);
+        assert_eq!(bundle.data.extra_static_covariates.ncols(), 1);
+        assert_eq!(bundle.data.extra_static_names, vec!["bmi".to_string()]);
     }
 
     #[test]
@@ -418,7 +477,9 @@ mod tests {
         let prediction = load_survival_prediction_data(file.path().to_str().unwrap(), 2)
             .expect("load prediction");
         let inputs = prediction.as_inputs();
-        assert_eq!(inputs.covariates.ncols(), 4);
+        assert_eq!(inputs.covariates.pgs.len(), 3);
+        assert_eq!(inputs.covariates.static_covariates.ncols(), 1);
+        assert_eq!(prediction.extra_static_names, vec!["bmi".to_string()]);
         assert_eq!(inputs.age_exit.len(), 3);
     }
 


### PR DESCRIPTION
## Summary
- extend the survival layout, training bundle, and prediction inputs with optional extra static covariate blocks and a CovariateViews helper
- update the survival data loader to discover numeric extra columns, validate them alongside core fields, and preserve their names
- adjust unit tests to exercise the additional covariate handling

## Testing
- not run (dependency download volume was prohibitive in the sandbox)


------
https://chatgpt.com/codex/tasks/task_e_6902e5415828832ebc2c66e98e2404f1