### PR TITLE
Enforce deterministic survival monotonicity

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -1561,7 +1561,7 @@ pub fn train_survival_model(
 ) -> Result<TrainedModel, EstimationError> {
     use crate::calibrate::basis::{clear_basis_cache, create_bspline_basis};
     use crate::calibrate::survival::{
-        AgeTransform, BasisDescriptor, CovariateLayout, HessianFactor, MonotonicityPenalty,
+        AgeTransform, BasisDescriptor, CovariateLayout, HessianFactor, MonotonicityConstraint,
         SurvivalError, SurvivalLayoutBundle, SurvivalModelArtifacts, SurvivalSpec, ValueRange,
         WorkingModelSurvival,
     };
@@ -1707,7 +1707,6 @@ pub fn train_survival_model(
         survival_cfg.guard_delta,
         config.penalty_order,
         survival_cfg.initial_lambda,
-        survival_cfg.monotonic_lambda,
         survival_cfg.monotonic_grid_size,
     )
     .map_err(map_error)?;
@@ -1730,7 +1729,7 @@ pub fn train_survival_model(
 
     struct SurvivalLambdaOptimizer<'a> {
         base_layout: SurvivalLayout,
-        monotonicity: MonotonicityPenalty,
+        monotonicity: MonotonicityConstraint,
         data: &'a crate::calibrate::survival::SurvivalTrainingData,
         spec: SurvivalSpec,
         options: crate::calibrate::pirls::WorkingModelPirlsOptions,
@@ -1748,7 +1747,7 @@ pub fn train_survival_model(
     impl<'a> SurvivalLambdaOptimizer<'a> {
         fn new(
             layout: SurvivalLayout,
-            monotonicity: MonotonicityPenalty,
+            monotonicity: MonotonicityConstraint,
             data: &'a crate::calibrate::survival::SurvivalTrainingData,
             spec: SurvivalSpec,
             options: crate::calibrate::pirls::WorkingModelPirlsOptions,
@@ -2314,6 +2313,7 @@ pub fn train_survival_model(
         penalties: penalty_descriptors,
         age_transform: layout.age_transform,
         reference_constraint: layout.reference_constraint.clone(),
+        monotonicity: layout.monotonicity.clone(),
         interaction_metadata,
         companion_models: Vec::new(),
         hessian_factor,

--- a/calibrate/model.rs
+++ b/calibrate/model.rs
@@ -1774,8 +1774,7 @@ mod tests {
             knot_vector: array![0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0],
             degree: 2,
         };
-        let layout_bundle =
-            build_survival_layout(&data, &basis, 0.1, 2, 0.5, 0.5 * 1e-4, 4, None).unwrap();
+        let layout_bundle = build_survival_layout(&data, &basis, 0.1, 2, 0.5, 4, None).unwrap();
         let layout = layout_bundle.layout;
         let coeffs = Array1::from_elem(layout.combined_exit.ncols(), 0.1);
 
@@ -1803,6 +1802,7 @@ mod tests {
             penalties: Vec::new(),
             age_transform: layout.age_transform,
             reference_constraint: layout.reference_constraint.clone(),
+            monotonicity: layout.monotonicity.clone(),
             interaction_metadata: Vec::new(),
             companion_models: Vec::new(),
             hessian_factor: Some(HessianFactor::Expected {

--- a/tests/survival_regression.rs
+++ b/tests/survival_regression.rs
@@ -33,10 +33,9 @@ struct TrustedReferenceFixture {
 
 impl TrustedReference {
     fn load() -> Self {
-        let raw: TrustedReferenceFixture = serde_json::from_str(include_str!(
-            "trusted_reference_artifacts.json"
-        ))
-        .expect("trusted reference fixture");
+        let raw: TrustedReferenceFixture =
+            serde_json::from_str(include_str!("trusted_reference_artifacts.json"))
+                .expect("trusted reference fixture");
 
         let static_covariates = rows_to_array(&raw.static_covariates);
         let extra_static_covariates = rows_to_array(&raw.extra_static_covariates);
@@ -89,7 +88,6 @@ fn rows_to_array(rows: &[Vec<f64>]) -> Array2<f64> {
     Array2::from_shape_vec((rows_len, cols), data).expect("reshape rows into matrix")
 }
 
-
 fn weighted_brier(weights: &Array1<f64>, outcomes: &Array1<f64>, predictions: &Array1<f64>) -> f64 {
     let total_weight: f64 = weights.sum();
     let mut score = 0.0;
@@ -121,7 +119,7 @@ fn replicated_brier(
 #[test]
 fn cumulative_incidence_matches_reference_library() {
     let trusted = TrustedReference::load();
-    
+
     // Compute CIF values using our implementation
     let mut computed_cif = Vec::new();
     for (idx, exit_age) in trusted.data.age_exit.iter().enumerate().take(4) {
@@ -129,35 +127,42 @@ fn cumulative_incidence_matches_reference_library() {
         let cif = cumulative_incidence(*exit_age, &cov, &trusted.artifacts).unwrap();
         computed_cif.push(cif);
     }
-    
+
     // Compare computed values against lifelines reference
     let expected = &trusted.lifelines_cif[..4];
     assert_eq!(computed_cif.len(), expected.len());
     for (computed, expected) in computed_cif.iter().zip(expected.iter()) {
-        assert!((computed - expected).abs() <= 1e-10, 
-            "CIF mismatch: computed={}, expected={}", computed, expected);
+        assert!(
+            (computed - expected).abs() <= 1e-10,
+            "CIF mismatch: computed={}, expected={}",
+            computed,
+            expected
+        );
     }
 }
 
 #[test]
 fn brier_score_matches_reference_library() {
     let trusted = TrustedReference::load();
-    
+
     // Compute predictions using our model
     let mut preds = Array1::<f64>::zeros(trusted.data.age_exit.len());
     for (idx, exit_age) in trusted.data.age_exit.iter().enumerate() {
         let cov = trusted.covariates_row(idx);
         preds[idx] = cumulative_incidence(*exit_age, &cov, &trusted.artifacts).unwrap();
     }
-    
+
     // Compute weighted Brier score
     let outcomes = trusted.data.event_target.map(|v| f64::from(*v));
     let computed_brier = weighted_brier(&trusted.data.sample_weight, &outcomes, &preds);
-    
+
     // Compare against lifelines reference
-    assert!((computed_brier - trusted.lifelines_weighted_brier).abs() <= 1e-10,
-        "Brier score mismatch: computed={}, expected={}", 
-        computed_brier, trusted.lifelines_weighted_brier);
+    assert!(
+        (computed_brier - trusted.lifelines_weighted_brier).abs() <= 1e-10,
+        "Brier score mismatch: computed={}, expected={}",
+        computed_brier,
+        trusted.lifelines_weighted_brier
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace the survival monotonicity penalty with a deterministic constraint and clamp logic in the working model
- persist the new constraint metadata through layout bundles, artifacts, and model helpers
- update survival regression fixtures and tests to cover the hardened constraint behaviour

## Testing
- cargo test calibrate::survival --tests

------
https://chatgpt.com/codex/tasks/task_e_69043d76a320832e98601d696fc26ccf