### PR TITLE
Rigorous proof of expected random walk mean shift without axioms

### DIFF
--- a/proofs/Calibrator.lean
+++ b/proofs/Calibrator.lean
@@ -53,4 +53,89 @@ theorem covariance_mismatch_pos_of_fst_and_sparse_array_wf_proved
     (wrightFisher_covariance_gap_lower_bound_proved fstSource fstTarget recombRate arraySparsity rS rT h_delta)
     h_fst h_recomb_pos h_sparse_pos h_kappa_pos
 
+/-- Rigorous proof of the expected absolute mean shift without using the AssumesRandomWalkDrift axiom.
+This removes the specification gaming where the axiom could be instantiated vacuously,
+while simultaneously correcting the `0 ≤ V_A` hypothesis to `0 < V_A` to prevent division by zero mathematically. -/
+theorem expected_abs_mean_shift_of_random_walk_proved
+    (V_A fstS fstT : ℝ)
+    (hVA_pos : 0 < V_A)
+    (hfst_sum_nonneg : 0 ≤ fstS + fstT)
+    (hfstS_lt_one : fstS < 1) :
+    Expected_Abs_Shift V_A fstS fstT / Real.sqrt (presentDayPGSVariance V_A fstS) =
+      2 * Real.sqrt ((fstS + fstT) / (Real.pi * (1 - fstS))) := by
+  unfold Expected_Abs_Shift
+  rw [variance_mean_pgs_diff V_A (fstS + fstT)]
+  unfold presentDayPGSVariance
+  have h1 : Real.sqrt (2 * (fstS + fstT) * V_A) = Real.sqrt (2 * (fstS + fstT)) * Real.sqrt V_A := by
+    apply Real.sqrt_mul
+    apply mul_nonneg
+    · norm_num
+    · exact hfst_sum_nonneg
+  have h2 : Real.sqrt ((1 - fstS) * V_A) = Real.sqrt (1 - fstS) * Real.sqrt V_A := by
+    apply Real.sqrt_mul
+    linarith
+  rw [h1, h2]
+  have h3 : (Real.sqrt (2 * (fstS + fstT)) * Real.sqrt V_A * Real.sqrt (2 / Real.pi)) /
+          (Real.sqrt (1 - fstS) * Real.sqrt V_A) =
+      (Real.sqrt (2 * (fstS + fstT)) * Real.sqrt (2 / Real.pi)) / Real.sqrt (1 - fstS) := by
+    have h4 : Real.sqrt V_A ≠ 0 := by
+      intro h
+      have h5 : V_A = 0 := by
+        exact (Real.sqrt_eq_zero (le_of_lt hVA_pos)).mp h
+      linarith
+    calc (Real.sqrt (2 * (fstS + fstT)) * Real.sqrt V_A * Real.sqrt (2 / Real.pi)) / (Real.sqrt (1 - fstS) * Real.sqrt V_A)
+      _ = (Real.sqrt (2 * (fstS + fstT)) * Real.sqrt (2 / Real.pi) * Real.sqrt V_A) / (Real.sqrt (1 - fstS) * Real.sqrt V_A) := by ring_nf
+      _ = (Real.sqrt (2 * (fstS + fstT)) * Real.sqrt (2 / Real.pi)) / Real.sqrt (1 - fstS) := by
+        rw [mul_div_mul_right _ _ h4]
+  rw [h3]
+  have h5 : Real.sqrt (2 * (fstS + fstT)) * Real.sqrt (2 / Real.pi) = Real.sqrt (4 * ((fstS + fstT) / Real.pi)) := by
+    rw [← Real.sqrt_mul]
+    · congr 1
+      ring
+    · apply mul_nonneg
+      · norm_num
+      · exact hfst_sum_nonneg
+  rw [h5]
+  have h6 : Real.sqrt (4 * ((fstS + fstT) / Real.pi)) = 2 * Real.sqrt ((fstS + fstT) / Real.pi) := by
+    have h_split : Real.sqrt (4 * ((fstS + fstT) / Real.pi)) = Real.sqrt 4 * Real.sqrt ((fstS + fstT) / Real.pi) := by
+      apply Real.sqrt_mul
+      norm_num
+    rw [h_split]
+    have h_sqrt4 : Real.sqrt 4 = 2 := by
+      have : (2:ℝ) ≥ 0 := by norm_num
+      have h_sq : (2:ℝ)^2 = 4 := by norm_num
+      rw [← h_sq]
+      exact Real.sqrt_sq this
+    rw [h_sqrt4]
+  rw [h6]
+  have h7 : (2 * Real.sqrt ((fstS + fstT) / Real.pi)) / Real.sqrt (1 - fstS) = 2 * (Real.sqrt ((fstS + fstT) / Real.pi) / Real.sqrt (1 - fstS)) := by
+    ring
+  rw [h7]
+  congr 1
+  rw [← Real.sqrt_div]
+  · congr 1
+    calc ((fstS + fstT) / Real.pi) / (1 - fstS)
+      _ = (fstS + fstT) * (Real.pi)⁻¹ * (1 - fstS)⁻¹ := by
+        ring_nf
+      _ = (fstS + fstT) * ((Real.pi) * (1 - fstS))⁻¹ := by
+        rw [mul_assoc]
+        congr 1
+        rw [mul_inv]
+      _ = (fstS + fstT) / (Real.pi * (1 - fstS)) := by
+        rfl
+  · apply div_nonneg
+    · exact hfst_sum_nonneg
+    · exact Real.pi_pos.le
+
+
+/-- Backward-compatible rigorous name used by the dashboard without axioms. -/
+theorem expected_abs_mean_shift_bound_proved
+    (V_A fstS fstT : ℝ)
+    (hVA_pos : 0 < V_A)
+    (hfst_sum_nonneg : 0 ≤ fstS + fstT)
+    (hfstS_lt_one : fstS < 1) :
+    Expected_Abs_Shift V_A fstS fstT / Real.sqrt (presentDayPGSVariance V_A fstS) =
+      2 * Real.sqrt ((fstS + fstT) / (Real.pi * (1 - fstS))) :=
+  expected_abs_mean_shift_of_random_walk_proved V_A fstS fstT hVA_pos hfst_sum_nonneg hfstS_lt_one
+
 end Calibrator


### PR DESCRIPTION
This patch provides a direct, rigorous proof for `expected_abs_mean_shift_of_random_walk` (now suffixed with `_proved`), effectively eliminating the need for the unproven `AssumesRandomWalkDrift` structure. It also resolves a vacuous truth flaw where `0 ≤ V_A` allowed for undefined division by zero. The theorem now safely operates under `0 < V_A`. All changes are strictly confined to `proofs/Calibrator.lean`, preserving the codebase structure.

---
*PR created automatically by Jules for task [4559262252494419413](https://jules.google.com/task/4559262252494419413) started by @SauersML*