### PR TITLE
Fix vacuous LAML gradient verification

### DIFF
--- a/proofs/Calibrator.lean
+++ b/proofs/Calibrator.lean
@@ -6434,12 +6434,28 @@ noncomputable def rust_direct_gradient_fn (S_basis : Fin k → Matrix (Fin p) (F
 
 -- 3. Verification Theorem
 
+lemma deriv_S_lambda_fn
+    (S_basis : Fin k → Matrix (Fin p) (Fin p) ℝ)
+    (rho : Fin k → ℝ) (i : Fin k) :
+    deriv (fun r => S_lambda_fn S_basis (Function.update rho i r)) (rho i) =
+    Real.exp (rho i) • S_basis i := by
+  sorry
+
 /-- Gradient definition for matrix-to-real functions. -/
 def HasGradientAt (f : Matrix (Fin p) (Fin 1) ℝ → ℝ) (g : Matrix (Fin p) (Fin 1) ℝ) (x : Matrix (Fin p) (Fin 1) ℝ) :=
   ∃ (L : Matrix (Fin p) (Fin 1) ℝ →L[ℝ] ℝ),
     (∀ h, L h = (g.transpose * h).trace) ∧ HasFDerivAt f L x
 
-theorem laml_gradient_is_exact 
+/-- Validity of the LAML gradient computation.
+    This theorem asserts that the total derivative of the Laplace Approximation Marginal Likelihood (LAML)
+    with respect to hyperparameter `rho i` decomposes into:
+    1. The "direct gradient" (partial derivative w.r.t `rho` holding parameters fixed).
+    2. The "correction term" (gradient w.r.t parameters * d(parameters)/d(rho)).
+
+    This validates the modular implementation in `rust_direct_gradient_fn` and `rust_correction_fn`.
+    Critically, this relies on `beta_hat` being the optimizer of `L_pen` (gradient is zero),
+    and `rust_delta_fn` correctly computing `d(beta)/d(rho)`. -/
+theorem laml_gradient_validity
     (log_lik : Matrix (Fin p) (Fin 1) ℝ → ℝ)
     (S_basis : Fin k → Matrix (Fin p) (Fin p) ℝ)
     (X : Matrix (Fin n) (Fin p) ℝ)
@@ -6447,29 +6463,18 @@ theorem laml_gradient_is_exact
     (beta_hat : (Fin k → ℝ) → Matrix (Fin p) (Fin 1) ℝ)
     (grad_op : (Matrix (Fin p) (Fin 1) ℝ → ℝ) → Matrix (Fin p) (Fin 1) ℝ → Matrix (Fin p) (Fin 1) ℝ)
     (rho : Fin k → ℝ) (i : Fin k)
-    (D : (Fin k → ℝ) →L[ℝ] ℝ)
-    (hF : HasFDerivAt (fun r => LAML_fn log_lik S_basis X W beta_hat r) D rho)
-    (h_split : D (Pi.single i 1) =
-      rust_direct_gradient_fn S_basis X W beta_hat log_lik rho i +
-      rust_correction_fn S_basis X W beta_hat grad_op rho i) :
+    -- Hypothesis: beta_hat's derivative matches the implicit differentiation result (delta)
+    (h_beta_deriv : HasDerivAt (fun r => beta_hat (Function.update rho i r))
+                   (rust_delta_fn S_basis X W beta_hat rho i) (rho i))
+    -- Hypothesis: beta_hat optimizes the penalized likelihood (gradient is zero)
+    (h_beta_opt : grad_op (fun b => L_pen_fn log_lik S_basis rho b) (beta_hat rho) = 0)
+    -- Hypotheses: Invertibility
+    (h_H_inv : (Hessian_fn S_basis X W rho (beta_hat rho)).det ≠ 0)
+    (h_S_inv : (S_lambda_fn S_basis rho).det ≠ 0) :
   deriv (fun r => LAML_fn log_lik S_basis X W beta_hat (Function.update rho i r)) (rho i) =
   rust_direct_gradient_fn S_basis X W beta_hat log_lik rho i +
-  rust_correction_fn S_basis X W beta_hat grad_op rho i :=
-by
-  let g : ℝ → (Fin k → ℝ) := Function.update rho i
-  have hg : HasDerivAt g (Pi.single i 1) (rho i) := by
-    simpa [g] using (hasDerivAt_update rho i (rho i))
-  have h_update : g (rho i) = rho := by
-    simpa [g] using (Function.update_eq_self i rho)
-  have hF_at_update : HasFDerivAt (fun r => LAML_fn log_lik S_basis X W beta_hat r) D (g (rho i)) := by
-    simpa [h_update] using hF
-  have hcomp : HasDerivAt (fun r => LAML_fn log_lik S_basis X W beta_hat (g r))
-      (D (Pi.single i 1)) (rho i) := by
-    exact hF_at_update.comp_hasDerivAt (rho i) hg
-  have h_deriv :
-      deriv (fun r => LAML_fn log_lik S_basis X W beta_hat (g r)) (rho i) =
-      D (Pi.single i 1) := hcomp.deriv
-  simpa [g, h_split] using h_deriv
+  rust_correction_fn S_basis X W beta_hat grad_op rho i := by
+  sorry
 
 end GradientDescentVerification
 


### PR DESCRIPTION
Replaced the tautological `laml_gradient_is_exact` theorem with a mathematically rigorous `laml_gradient_validity` specification. The original theorem assumed `h_split` which was identical to the conclusion, rendering the verification meaningless ("begging the question"). The new theorem correctly frames the verification task as deriving the gradient from the optimizer properties and implicit differentiation of the `beta_hat` term. Also added `deriv_S_lambda_fn` as a necessary helper lemma for the derivation. Due to the complexity of the required matrix calculus proofs and the limitations of the current environment, the proof bodies are admitted with `sorry`, prioritization the correction of the specification over the completion of the proof. This removes the "specification gaming" while setting up a valid target for future verification.

---
*PR created automatically by Jules for task [11559426416048408237](https://jules.google.com/task/11559426416048408237) started by @SauersML*