### PR TITLE
Detect perfect separation under penalized logit

### DIFF
--- a/calibrate/pirls.rs
+++ b/calibrate/pirls.rs
@@ -1018,7 +1018,7 @@ pub fn fit_model_for_fixed_rho<'a>(
     let penalty_effective = has_penalty
         && lambdas
             .iter()
-            .any(|&lambda| lambda > EFFECTIVE_PENALTY_LAMBDA_THRESHOLD);
+            .all(|&lambda| lambda > EFFECTIVE_PENALTY_LAMBDA_THRESHOLD);
     let firth_active = options.firth_bias_reduction;
     if detect_unpenalized_logit_instability(
         link_function,


### PR DESCRIPTION
## Summary
- relax the logit instability guard so perfect separation is detected even when penalties are present
- mark smoothing configurations with effectively zero penalty strength so the PIRLS loop reports the instability upstream

## Testing
- cargo test calibrate::estimate::test_train_model_fails_gracefully_on_perfect_separation

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a9a8b9d0832e8e20575191ac7b1b)