### PR TITLE
Automate survival penalty seeding and drop CLI overrides

### DIFF
--- a/calibrate/README.md
+++ b/calibrate/README.md
@@ -126,7 +126,10 @@ metadata so predictions can reproduce the post-hoc correction faithfully.
 3. **Optimize smoothing parameters** – With the design in place, the REML
    optimizer in `estimate.rs` alternates between P-IRLS solves (via `pirls.rs`)
    and BFGS updates over log-smoothing parameters until convergence or until it
-   detects degeneracy (separation, rank deficiency, etc.).
+   detects degeneracy (separation, rank deficiency, etc.). Survival models seed
+   their baseline and monotonic penalties from basis metadata and age ranges,
+   but the final smoothing strengths are still chosen automatically by the
+   REML/BFGS loop.
 4. **Capture geometric guards** – During training the optimizer builds a peeled
    hull from the polygenic score and principal components. The hull and its
    signed-distance function inform both the calibrator and future prediction

--- a/calibrate/model.rs
+++ b/calibrate/model.rs
@@ -91,9 +91,7 @@ pub struct PrincipalComponentConfig {
 pub struct SurvivalModelConfig {
     pub baseline_basis: BasisConfig,
     pub guard_delta: f64,
-    pub initial_lambda: f64,
     pub monotonic_grid_size: usize,
-    pub monotonic_lambda: f64,
 }
 
 /// Holds the transformation matrix for a sum-to-zero constraint.
@@ -1774,8 +1772,7 @@ mod tests {
             knot_vector: array![0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0],
             degree: 2,
         };
-        let layout_bundle =
-            build_survival_layout(&data, &basis, 0.1, 2, 0.5, 0.5 * 1e-4, 4, None).unwrap();
+        let layout_bundle = build_survival_layout(&data, &basis, 0.1, 2, 4, None).unwrap();
         let layout = layout_bundle.layout;
         let coeffs = Array1::from_elem(layout.combined_exit.ncols(), 0.1);
 
@@ -1841,9 +1838,7 @@ mod tests {
                     degree: basis.degree,
                 },
                 guard_delta: 0.1,
-                initial_lambda: 0.5,
                 monotonic_grid_size: 4,
-                monotonic_lambda: 0.5,
             }),
         };
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -101,17 +101,9 @@ pub struct TrainArgs {
     #[arg(long, default_value = "3")]
     pub survival_baseline_degree: usize,
 
-    /// Initial smoothing parameter for the survival baseline spline
-    #[arg(long, default_value = "1.0")]
-    pub survival_initial_lambda: f64,
-
     /// Grid size for the survival monotonicity penalty
     #[arg(long, default_value = "64")]
     pub survival_monotonic_grid: usize,
-
-    /// Weight of the survival monotonicity barrier
-    #[arg(long, default_value = "0.0001")]
-    pub survival_monotonic_lambda: f64,
 
     /// Derivative guard threshold used inside the survival likelihood
     #[arg(long, default_value = "1e-8")]
@@ -255,9 +247,7 @@ pub fn train(args: TrainArgs) -> Result<(), Box<dyn std::error::Error>> {
                     degree: args.survival_baseline_degree,
                 },
                 guard_delta: args.survival_guard_delta,
-                initial_lambda: args.survival_initial_lambda,
                 monotonic_grid_size: args.survival_monotonic_grid,
-                monotonic_lambda: args.survival_monotonic_lambda,
             };
 
             let config = ModelConfig {


### PR DESCRIPTION
## Summary
- remove the survival initial/monotonic lambda flags from the training CLI and model configuration
- seed survival baseline and monotonic penalties from basis metadata within `build_survival_layout`, logging the automatically selected starting values
- adjust survival tests to work through the new automatic initialization path and document that smoothing is REML-selected

## Testing
- `cargo test survival`


------
https://chatgpt.com/codex/tasks/task_e_69043d76e9a8832e9ce3067d9387b006