### PR TITLE
Strengthen derivative proofs in Calibrator.lean

### DIFF
--- a/proofs/Calibrator.lean
+++ b/proofs/Calibrator.lean
@@ -5722,10 +5722,32 @@ lemma differentiable_sigmoid (x : ℝ) : DifferentiableAt ℝ sigmoid x := by
     linarith
 
 lemma deriv_sigmoid (x : ℝ) : deriv sigmoid x = sigmoid x * (1 - sigmoid x) := by
-  admit
+  unfold sigmoid
+  have h_ne : 1 + Real.exp (-x) ≠ 0 := by
+    apply ne_of_gt
+    apply add_pos_of_pos_of_nonneg zero_lt_one (le_of_lt (Real.exp_pos _))
+  have h_diff_num : DifferentiableAt ℝ (fun _ => 1) x := differentiableAt_const _
+  have h_diff_denom : DifferentiableAt ℝ (fun x => 1 + Real.exp (-x)) x := by
+    apply DifferentiableAt.add
+    · apply differentiableAt_const
+    · apply DifferentiableAt.exp
+      apply DifferentiableAt.neg
+      apply differentiableAt_id
+  rw [deriv_div h_diff_num h_diff_denom h_ne]
+  field_simp [h_ne]
+  simp only [deriv_const, zero_mul, deriv_add, deriv_exp, deriv_neg, deriv_id, mul_neg, mul_one, zero_add, sub_zero, zero_sub]
+  ring
 
 lemma deriv2_sigmoid (x : ℝ) : deriv (deriv sigmoid) x = sigmoid x * (1 - sigmoid x) * (1 - 2 * sigmoid x) := by
-  admit
+  have h_deriv : deriv sigmoid = fun x => sigmoid x * (1 - sigmoid x) := funext deriv_sigmoid
+  rw [h_deriv]
+  have h_diff_sig : DifferentiableAt ℝ sigmoid x := differentiable_sigmoid x
+  have h_diff_one_sub : DifferentiableAt ℝ (fun x => 1 - sigmoid x) x := DifferentiableAt.sub (differentiableAt_const _) h_diff_sig
+  rw [deriv_mul h_diff_sig h_diff_one_sub]
+  rw [deriv_sub (differentiableAt_const _) h_diff_sig]
+  rw [deriv_const, zero_sub]
+  rw [deriv_sigmoid]
+  ring
 
 lemma sigmoid_strictConcaveOn_Ici : StrictConcaveOn ℝ (Set.Ici 0) sigmoid := by
   apply strictConcaveOn_of_deriv2_neg (convex_Ici 0)


### PR DESCRIPTION
Strengthened the proofs for `deriv_sigmoid` and `deriv2_sigmoid` in `proofs/Calibrator.lean` by replacing `admit` with actual tactic proofs. This ensures that the derivative properties of the sigmoid function, which are critical for subsequent convexity proofs, are mathematically verified rather than assumed. The proofs utilize `deriv_div` and `deriv_mul` along with properties of the exponential function.

Attempted to also replace `admit`s related to Gaussian integrals in `quantitative_error_of_normalization_multiplicative`, but these were reverted to ensure the build remains stable as the specific Mathlib theorem names for Gaussian moments were not immediately resolvable without further exploration. The derivative proofs are a self-contained and significant improvement.

---
*PR created automatically by Jules for task [13436474006432569505](https://jules.google.com/task/13436474006432569505) started by @SauersML*