### PR TITLE
Fix unclosed delimiter in survival.rs tests

### DIFF
--- a/calibrate/survival.rs
+++ b/calibrate/survival.rs
@@ -2727,6 +2727,9 @@ mod tests {
                     .to_string()
                     .contains("Monotonicity barrier active")
         }));
+    }
+
+    #[test]
     fn monotonic_penalty_triggers_for_negative_slopes() {
         let mut data = toy_training_data();
         data.sample_weight.fill(0.0);


### PR DESCRIPTION
Added missing closing brace for barrier_activation_warning_silent_when_fraction_below_threshold test function and added missing #[test] attribute for monotonic_penalty_triggers_for_negative_slopes.