### PR TITLE
Enforce hard monotonicity constraints in survival calibration

### DIFF
--- a/calibrate/estimate.rs
+++ b/calibrate/estimate.rs
@@ -1777,15 +1777,16 @@ pub fn train_survival_model(
     )
     .map_err(map_error)?;
 
+    let monotonic_points = monotonicity.derivative_design.nrows();
     if let Some(block) = layout.penalties.blocks.first() {
         eprintln!(
-            "[STAGE 1/3] Baseline λ seed (auto): {:.3e}; monotonic weight: {:.3e}",
-            block.lambda, monotonicity.lambda,
+            "[STAGE 1/3] Baseline λ seed (auto): {:.3e}; monotonic grid points: {}",
+            block.lambda, monotonic_points,
         );
     } else {
         eprintln!(
-            "[STAGE 1/3] No baseline penalty detected; monotonic weight: {:.3e}",
-            monotonicity.lambda,
+            "[STAGE 1/3] No baseline penalty detected; monotonic grid points: {}",
+            monotonic_points,
         );
     }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -109,14 +109,6 @@ pub struct TrainArgs {
     #[arg(long, default_value = "1e-8")]
     pub survival_derivative_guard: f64,
 
-    /// Soft barrier weight discouraging negative derivatives in survival models
-    #[arg(long, default_value = "0.0001")]
-    pub survival_barrier_weight: f64,
-
-    /// Soft barrier scale controlling derivative penalties in survival models
-    #[arg(long, default_value = "1.0")]
-    pub survival_barrier_scale: f64,
-
     /// Use expected information instead of observed Hessian when fitting survival models
     #[arg(long)]
     pub survival_expected_information: bool,
@@ -253,8 +245,6 @@ pub fn train(args: TrainArgs) -> Result<(), Box<dyn std::error::Error>> {
 
             let mut spec = SurvivalSpec::default();
             spec.derivative_guard = args.survival_derivative_guard;
-            spec.barrier_weight = args.survival_barrier_weight;
-            spec.barrier_scale = args.survival_barrier_scale;
             spec.use_expected_information = args.survival_expected_information;
 
             let time_varying = if args.survival_enable_time_varying {


### PR DESCRIPTION
## Summary
- enforce a hard monotonicity check on survival derivatives and surface dedicated errors when violations are detected
- remove user-tunable barrier weights/scales, updating the CLI and layout pipeline to rely on deterministic constraints
- refresh survival layout messaging and unit tests to reflect the hard enforcement path

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_6904ecef496c832eb51b54a54d7708db