### PR TITLE
Fix survival spec sanitization for updated struct

### DIFF
--- a/calibrate/model.rs
+++ b/calibrate/model.rs
@@ -213,11 +213,7 @@ impl ModelConfig {
         match &self.model_family {
             ModelFamily::Gam(_) => None,
             ModelFamily::Survival(spec) => {
-                let defaults = SurvivalSpec::default();
-                let mut sanitized = spec.clone();
-                sanitized.barrier_weight = defaults.barrier_weight;
-                sanitized.barrier_scale = defaults.barrier_scale;
-                Some(sanitized)
+                Some(spec.clone())
             }
         }
     }


### PR DESCRIPTION
## Summary
- return the configured survival specification without resetting removed barrier parameters

## Testing
- cargo build
- cargo test --test survival_regression (fails: brier_score_matches_reference_library, cumulative_incidence_matches_reference_library)


------
https://chatgpt.com/codex/tasks/task_e_69050742ca6c832ea688db59fd66109c