### PR TITLE
Add manual workflow to run a single Rust test

### DIFF
--- a/.github/workflows/manual-single-test.yml
+++ b/.github/workflows/manual-single-test.yml
@@ -1,0 +1,35 @@
+name: Manual Single Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_name:
+        description: "Name of the test to run"
+        required: true
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+jobs:
+  single-test:
+    name: Run selected test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cargo build (release)
+        run: cargo +nightly build --release
+
+      - name: Run selected test
+        env:
+          TEST_NAME: ${{ inputs.test_name }}
+        run: |
+          echo "Running test: $TEST_NAME"
+          cargo +nightly test --release "$TEST_NAME"


### PR DESCRIPTION
## Summary
- add a workflow_dispatch-powered CI job that builds in release mode and runs a single user-specified test

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917aa58ff54832ea35ee1bac0c1f4ae)