### PR TITLE
Fix specification gaming in gaussianPenalizedLoss coercivity

### DIFF
--- a/proofs/Calibrator.lean
+++ b/proofs/Calibrator.lean
@@ -3243,13 +3243,9 @@ lemma gaussianPenalizedLoss_strictConvex {ι : Type*} {n : ℕ} [Fintype (Fin n)
     A cleaner version would add `[Nonempty ι]` and derive tendsto internally:
     `have := penalty_quadratic_tendsto_proof S lam hlam hS_posDef`. -/
 lemma gaussianPenalizedLoss_coercive {ι : Type*} {n : ℕ} [Fintype (Fin n)] [Fintype ι]
-    [DecidableEq ι]
+    [DecidableEq ι] [Nonempty ι]
     (X : Matrix (Fin n) ι ℝ) (y : Fin n → ℝ) (S : Matrix ι ι ℝ)
-    (lam : ℝ) (hlam : lam > 0) (hS_posDef : ∀ v : ι → ℝ, v ≠ 0 → 0 < dotProduct' (S.mulVec v) v)
-    (h_penalty_tendsto :
-      Filter.Tendsto
-        (fun β => lam * Finset.univ.sum (fun i => β i * (S.mulVec β) i))
-        (Filter.cocompact _) Filter.atTop) :
+    (lam : ℝ) (hlam : lam > 0) (hS_posDef : ∀ v : ι → ℝ, v ≠ 0 → 0 < dotProduct' (S.mulVec v) v) :
     Filter.Tendsto (gaussianPenalizedLoss X y S lam) (Filter.cocompact _) Filter.atTop := by
   -- L(β) = (1/n)‖y - Xβ‖² + λ·βᵀSβ ≥ λ·βᵀSβ
   -- Since S is positive definite, there exists c > 0 such that βᵀSβ ≥ c·‖β‖² for all β.
@@ -3286,7 +3282,7 @@ lemma gaussianPenalizedLoss_coercive {ι : Type*} {n : ℕ} [Fintype (Fin n)] [F
   -- Key: the penalty term Σᵢ βᵢ(Sβ)ᵢ grows as ‖β‖² → ∞
 
   -- Show penalty term tends to infinity
-  have h_penalty_tendsto := h_penalty_tendsto
+  have h_penalty_tendsto := penalty_quadratic_tendsto_proof S lam hlam hS_posDef
     -- The quadratic form is coercive when S is positive definite
     -- On finite-dimensional space, S pos def implies ∃ c > 0, βᵀSβ ≥ c‖β‖²
     -- This requires the spectral theorem or compactness of unit sphere.
@@ -3332,13 +3328,9 @@ lemma gaussianPenalizedLoss_coercive {ι : Type*} {n : ℕ} [Fintype (Fin n)] [F
     `h_penalty_tendsto` parameter could be derived internally from `hS_posDef`
     via `penalty_quadratic_tendsto_proof`. -/
 lemma gaussianPenalizedLoss_exists_min {ι : Type*} {n : ℕ} [Fintype (Fin n)] [Fintype ι]
-    [DecidableEq ι]
+    [DecidableEq ι] [Nonempty ι]
     (X : Matrix (Fin n) ι ℝ) (y : Fin n → ℝ) (S : Matrix ι ι ℝ)
-    (lam : ℝ) (hlam : lam > 0) (hS_posDef : ∀ v : ι → ℝ, v ≠ 0 → 0 < dotProduct' (S.mulVec v) v)
-    (h_penalty_tendsto :
-      Filter.Tendsto
-        (fun β => lam * Finset.univ.sum (fun i => β i * (S.mulVec β) i))
-        (Filter.cocompact _) Filter.atTop) :
+    (lam : ℝ) (hlam : lam > 0) (hS_posDef : ∀ v : ι → ℝ, v ≠ 0 → 0 < dotProduct' (S.mulVec v) v) :
     ∃ β : ι → ℝ, ∀ β' : ι → ℝ, gaussianPenalizedLoss X y S lam β ≤ gaussianPenalizedLoss X y S lam β' := by
   -- Weierstrass theorem: A continuous coercive function achieves its minimum.
   --
@@ -3374,7 +3366,7 @@ lemma gaussianPenalizedLoss_exists_min {ι : Type*} {n : ℕ} [Fintype (Fin n)] 
                 lam * Finset.univ.sum (fun i => β i * (S.mulVec β) i)))
 
   -- Step 2: Get coercivity
-  have h_coercive := gaussianPenalizedLoss_coercive X y S lam hlam hS_posDef h_penalty_tendsto
+  have h_coercive := gaussianPenalizedLoss_coercive X y S lam hlam hS_posDef
 
   -- Step 3: Apply Weierstrass-style theorem
   -- For continuous coercive function on ℝⁿ, minimum exists.


### PR DESCRIPTION
Refactored `gaussianPenalizedLoss_coercive` and `gaussianPenalizedLoss_exists_min` theorems to fix a specification gaming issue. The theorems previously took `h_penalty_tendsto` as an input hypothesis, vacuously verifying a critical component of the coercivity claim. This PR removes the hypothesis, correctly relies on `[Nonempty ι]`, and applies `penalty_quadratic_tendsto_proof` internally.

Testing:
- Checked all calls to both theorems.
- Ran `lake build Calibrator` and successfully compiled.

---
*PR created automatically by Jules for task [13897693442064353934](https://jules.google.com/task/13897693442064353934) started by @SauersML*