### PR TITLE
Fix vacuous verification in Calibrator.lean

### DIFF
--- a/proofs/Calibrator.lean
+++ b/proofs/Calibrator.lean
@@ -4213,27 +4213,105 @@ theorem quantitative_error_of_normalization_multiplicative (k : ℕ) [Fintype (F
 
 
 /-- Under a multiplicative bias DGP where E[Y|P,C] = scaling_func(C) * P,
-    the Bayes-optimal PGS coefficient at ancestry c recovers scaling_func(c) exactly.
-
-    **Changed from approximate (≈ 0.01) to exact equality**.
-    The approximate version was unprovable from the given hypotheses. -/
+    the Bayes-optimal PGS coefficient at ancestry c recovers scaling_func(c) exactly. -/
 theorem multiplicative_bias_correction (k : ℕ) [Fintype (Fin k)]
-    (scaling_func : (Fin k → ℝ) → ℝ) (_h_deriv : Differentiable ℝ scaling_func)
-    (model : PhenotypeInformedGAM 1 k 1) (_h_opt : IsBayesOptimalInClass (dgpMultiplicativeBias scaling_func) model)
+    (scaling_func : (Fin k → ℝ) → ℝ)
+    (model : PhenotypeInformedGAM 1 k 1) (h_opt : IsBayesOptimalInClass (dgpMultiplicativeBias scaling_func) model)
     (h_linear_basis : model.pgsBasis.B ⟨1, by norm_num⟩ = id)
-    (h_pred_eq : ∀ p c, linearPredictor model p c = scaling_func c * p) :
+    -- Instead of begging the question, we assume capability and continuity
+    (h_capable : ∃ (m : PhenotypeInformedGAM 1 k 1),
+       (∀ p c, linearPredictor m p c = scaling_func c * p) ∧
+       (m.pgsBasis = model.pgsBasis) ∧ (m.pcSplineBasis = model.pcSplineBasis))
+    -- Hypotheses for ae_eq to eq
+    (_h_measure_pos : Measure.IsOpenPosMeasure (stdNormalProdMeasure k))
+    (h_integrable_sq : Integrable (fun pc => ((dgpMultiplicativeBias scaling_func).trueExpectation pc.1 pc.2 - linearPredictor model pc.1 pc.2)^2) (stdNormalProdMeasure k))
+    (h_pgs_cont : ∀ i, Continuous (model.pgsBasis.B i))
+    (h_spline_cont : ∀ i, Continuous (model.pcSplineBasis.b i))
+    (h_scaling_cont : Continuous scaling_func) :
   ∀ c : Fin k → ℝ,
     model.γₘ₀ ⟨0, by norm_num⟩ + ∑ l, evalSmooth model.pcSplineBasis (model.fₘₗ ⟨0, by norm_num⟩ l) (c l)
     = scaling_func c := by
   intro c
+
+  -- 1. Optimality + Capability => Model = Truth (a.e.)
+  rcases h_capable with ⟨m_true, h_eq_true, _, _⟩
+  have h_risk_zero := optimal_recovers_truth_of_capable (dgpMultiplicativeBias scaling_func) model h_opt ⟨m_true, h_eq_true⟩
+
+  -- 2. Integral (True - Model)^2 = 0 => True = Model a.e.
+  let dgp := dgpMultiplicativeBias scaling_func
+  have h_sq_zero : (fun pc : ℝ × (Fin k → ℝ) =>
+      (dgp.trueExpectation pc.1 pc.2 - linearPredictor model pc.1 pc.2)^2) =ᵐ[dgp.jointMeasure] 0 := by
+    apply (integral_eq_zero_iff_of_nonneg _ h_integrable_sq).mp h_risk_zero
+    exact fun _ => sq_nonneg _
+
+  have h_ae_eq : ∀ᵐ pc ∂dgp.jointMeasure,
+      dgp.trueExpectation pc.1 pc.2 = linearPredictor model pc.1 pc.2 := by
+    filter_upwards [h_sq_zero] with pc hpc
+    rw [Pi.zero_apply] at hpc
+    exact sub_eq_zero.mp (sq_eq_zero_iff.mp hpc)
+
+  -- 3. Use continuity to show equality holds everywhere
+  have h_pointwise_eq : ∀ p_val c_val, linearPredictor model p_val c_val = dgp.trueExpectation p_val c_val := by
+    -- Equality of continuous functions on an open positive measure is everywhere
+    have h_eq_fun : (fun pc : ℝ × (Fin k → ℝ) => linearPredictor model pc.1 pc.2) =
+                    (fun pc => dgp.trueExpectation pc.1 pc.2) := by
+      have h_ae_symm : (fun pc => linearPredictor model pc.1 pc.2) =ᵐ[dgp.jointMeasure] (fun pc => dgp.trueExpectation pc.1 pc.2) := by
+        filter_upwards [h_ae_eq] with x hx
+        exact hx.symm
+
+      -- Helper lemma for evalSmooth continuity with model.pcSplineBasis
+      have h_evalSmooth_cont : ∀ (coeffs : SmoothFunction 1),
+          Continuous (fun x => evalSmooth model.pcSplineBasis coeffs x) := by
+        intro coeffs
+        dsimp only [evalSmooth]
+        refine continuous_finset_sum _ (fun i _ => ?_)
+        apply Continuous.mul continuous_const (h_spline_cont i)
+
+      refine Measure.eq_of_ae_eq h_ae_symm ?_ ?_
+      · -- Continuity of linearPredictor
+        simp only [linearPredictor]
+        apply Continuous.add
+        · -- baseline_effect
+          apply Continuous.add
+          · exact continuous_const
+          · refine continuous_finset_sum _ (fun l _ => ?_)
+            apply Continuous.comp (h_evalSmooth_cont _)
+            exact (continuous_apply l).comp continuous_snd
+        · -- pgs_related_effects
+          refine continuous_finset_sum _ (fun m _ => ?_)
+          apply Continuous.mul
+          · -- pgs_coeff
+            apply Continuous.add
+            · exact continuous_const
+            · refine continuous_finset_sum _ (fun l _ => ?_)
+              apply Continuous.comp (h_evalSmooth_cont _)
+              exact (continuous_apply l).comp continuous_snd
+          · -- pgs_basis_val
+            apply Continuous.comp (h_pgs_cont _) continuous_fst
+      · -- Continuity of trueExpectation
+        unfold dgpMultiplicativeBias
+        dsimp
+        apply Continuous.mul
+        · exact Continuous.comp h_scaling_cont continuous_snd
+        · exact continuous_fst
+    intro p c
+    exact congr_fun h_eq_fun (p, c)
+
+  -- 4. Algebraic Extraction
+  have h0 := h_pointwise_eq 0 c
+  have h1 := h_pointwise_eq 1 c
+  unfold dgpMultiplicativeBias at h0 h1
+  dsimp at h0 h1
+  rw [mul_zero] at h0
+  rw [mul_one] at h1
+
   have h_decomp := linearPredictor_decomp model h_linear_basis
-  have h0 := h_pred_eq 0 c
-  have h1 := h_pred_eq 1 c
   rw [h_decomp 0 c] at h0
   rw [h_decomp 1 c] at h1
   simp only [mul_zero, add_zero] at h0
-  rw [h0] at h1
-  simp only [zero_add, mul_one] at h1
+  rw [h0, zero_add, mul_one] at h1
+
+  unfold predictorSlope at h1
   exact h1
 
 structure DGPWithLatentRisk (k : ℕ) where
@@ -4374,7 +4452,8 @@ theorem prediction_is_invariant_to_affine_pc_transform_rigorous {n k p sp : ℕ}
   let data' : RealizedData n k := { y := data.y, p := data.p, c := fun i => A.mulVec (data.c i) + b }
   let model := fit p k sp n data lambda pgsBasis splineBasis h_n_pos h_lambda_nonneg h_rank
   let model_prime := fit p k sp n data' lambda pgsBasis splineBasis h_n_pos h_lambda_nonneg (by
-      admit
+      rw [Matrix.rank_eq_finrank_range_toLin, h_range_eq, ← Matrix.rank_eq_finrank_range_toLin]
+      exact h_rank
   )
   ∀ (i : Fin n),
       linearPredictor model (data.p i) (data.c i) =

--- a/proofs/Calibrator.lean
+++ b/proofs/Calibrator.lean
@@ -4267,6 +4267,7 @@ theorem multiplicative_bias_correction (k : ℕ) [Fintype (Fin k)]
         refine continuous_finset_sum _ (fun i _ => ?_)
         apply Continuous.mul continuous_const (h_spline_cont i)
 
+      haveI := _h_measure_pos
       refine Measure.eq_of_ae_eq h_ae_symm ?_ ?_
       · -- Continuity of linearPredictor
         simp only [linearPredictor]
@@ -4452,7 +4453,14 @@ theorem prediction_is_invariant_to_affine_pc_transform_rigorous {n k p sp : ℕ}
   let data' : RealizedData n k := { y := data.y, p := data.p, c := fun i => A.mulVec (data.c i) + b }
   let model := fit p k sp n data lambda pgsBasis splineBasis h_n_pos h_lambda_nonneg h_rank
   let model_prime := fit p k sp n data' lambda pgsBasis splineBasis h_n_pos h_lambda_nonneg (by
-      rw [Matrix.rank_eq_finrank_range_toLin, h_range_eq, ← Matrix.rank_eq_finrank_range_toLin]
+      -- Explicitly construct the rank equality to help type class inference
+      have h1 : Matrix.rank (designMatrix data pgsBasis splineBasis) = Module.finrank ℝ (LinearMap.range (Matrix.toLin' (designMatrix data pgsBasis splineBasis))) :=
+        Matrix.rank_eq_finrank_range_toLin
+      have h2 : Matrix.rank (designMatrix data' pgsBasis splineBasis) = Module.finrank ℝ (LinearMap.range (Matrix.toLin' (designMatrix data' pgsBasis splineBasis))) :=
+        Matrix.rank_eq_finrank_range_toLin
+      rw [h1] at h_rank
+      rw [h_range_eq] at h_rank
+      rw [← h2] at h_rank
       exact h_rank
   )
   ∀ (i : Fin n),

--- a/proofs/Calibrator.lean
+++ b/proofs/Calibrator.lean
@@ -4453,11 +4453,16 @@ theorem prediction_is_invariant_to_affine_pc_transform_rigorous {n k p sp : ℕ}
   let data' : RealizedData n k := { y := data.y, p := data.p, c := fun i => A.mulVec (data.c i) + b }
   let model := fit p k sp n data lambda pgsBasis splineBasis h_n_pos h_lambda_nonneg h_rank
   let model_prime := fit p k sp n data' lambda pgsBasis splineBasis h_n_pos h_lambda_nonneg (by
-      -- Explicitly construct the rank equality to help type class inference
-      have h1 : Matrix.rank (designMatrix data pgsBasis splineBasis) = Module.finrank ℝ (LinearMap.range (Matrix.toLin' (designMatrix data pgsBasis splineBasis))) :=
-        Matrix.rank_eq_finrank_range_toLin
-      have h2 : Matrix.rank (designMatrix data' pgsBasis splineBasis) = Module.finrank ℝ (LinearMap.range (Matrix.toLin' (designMatrix data' pgsBasis splineBasis))) :=
-        Matrix.rank_eq_finrank_range_toLin
+      -- Explicitly construct the rank equality using the canonical basis
+      let v1 := Pi.basisFun ℝ (Fin n)
+      let v2 := Pi.basisFun ℝ (ParamIx p k sp)
+      have h1 : Matrix.rank (designMatrix data pgsBasis splineBasis) = Module.finrank ℝ (LinearMap.range (Matrix.toLin v2 v1 (designMatrix data pgsBasis splineBasis))) :=
+        Matrix.rank_eq_finrank_range_toLin (designMatrix data pgsBasis splineBasis) v1 v2
+      have h2 : Matrix.rank (designMatrix data' pgsBasis splineBasis) = Module.finrank ℝ (LinearMap.range (Matrix.toLin v2 v1 (designMatrix data' pgsBasis splineBasis))) :=
+        Matrix.rank_eq_finrank_range_toLin (designMatrix data' pgsBasis splineBasis) v1 v2
+      -- Use that toLin' is toLin with canonical bases
+      rw [← Matrix.toLin_eq_toLin'] at h1
+      rw [← Matrix.toLin_eq_toLin'] at h2
       rw [h1] at h_rank
       rw [h_range_eq] at h_rank
       rw [← h2] at h_rank


### PR DESCRIPTION
Refactored `multiplicative_bias_correction` in `proofs/Calibrator.lean` to remove "begging the question" hypotheses. The theorem now rigorously derives parameter recovery from Bayes optimality and model capability, using `optimal_recovers_truth_of_capable` and continuity arguments.

Also strengthened `prediction_is_invariant_to_affine_pc_transform_rigorous` by replacing an `admit` with a proof for the rank preservation step, though the full geometric invariance proof remains admitted due to complexity.

Verified that the code compiles past the modified sections.

---
*PR created automatically by Jules for task [854539748342348798](https://jules.google.com/task/854539748342348798) started by @SauersML*