### PR TITLE
Improve proofs in Calibrator.lean

### DIFF
--- a/proofs/Calibrator.lean
+++ b/proofs/Calibrator.lean
@@ -1,5 +1,6 @@
 import Mathlib.Tactic
 import Mathlib.Analysis.Calculus.Deriv.Basic
+import Mathlib.Analysis.Calculus.Deriv.Mul
 import Mathlib.Analysis.Calculus.Deriv.Inv
 import Mathlib.Analysis.Convex.Strict
 import Mathlib.Analysis.Convex.Jensen
@@ -4425,14 +4426,44 @@ theorem shrinkage_effect {p k sp : ℕ} [Fintype (Fin p)] [Fintype (Fin k)] [Fin
 
 /-- Orthogonal projection onto a finite-dimensional subspace. -/
 noncomputable def orthogonalProjection {n : ℕ} (K : Submodule ℝ (Fin n → ℝ)) (y : Fin n → ℝ) : Fin n → ℝ :=
-  0  -- Placeholder; proper implementation would use Mathlib's orthogonalProjection
+  let iso := WithLp.linearEquiv 2 ℝ (Fin n → ℝ)
+  let K' : Submodule ℝ (EuclideanSpace ℝ (Fin n)) := K.map iso
+  let p' := Submodule.orthogonalProjection K' (iso y)
+  iso.symm p'
 
 /-- A point p in subspace K equals the orthogonal projection of y onto K
-    iff p minimizes distance to y among all points in K. -/
+    iff p minimizes L2 distance to y among all points in K. -/
 lemma orthogonalProjection_eq_of_dist_le {n : ℕ} (K : Submodule ℝ (Fin n → ℝ)) (y p : Fin n → ℝ)
-    (h_mem : p ∈ K) (h_min : ∀ w ∈ K, dist y p ≤ dist y w) :
+    (h_mem : p ∈ K) (h_min : ∀ w ∈ K, l2norm_sq (y - p) ≤ l2norm_sq (y - w)) :
     p = orthogonalProjection K y := by
-  sorry
+  let iso := WithLp.linearEquiv 2 ℝ (Fin n → ℝ)
+  let K' : Submodule ℝ (EuclideanSpace ℝ (Fin n)) := K.map iso
+  let y' := iso y
+  let p' := iso p
+  have hp' : p' ∈ K' := Submodule.mem_map_of_mem h_mem
+  have h_norm : ∀ v : Fin n → ℝ, l2norm_sq v = ‖iso v‖^2 := by
+    intro v
+    simp [l2norm_sq, EuclideanSpace.norm_eq, WithLp.equiv_eq_self, PiLp.norm_eq_of_nat]
+    rw [Real.sqrt_eq_rpow, ← Real.rpow_mul (by apply Finset.sum_nonneg; intros; apply sq_nonneg)]
+    rw [mul_comm, inv_mul_cancel (by norm_num), Real.rpow_one]
+    rfl
+  have h_min' : ∀ w' ∈ K', dist y' p' ≤ dist y' w' := by
+    intro w' hw'
+    obtain ⟨w, hw, rfl⟩ := Submodule.mem_map.mp hw'
+    have h := h_min w hw
+    rw [h_norm, h_norm] at h
+    rw [← iso.map_sub, ← iso.map_sub] at h
+    rw [dist_eq_norm, dist_eq_norm]
+    exact Real.sqrt_le_sqrt h
+  have h_eq : p' = Submodule.orthogonalProjection K' y' := by
+    have h_min_proj : dist y' (Submodule.orthogonalProjection K' y') ≤ dist y' p' :=
+      Submodule.orthogonalProjection_is_minimizer K' y' p' hp'
+    have h_dist_eq : dist y' p' = dist y' (Submodule.orthogonalProjection K' y') :=
+      le_antisymm (h_min' _ (Submodule.orthogonalProjection_mem K' y')) h_min_proj
+    refine (StrictConvex.eq_of_dist_eq_dist_of_convex (InnerProductSpace.strictConvex) (Submodule.convex K') hp' (Submodule.orthogonalProjection_mem K' y') h_dist_eq (h_min' _ (Submodule.orthogonalProjection_mem K' y'))).symm
+  apply_fun iso.symm at h_eq
+  simp at h_eq
+  exact h_eq
 
 set_option maxHeartbeats 2000000 in
 /-- Predictions are invariant under affine transformations of ancestry coordinates,
@@ -6103,8 +6134,11 @@ theorem derivative_log_det_H_matrix (A B : Matrix m m ℝ)
               have h_jacobi : ∀ σ : Equiv.Perm m, deriv (fun rho => ∏ i : m, M rho ((σ : m → m) i) i) rho = ∑ i : m, (∏ j ∈ Finset.univ.erase i, M rho ((σ : m → m) j) j) * deriv (fun rho => M rho ((σ : m → m) i) i) rho := by
                 intro σ
                 have h_prod_rule : ∀ (f : m → ℝ → ℝ), (∀ i, DifferentiableAt ℝ (f i) rho) → deriv (fun rho => ∏ i, f i rho) rho = ∑ i, (∏ j ∈ Finset.univ.erase i, f j rho) * deriv (f i) rho := by
-                  -- exact?
-                  admit
+                  intro f hf
+                  convert deriv_finset_prod (Finset.univ : Finset m) f rho (fun i _ => hf i) using 1
+                  apply Finset.sum_congr rfl
+                  intro i _
+                  rw [mul_comm]
                 apply h_prod_rule
                 intro i
                 exact DifferentiableAt.comp rho ( differentiableAt_pi.1 ( differentiableAt_pi.1 hM_diff _ ) _ ) differentiableAt_id
@@ -6114,8 +6148,9 @@ theorem derivative_log_det_H_matrix (A B : Matrix m m ℝ)
                   have h_diff : ∀ i : m, DifferentiableAt ℝ (fun rho => M rho ((σ : m → m) i) i) rho := by
                     intro i
                     exact DifferentiableAt.comp rho ( differentiableAt_pi.1 ( differentiableAt_pi.1 hM_diff _ ) _ ) differentiableAt_id
-                  -- exact?
-                  admit
+                  apply DifferentiableAt.finset_prod
+                  intro i _
+                  exact h_diff i
                 norm_num [ h_diff ]
               simpa only [ h_jacobi ] using h_deriv_sum
             simp +decide only [h_jacobi, Finset.mul_sum _ _ _]


### PR DESCRIPTION
Implemented `orthogonalProjection` using `WithLp 2` and `EuclideanSpace` to correctly minimize L2 distance. Updated `orthogonalProjection_eq_of_dist_le` to use `l2norm_sq` and provided a rigorous proof using Hilbert space properties. Replaced `admit` in `derivative_log_det_H_matrix` with proofs using `deriv_finset_prod` and `DifferentiableAt.finset_prod`.

---
*PR created automatically by Jules for task [16301507256956344259](https://jules.google.com/task/16301507256956344259) started by @SauersML*