### PR TITLE
Relax PIRLS deviance convergence tolerance

### DIFF
--- a/calibrate/pirls.rs
+++ b/calibrate/pirls.rs
@@ -576,6 +576,11 @@ where
             .sum::<f64>()
             .sqrt();
         let deviance_change = current_penalized - candidate_penalized;
+        let deviance_scale = current_penalized
+            .abs()
+            .max(candidate_penalized.abs())
+            .max(1.0);
+        let deviance_tolerance = options.convergence_tolerance * deviance_scale;
         #[cfg(test)]
         record_penalized_deviance(candidate_penalized);
 
@@ -609,7 +614,7 @@ where
         }
 
         if candidate_grad_norm < options.convergence_tolerance {
-            status = if deviance_change.abs() < options.convergence_tolerance {
+            status = if deviance_change.abs() < deviance_tolerance {
                 PirlsStatus::Converged
             } else {
                 PirlsStatus::StalledAtValidMinimum
@@ -618,7 +623,7 @@ where
             break;
         }
 
-        if deviance_change.abs() < options.convergence_tolerance {
+        if deviance_change.abs() < deviance_tolerance {
             status = PirlsStatus::Converged;
             final_state = Some(candidate_state);
             break;


### PR DESCRIPTION
## Summary
- scale the penalized deviance convergence tolerance by the deviance magnitude to avoid false `StalledAtValidMinimum` statuses

## Testing
- cargo test calibrate::pirls::tests::pirls_penalized_deviance_is_monotone

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910aa652f04832e93030c5772effc5e)