### PR TITLE
Fix PIRLS stability and expose calibration metrics

### DIFF
--- a/tests/calibration.rs
+++ b/tests/calibration.rs
@@ -386,7 +386,7 @@ fn cli_train_large_zero_pc_dataset_produces_model() -> Result<(), Box<dyn std::e
 
     let model_path = tmp.path().join("model.toml");
     assert!(model_path.exists(), "expected model.toml to be created");
-    let metadata = fs::metadata(model_path)?;
+    let metadata = fs::metadata(&model_path)?;
     assert!(metadata.len() > 0, "model.toml should not be empty");
 
     let prediction_input_path = tmp.path().join("large_predict.tsv");


### PR DESCRIPTION
## Summary
- stabilize the GAM logit working model by sharing the derivative floor across weights and the working response, clamping the residual, and symmetrizing the Hessian
- add a ridge-regularized fallback when the Newton direction is not a descent direction and ensure the line search rejects non-finite penalized deviance values
- re-export calibration metrics helpers (reliability bins, AUC, etc.) from the calibrator module and fix the CLI calibration test to borrow the model path when checking metadata

## Testing
- `cargo test cli_train_large_zero_pc_dataset_produces_model -- --nocapture` *(long-running in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910103e1b88832ea0891c2887a820ac)