### PR TITLE
Refactor survival training to use shared PIRLS runner

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -1641,40 +1641,6 @@ pub fn train_survival_model(
             .collect()
     }
 
-    fn solve_newton_direction(
-        hessian: &Array2<f64>,
-        gradient: &Array1<f64>,
-    ) -> Result<Array1<f64>, EstimationError> {
-        use crate::calibrate::faer_ndarray::{FaerArrayView, array1_to_col_mat_mut};
-        use faer::Side;
-        use faer::linalg::solvers::{Ldlt as FaerLdlt, Solve as FaerSolve};
-
-        let mut matrix = hessian.clone();
-        let mut rhs = gradient.mapv(|v| -v);
-        let mut attempt = 0usize;
-        loop {
-            match FaerLdlt::new(FaerArrayView::new(&matrix).as_ref(), Side::Lower) {
-                Ok(factor) => {
-                    {
-                        let mut rhs_mat = array1_to_col_mat_mut(&mut rhs);
-                        factor.solve_in_place(rhs_mat.as_mut());
-                    }
-                    return Ok(rhs);
-                }
-                Err(err) => {
-                    if attempt >= 6 {
-                        return Err(EstimationError::LinearSystemSolveFailed(err));
-                    }
-                    let ridge = 10f64.powi((attempt as i32) - 6);
-                    for i in 0..matrix.nrows() {
-                        matrix[[i, i]] += ridge;
-                    }
-                    attempt += 1;
-                }
-            }
-        }
-    }
-
     fn factor_hessian(
         hessian: &Array2<f64>,
         use_expected: bool,
@@ -1777,68 +1743,55 @@ pub fn train_survival_model(
             .map_err(map_error)?;
 
     let p = layout.combined_exit.ncols();
-    let mut beta = Array1::<f64>::zeros(p);
-    let mut last_deviance = f64::INFINITY;
-    let mut final_state = None;
+    let options = crate::calibrate::pirls::WorkingModelPirlsOptions {
+        max_iterations: config.max_iterations,
+        convergence_tolerance: config.convergence_tolerance,
+        max_step_halving: 20,
+        min_step_size: 1e-6,
+    };
 
-    for iter in 1..=config.max_iterations {
-        let state = model.update(&beta).map_err(map_error)?;
-        let grad_norm = state.gradient.mapv(|v| v * v).sum().sqrt();
-        let delta = solve_newton_direction(&state.hessian, &state.gradient)?;
+    let pirls_outcome = crate::calibrate::pirls::run_working_model_pirls(
+        &mut model,
+        Array1::<f64>::zeros(p),
+        &options,
+        |info: &crate::calibrate::pirls::WorkingModelIterationInfo| {
+            let halving_note = if info.step_halving > 0 {
+                format!(" (halved {}x)", info.step_halving)
+            } else {
+                String::new()
+            };
+            eprintln!(
+                "  [Iter {:>3}] deviance = {:.6e}, |grad| = {:.3e}, step = {:.3e}{}",
+                info.iteration, info.deviance, info.gradient_norm, info.step_size, halving_note
+            );
+        },
+    )?;
 
-        let mut step = 1.0;
-        let mut accepted = false;
-        let mut candidate_beta = beta.clone();
-        let mut candidate_state = state.clone();
-        for _ in 0..20 {
-            candidate_beta = &beta + &(delta.mapv(|v| step * v));
-            match model.update(&candidate_beta).map_err(map_error) {
-                Ok(updated) => {
-                    if updated.deviance <= state.deviance || !updated.deviance.is_finite() {
-                        candidate_state = updated;
-                        accepted = true;
-                        break;
-                    }
-                    step *= 0.5;
-                }
-                Err(err) => {
-                    if step <= 1e-6 {
-                        return Err(err);
-                    }
-                    step *= 0.5;
-                }
-            }
-        }
-
-        if !accepted {
+    let status = pirls_outcome.status.clone();
+    match status {
+        crate::calibrate::pirls::PirlsStatus::Converged
+        | crate::calibrate::pirls::PirlsStatus::StalledAtValidMinimum => {}
+        crate::calibrate::pirls::PirlsStatus::MaxIterationsReached
+        | crate::calibrate::pirls::PirlsStatus::Unstable => {
             return Err(EstimationError::PirlsDidNotConverge {
-                max_iterations: iter,
-                last_change: grad_norm,
+                max_iterations: config.max_iterations,
+                last_change: pirls_outcome.last_gradient_norm,
             });
-        }
-
-        let deviance_change = last_deviance - candidate_state.deviance;
-        beta = candidate_beta;
-        last_deviance = candidate_state.deviance;
-        final_state = Some(candidate_state);
-
-        eprintln!(
-            "  [Iter {:>3}] deviance = {:.6e}, |grad| = {:.3e}, step = {:.3e}",
-            iter, last_deviance, grad_norm, step
-        );
-
-        if grad_norm < config.convergence_tolerance {
-            break;
-        }
-        if deviance_change.abs() < config.convergence_tolerance {
-            break;
         }
     }
 
-    let final_state = final_state.ok_or_else(|| EstimationError::PirlsDidNotConverge {
-        max_iterations: config.max_iterations,
-        last_change: 0.0,
-    })?;
+    if let crate::calibrate::pirls::PirlsStatus::StalledAtValidMinimum = status {
+        eprintln!(
+            "  [Info] PIRLS stalled with small gradient after {} iterations (ΔD = {:.3e}).",
+            pirls_outcome.iterations, pirls_outcome.last_deviance_change
+        );
+    }
+
+    let crate::calibrate::pirls::WorkingModelPirlsResult {
+        beta,
+        state: final_state,
+        ..
+    } = pirls_outcome;
 
     let hessian_factor = factor_hessian(&final_state.hessian, model.spec.use_expected_information)?;
 

--- a/calibrate/survival.rs
+++ b/calibrate/survival.rs
@@ -3,8 +3,10 @@ use crate::calibrate::basis::{
     null_range_whiten,
 };
 use crate::calibrate::calibrator::{self, CalibratorModel};
+use crate::calibrate::estimate::EstimationError;
 use crate::calibrate::faer_ndarray::{FaerSvd, ldlt_rook};
 use crate::calibrate::model::calibrator_enabled;
+use crate::calibrate::pirls::{WorkingModel as PirlsWorkingModel, WorkingState};
 use log::warn;
 use ndarray::prelude::*;
 use ndarray::{ArrayBase, Data, Ix1, Zip, concatenate};
@@ -105,19 +107,7 @@ pub enum SurvivalError {
     Calibrator(String),
 }
 
-/// Working model abstraction shared between GAM and survival implementations.
-pub trait WorkingModel {
-    fn update(&mut self, beta: &Array1<f64>) -> Result<WorkingState, SurvivalError>;
-}
-
-/// Aggregated state returned by [`WorkingModel::update`].
-#[derive(Debug, Clone)]
-pub struct WorkingState {
-    pub eta: Array1<f64>,
-    pub gradient: Array1<f64>,
-    pub hessian: Array2<f64>,
-    pub deviance: f64,
-}
+pub use crate::calibrate::pirls::WorkingModel;
 
 /// Guarded log-age transformation used across training and scoring.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
@@ -676,8 +666,7 @@ pub fn build_survival_layout(
     let static_covariate_names = assemble_static_covariate_names(data);
 
     let baseline_cols = constrained_exit.ncols();
-    let penalty_matrix =
-        create_difference_penalty_matrix(baseline_cols, baseline_penalty_order)?;
+    let penalty_matrix = create_difference_penalty_matrix(baseline_cols, baseline_penalty_order)?;
     let mut penalty_blocks = vec![PenaltyBlock {
         matrix: penalty_matrix.clone(),
         lambda: baseline_lambda,
@@ -1293,8 +1282,8 @@ impl WorkingModelSurvival {
     }
 }
 
-impl WorkingModel for WorkingModelSurvival {
-    fn update(&mut self, beta: &Array1<f64>) -> Result<WorkingState, SurvivalError> {
+impl WorkingModelSurvival {
+    pub fn update_state(&mut self, beta: &Array1<f64>) -> Result<WorkingState, SurvivalError> {
         let expected_dim = self.layout.combined_exit.ncols();
         if beta.len() != expected_dim {
             return Err(SurvivalError::DesignDimensionMismatch);
@@ -1446,6 +1435,13 @@ impl WorkingModel for WorkingModelSurvival {
             hessian,
             deviance,
         })
+    }
+}
+
+impl PirlsWorkingModel for WorkingModelSurvival {
+    fn update(&mut self, beta: &Array1<f64>) -> Result<WorkingState, EstimationError> {
+        self.update_state(beta)
+            .map_err(|err| EstimationError::InvalidSpecification(err.to_string()))
     }
 }
 
@@ -2481,7 +2477,7 @@ mod tests {
             SurvivalSpec::default(),
         )
         .unwrap();
-        model.update(beta).unwrap()
+        model.update_state(beta).unwrap()
     }
 
     #[test]
@@ -2513,7 +2509,7 @@ mod tests {
             WorkingModelSurvival::new(layout, &data, monotonicity, SurvivalSpec::default())
                 .unwrap();
         let beta = Array1::<f64>::zeros(model.layout.combined_exit.ncols());
-        let state = model.update(&beta).unwrap();
+        let state = model.update_state(&beta).unwrap();
         assert!(state.deviance.is_finite());
     }
 
@@ -2695,7 +2691,7 @@ mod tests {
             WorkingModelSurvival::new(layout, &data, monotonicity, SurvivalSpec::default())
                 .unwrap();
         let beta = Array1::<f64>::zeros(model.layout.combined_exit.ncols());
-        let state = model.update(&beta).unwrap();
+        let state = model.update_state(&beta).unwrap();
         assert_eq!(state.gradient.len(), beta.len());
         assert_eq!(state.hessian.nrows(), beta.len());
         assert_eq!(state.hessian.ncols(), beta.len());
@@ -2724,7 +2720,7 @@ mod tests {
             *value = 0.01 * (idx as f64 + 1.0);
         }
 
-        let state = model.update(&beta).unwrap();
+        let state = model.update_state(&beta).unwrap();
         let eta_exit = layout.combined_exit.dot(&beta);
         let eta_entry = layout.combined_entry.dot(&beta);
         let derivative_exit = layout.combined_derivative_exit.dot(&beta);
@@ -2770,7 +2766,7 @@ mod tests {
             beta[idx] = 0.05 * (idx as f64 + 1.0);
         }
 
-        let state = model.update(&beta).unwrap();
+        let state = model.update_state(&beta).unwrap();
         assert!(state.deviance.is_finite());
 
         let artifacts = SurvivalModelArtifacts {
@@ -2837,7 +2833,7 @@ mod tests {
             }
         }
 
-        let base_state = model.update(&beta).unwrap();
+        let base_state = model.update_state(&beta).unwrap();
         let eta_exit = layout.combined_exit.dot(&beta);
         let eta_entry = layout.combined_entry.dot(&beta);
         let derivative_vector = layout.combined_derivative_exit.dot(&beta);
@@ -2931,13 +2927,13 @@ mod tests {
             beta[idx] = 0.02 * (idx as f64 + 1.0);
         }
 
-        let state_initial = model.update(&beta).unwrap();
+        let state_initial = model.update_state(&beta).unwrap();
         let mut step = 1e-3;
         let mut beta_next = beta.clone();
         let mut state_next = state_initial.clone();
         loop {
             beta_next = &beta - &(state_initial.gradient.mapv(|g| step * g));
-            match model.update(&beta_next) {
+            match model.update_state(&beta_next) {
                 Ok(next) => {
                     state_next = next;
                     if state_next.deviance < state_initial.deviance {
@@ -2994,8 +2990,8 @@ mod tests {
             beta[idx] = 0.015 * (idx as f64 + 1.0);
         }
 
-        let observed_state = observed_model.update(&beta).unwrap();
-        let expected_state = expected_model.update(&beta).unwrap();
+        let observed_state = observed_model.update_state(&beta).unwrap();
+        let expected_state = expected_model.update_state(&beta).unwrap();
 
         for (obs, exp) in observed_state
             .gradient
@@ -3125,8 +3121,8 @@ mod tests {
             beta[idx] = 0.03 * (idx as f64 + 1.0);
         }
 
-        let state_weighted = weighted_model.update(&beta).unwrap();
-        let state_expanded = expanded_model.update(&beta).unwrap();
+        let state_weighted = weighted_model.update_state(&beta).unwrap();
+        let state_expanded = expanded_model.update_state(&beta).unwrap();
 
         assert_abs_diff_eq!(
             state_weighted.deviance,
@@ -3364,10 +3360,7 @@ mod tests {
         for (raw, offset) in raw_means.iter().zip(offsets.iter()) {
             assert_abs_diff_eq!(raw, offset, epsilon = 1e-10);
         }
-        for (mut column, &offset) in pgs_basis_matrix
-            .axis_iter_mut(Axis(1))
-            .zip(offsets.iter())
-        {
+        for (mut column, &offset) in pgs_basis_matrix.axis_iter_mut(Axis(1)).zip(offsets.iter()) {
             column.mapv_inplace(|value| value - offset);
         }
         let centered_means = compute_weighted_column_means(&pgs_basis_matrix, &data.sample_weight);
@@ -3408,7 +3401,7 @@ mod tests {
             SurvivalSpec::default(),
         )
         .unwrap();
-        let state = model.update(&artifacts.coefficients).unwrap();
+        let state = model.update_state(&artifacts.coefficients).unwrap();
         assert!(state.deviance.is_finite());
     }
 

--- a/tests/survival_regression.rs
+++ b/tests/survival_regression.rs
@@ -94,7 +94,7 @@ fn reference_basis() -> gnomon::calibrate::survival::BasisDescriptor {
 fn newton_solve(model: &mut WorkingModelSurvival) -> Array1<f64> {
     let mut beta = Array1::<f64>::zeros(model.layout.combined_exit.ncols());
     for _ in 0..64 {
-        let state = model.update(&beta).expect("update");
+        let state = model.update_state(&beta).expect("update");
         let grad_norm = l2_norm(state.gradient.view());
         if grad_norm < 1e-10 {
             break;
@@ -207,11 +207,13 @@ fn covariate_layout(layout: &gnomon::calibrate::survival::SurvivalLayout) -> Cov
 }
 
 /// Helper to combine static and extra covariates for a single row
-fn combined_covariates_row(layout: &gnomon::calibrate::survival::SurvivalLayout, row_idx: usize) -> Array1<f64> {
+fn combined_covariates_row(
+    layout: &gnomon::calibrate::survival::SurvivalLayout,
+    row_idx: usize,
+) -> Array1<f64> {
     let static_row = layout.static_covariates.row(row_idx);
     let extra_row = layout.extra_static_covariates.row(row_idx);
-    ndarray::concatenate(Axis(0), &[static_row, extra_row])
-        .expect("concatenate covariates")
+    ndarray::concatenate(Axis(0), &[static_row, extra_row]).expect("concatenate covariates")
 }
 
 fn value_ranges(matrix: &Array2<f64>) -> Vec<gnomon::calibrate::survival::ValueRange> {
@@ -303,9 +305,11 @@ fn conditional_risk_monotonic_with_calibration_toggle() {
     let mut base = Vec::new();
     let mut calibrated = Vec::new();
     for &t1 in &horizons {
-        let raw = conditional_absolute_risk(t0, t1, &covs, Some(0.0), None, &trusted.artifacts).unwrap();
+        let raw =
+            conditional_absolute_risk(t0, t1, &covs, Some(0.0), None, &trusted.artifacts).unwrap();
         base.push(raw);
-        let cal = conditional_absolute_risk(t0, t1, &covs, Some(0.12), None, &trusted.artifacts).unwrap();
+        let cal =
+            conditional_absolute_risk(t0, t1, &covs, Some(0.12), None, &trusted.artifacts).unwrap();
         calibrated.push(cal);
     }
     assert!(base.windows(2).all(|w| w[1] + 1e-12 >= w[0]));


### PR DESCRIPTION
## Summary
- reuse the PIRLS `WorkingModel` trait inside the survival implementation and expose an inherent `update_state` helper for survival-specific callers
- add a generic PIRLS driver that works with dense Hessians so survival and GAM models can share the same iteration plumbing
- switch `train_survival_model` to call the shared runner and adjust the regression tests to use the new `update_state` method

## Testing
- cargo fmt
- cargo test survival_regression -- --nocapture *(aborted after a long dependency build)*

------
https://chatgpt.com/codex/tasks/task_e_69038847770c832ea6682c2e73793567