### PR TITLE
Handle survival companion CIF inputs

### DIFF
--- a/calibrate/construction.rs
+++ b/calibrate/construction.rs
@@ -3225,6 +3225,7 @@ mod tests {
             scale: None,
             calibrator: None,
             survival: None,
+            survival_companions: HashMap::new(),
         };
 
         let preds_via_predict = model

--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -871,6 +871,7 @@ pub fn train_model(
             scale: Some(scale_val),
             calibrator: None,
             survival: None,
+            survival_companions: HashMap::new(),
         };
 
         trained_model
@@ -1537,6 +1538,7 @@ pub fn train_model(
         scale: Some(scale_val),
         calibrator: calibrator_opt,
         survival: None,
+        survival_companions: HashMap::new(),
     };
 
     trained_model
@@ -2342,6 +2344,7 @@ pub fn train_survival_model(
         scale: None,
         calibrator: None,
         survival: Some(artifacts),
+        survival_companions: HashMap::new(),
     })
 }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -377,6 +377,7 @@ pub fn infer(args: InferArgs) -> Result<(), Box<dyn std::error::Error>> {
                     data.sex.view(),
                     data.pcs.view(),
                     None,
+                    Some(&model.survival_companions),
                 )?;
 
                 let calibrated_risk = if args.no_calibration {
@@ -396,6 +397,7 @@ pub fn infer(args: InferArgs) -> Result<(), Box<dyn std::error::Error>> {
                         data.sex.view(),
                         data.pcs.view(),
                         None,
+                        Some(&model.survival_companions),
                     ) {
                         Ok(calibrated) => Some(calibrated),
                         Err(_) => None,


### PR DESCRIPTION
## Summary
- store a companion survival registry on `TrainedModel` and thread it through survival prediction APIs
- evaluate competing CIFs via `competing_cif_value`, surfacing `MissingCompanionCifData` when no source is available and wiring CLI calls to the registry
- extend survival regression coverage to companion scenarios, including new regression tests for missing competing-risk data

## Testing
- cargo fmt


------
https://chatgpt.com/codex/tasks/task_e_69043d7a50e8832e9d4aa52b24bd0696