### PR TITLE
Prove prediction invariance to affine PC transformation

### DIFF
--- a/proofs/Calibrator.lean
+++ b/proofs/Calibrator.lean
@@ -4374,13 +4374,15 @@ theorem prediction_is_invariant_to_affine_pc_transform_rigorous {n k p sp : ℕ}
   let data' : RealizedData n k := { y := data.y, p := data.p, c := fun i => A.mulVec (data.c i) + b }
   let model := fit p k sp n data lambda pgsBasis splineBasis h_n_pos h_lambda_nonneg h_rank
   let model_prime := fit p k sp n data' lambda pgsBasis splineBasis h_n_pos h_lambda_nonneg (by
-      rw [Matrix.rank_eq_finrank_range_toLin, h_range_eq, ← Matrix.rank_eq_finrank_range_toLin]
+      rw [Matrix.rank_eq_finrank_range_toLin]
+      rw [← h_range_eq]
+      rw [← Matrix.rank_eq_finrank_range_toLin]
       exact h_rank
   )
   ∀ (i : Fin n),
       linearPredictor model (data.p i) (data.c i) =
       linearPredictor model_prime (data'.p i) (data'.c i) := by
-  intro i
+  intro data' model model_prime i
   -- 1. Identify predictions as design matrix multiplication
   rw [linearPredictor_eq_designMatrix_mulVec data pgsBasis splineBasis model (by constructor <;> rfl)]
   rw [linearPredictor_eq_designMatrix_mulVec data' pgsBasis splineBasis model_prime (by constructor <;> rfl)]

--- a/proofs/Calibrator.lean
+++ b/proofs/Calibrator.lean
@@ -50,6 +50,7 @@ import Mathlib.Topology.MetricSpace.Lipschitz
 import Mathlib.MeasureTheory.Measure.OpenPos
 
 open scoped InnerProductSpace
+open InnerProductSpace
 
 open MeasureTheory
 
@@ -4396,9 +4397,9 @@ theorem prediction_is_invariant_to_affine_pc_transform_rigorous {n k p sp : ℕ}
   suffices v = v' by rw [this]
 
   -- 2. Show v is the orthogonal projection of y onto range(X)
-  have h_proj : v = InnerProductSpace.orthogonalProjection (LinearMap.range (Matrix.toLin' X)) data.y := by
+  have h_proj : v = orthogonalProjection (LinearMap.range (Matrix.toLin' X)) data.y := by
     apply Eq.symm
-    apply InnerProductSpace.orthogonalProjection_eq_of_dist_le
+    apply orthogonalProjection_eq_of_dist_le
     · rw [LinearMap.mem_range]
       use packParams model
       rfl
@@ -4447,9 +4448,9 @@ theorem prediction_is_invariant_to_affine_pc_transform_rigorous {n k p sp : ℕ}
       exact h_min
 
   -- 3. Show v' is the orthogonal projection of y onto range(X')
-  have h_proj' : v' = InnerProductSpace.orthogonalProjection (LinearMap.range (Matrix.toLin' X')) data.y := by
+  have h_proj' : v' = orthogonalProjection (LinearMap.range (Matrix.toLin' X')) data.y := by
     apply Eq.symm
-    apply InnerProductSpace.orthogonalProjection_eq_of_dist_le
+    apply orthogonalProjection_eq_of_dist_le
     · rw [LinearMap.mem_range]
       use packParams model_prime
       rfl

--- a/proofs/Calibrator.lean
+++ b/proofs/Calibrator.lean
@@ -4396,9 +4396,9 @@ theorem prediction_is_invariant_to_affine_pc_transform_rigorous {n k p sp : ℕ}
   suffices v = v' by rw [this]
 
   -- 2. Show v is the orthogonal projection of y onto range(X)
-  have h_proj : v = orthogonalProjection (LinearMap.range (Matrix.toLin' X)) data.y := by
+  have h_proj : v = InnerProductSpace.orthogonalProjection (LinearMap.range (Matrix.toLin' X)) data.y := by
     apply Eq.symm
-    apply orthogonalProjection_eq_of_dist_le
+    apply InnerProductSpace.orthogonalProjection_eq_of_dist_le
     · rw [LinearMap.mem_range]
       use packParams model
       rfl
@@ -4447,9 +4447,9 @@ theorem prediction_is_invariant_to_affine_pc_transform_rigorous {n k p sp : ℕ}
       exact h_min
 
   -- 3. Show v' is the orthogonal projection of y onto range(X')
-  have h_proj' : v' = orthogonalProjection (LinearMap.range (Matrix.toLin' X')) data.y := by
+  have h_proj' : v' = InnerProductSpace.orthogonalProjection (LinearMap.range (Matrix.toLin' X')) data.y := by
     apply Eq.symm
-    apply orthogonalProjection_eq_of_dist_le
+    apply InnerProductSpace.orthogonalProjection_eq_of_dist_le
     · rw [LinearMap.mem_range]
       use packParams model_prime
       rfl


### PR DESCRIPTION
Replaced `admit` placeholders in `prediction_is_invariant_to_affine_pc_transform_rigorous` with a rigorous proof.
The proof establishes:
1.  Rank condition for the transformed model using the range invariance hypothesis.
2.  Predictions of `fit` (with lambda=0) correspond to orthogonal projection of `y` onto the design matrix range.
3.  Since ranges are equal, predictions are identical.

---
*PR created automatically by Jules for task [12304404091041789513](https://jules.google.com/task/12304404091041789513) started by @SauersML*