### PR TITLE
fix: Remove specification gaming and strengthen portability proofs

### DIFF
--- a/proofs/Calibrator/DGP.lean
+++ b/proofs/Calibrator/DGP.lean
@@ -1002,20 +1002,78 @@ theorem ld_decay_implies_shrinkage {k : ℕ} [Fintype (Fin k)]
 
 theorem ld_decay_implies_nonlinear_calibration_sketch {k : ℕ} [Fintype (Fin k)]
     (mech : LDDecayMechanism k)
-    (h_nonlin : ¬ ∃ a b, ∀ d ∈ Set.range mech.distance, mech.tagging_efficiency d = a + b * d) :
+    (lambda : ℝ)
+    (h_lambda_pos : 0 < lambda)
+    (h_eff : mech.tagging_efficiency = fun d => Real.exp (- (lambda * d)))
+    (h_dist0 : ∃ c0, mech.distance c0 = 0)
+    (h_dist1 : ∃ c1, mech.distance c1 = 1)
+    (h_dist2 : ∃ c2, mech.distance c2 = 2) :
     ∀ (beta0 beta1 : ℝ),
       (fun c => beta0 + beta1 * mech.distance c) ≠
         (fun c => decaySlope mech c) := by
   intro beta0 beta1 h_eq
-  have h_forall : ∀ c, beta0 + beta1 * mech.distance c = mech.tagging_efficiency (mech.distance c) :=
-    fun c => congr_fun h_eq c
+  have h_forall : ∀ c, beta0 + beta1 * mech.distance c = Real.exp (- (lambda * mech.distance c)) := by
+    intro c
+    have h := congr_fun h_eq c
+    unfold decaySlope at h
+    rw [h_eff] at h
+    exact h
 
-  -- This contradicts h_nonlin
-  apply h_nonlin
-  use beta0, beta1
-  intro d hd
-  obtain ⟨c, hc⟩ := hd
-  rw [← hc, h_forall c]
+  rcases h_dist0 with ⟨c0, hc0⟩
+  rcases h_dist1 with ⟨c1, hc1⟩
+  rcases h_dist2 with ⟨c2, hc2⟩
+
+  have h0 := h_forall c0
+  rw [hc0] at h0
+  have h0_simp : beta0 = 1 := by
+    calc beta0 = beta0 + beta1 * 0 := by ring
+      _ = Real.exp (- (lambda * 0)) := h0
+      _ = 1 := by simp
+
+  have h1 := h_forall c1
+  rw [hc1, h0_simp] at h1
+  have h1_simp : 1 + beta1 = Real.exp (- lambda) := by
+    calc 1 + beta1 = 1 + beta1 * 1 := by ring
+      _ = Real.exp (- (lambda * 1)) := h1
+      _ = Real.exp (- lambda) := by ring_nf
+
+  have h2 := h_forall c2
+  rw [hc2, h0_simp] at h2
+  have h2_simp : 1 + beta1 * 2 = Real.exp (- (lambda * 2)) := h2
+
+  have h_beta1 : beta1 = Real.exp (- lambda) - 1 := by linarith [h1_simp]
+
+  have h2_sub : 1 + (Real.exp (- lambda) - 1) * 2 = Real.exp (- (lambda * 2)) := by
+    rw [← h_beta1]
+    exact h2_simp
+
+  have h_exp_sq : Real.exp (- (lambda * 2)) = (Real.exp (- lambda)) ^ 2 := by
+    rw [← Real.exp_nat_mul]
+    congr 1
+    ring
+
+  rw [h_exp_sq] at h2_sub
+
+  set x := Real.exp (- lambda)
+  have h_quad : 1 + (x - 1) * 2 = x ^ 2 := h2_sub
+
+  have h_quad_simp : x ^ 2 - 2 * x + 1 = 0 := by linarith [h_quad]
+  have h_sq : (x - 1) ^ 2 = 0 := by
+    calc (x - 1) ^ 2 = x ^ 2 - 2 * x + 1 := by ring
+      _ = 0 := h_quad_simp
+
+  have h_x_eq_1 : x = 1 := by
+    have h_x_sub_1 : x - 1 = 0 := sq_eq_zero_iff.mp h_sq
+    linarith
+
+  have h_lambda_zero : lambda = 0 := by
+    have h_exp : Real.exp (- lambda) = Real.exp 0 := by
+      rw [h_x_eq_1]
+      exact Real.exp_zero.symm
+    have h_neg_lambda_zero : - lambda = 0 := Real.exp_injective h_exp
+    linarith
+
+  linarith [h_lambda_pos]
 
 theorem optimal_slope_trace_variance {k : ℕ} [Fintype (Fin k)]
     (arch : GeneticArchitecture k) (c : Fin k → ℝ)

--- a/proofs/Calibrator/PortabilityDrift.lean
+++ b/proofs/Calibrator/PortabilityDrift.lean
@@ -391,12 +391,20 @@ theorem drift_degrades_signalToNoise
 theorem drift_degrades_R2
     (V_A V_E fstS fstT : ℝ)
     (hVA : 0 < V_A)
+    (hVE : 0 < V_E)
     (hfst : fstS < fstT)
-    (hmono : StrictMono (fun x : ℝ => x / (x + V_E))) :
+    (hfstT_le_one : fstT ≤ 1) :
     presentDayR2 V_A V_E fstT < presentDayR2 V_A V_E fstS := by
-  unfold presentDayR2 presentDayPGSVariance
-  apply hmono
-  nlinarith [mul_lt_mul_of_pos_right hfst hVA]
+  unfold presentDayR2
+  have h_var_lt : presentDayPGSVariance V_A fstT < presentDayPGSVariance V_A fstS := by
+    unfold presentDayPGSVariance
+    nlinarith [mul_lt_mul_of_pos_right hfst hVA]
+  have h_var_T_nonneg : 0 ≤ presentDayPGSVariance V_A fstT := by
+    unfold presentDayPGSVariance
+    exact mul_nonneg (by linarith) (le_of_lt hVA)
+  have h_mono : expectedR2 (presentDayPGSVariance V_A fstT) V_E < expectedR2 (presentDayPGSVariance V_A fstS) V_E :=
+    expectedR2_strictMono_nonneg V_E (presentDayPGSVariance V_A fstT) (presentDayPGSVariance V_A fstS) hVE h_var_T_nonneg h_var_lt
+  exact h_mono
 
 /-- Drift monotonically degrades AUC for any strictly increasing AUC link on SNR. -/
 theorem drift_degrades_AUC_of_strictMono
@@ -450,34 +458,37 @@ noncomputable def targetLinearRisk {p : ℕ}
     (w : Fin p → ℝ) : ℝ :=
   noiseVar + dotProduct w (sigmaObsTarget.mulVec w) - 2 * dotProduct w crossTarget
 
-/-- If source ERM satisfies source normal equations but not target normal equations,
-the learned projection is source-LD specific (Euro-centric mismatch statement). -/
-theorem source_erm_is_ld_specific_of_normal_eq_mismatch
-    {p : Nat}
-    (sigmaObsSource sigmaObsTarget : Matrix (Fin p) (Fin p) Real)
-    (crossSource crossTarget : Fin p -> Real)
-    (wSource : Fin p -> Real)
-    (_hSource : sigmaObsSource.mulVec wSource = crossSource)
-    (hMismatch : sigmaObsTarget.mulVec wSource ≠ crossTarget) :
-    ¬ sigmaObsTarget.mulVec wSource = crossTarget := by
-  exact hMismatch
+/-- Source ERM is LD-specific under concrete structural shifts:
+the optimal source weights do not solve the target normal equations. -/
+theorem source_erm_is_ld_specific_concrete :
+    sigmaObsTarget.mulVec wSource_opt ≠ crossTarget := by
+  intro h
+  have h_eval : sigmaObsTarget.mulVec wSource_opt = ![0.8, 0.08] := by
+    ext i
+    fin_cases i <;> norm_num [sigmaObsTarget, wSource_opt, Matrix.mulVec, dotProduct]
+  have h_cross : crossTarget = ![0.8, 0.0] := rfl
+  rw [h_eval, h_cross] at h
+  have h_1 : (![0.8, 0.08] : Fin 2 → ℝ) 1 = 0.08 := rfl
+  have h_2 : (![0.8, 0.0] : Fin 2 → ℝ) 1 = 0.0 := rfl
+  have h_eq : (0.08 : ℝ) = 0.0 := by
+    calc
+      (0.08 : ℝ) = (![0.8, 0.08] : Fin 2 → ℝ) 1 := h_1.symm
+      _ = (![0.8, 0.0] : Fin 2 → ℝ) 1 := by rw [h]
+      _ = 0.0 := h_2
+  norm_num at h_eq
 
-/-- If one coefficient vector solves source normal equations and another solves target normal equations,
-and no single vector can satisfy both systems, then source ERM and target ERM must differ. -/
-theorem source_target_erm_differ_of_ld_system_conflict
-    {p : Nat}
-    (sigmaObsSource sigmaObsTarget : Matrix (Fin p) (Fin p) Real)
-    (crossSource crossTarget : Fin p -> Real)
-    (wSource wTarget : Fin p -> Real)
-    (hSource : sigmaObsSource.mulVec wSource = crossSource)
-    (hTarget : sigmaObsTarget.mulVec wTarget = crossTarget)
-    (hConflict :
-      ∀ w : Fin p -> Real, sigmaObsSource.mulVec w = crossSource -> sigmaObsTarget.mulVec w ≠ crossTarget) :
-    wSource ≠ wTarget := by
-  intro hEq
-  have hNotTargetAtSource : sigmaObsTarget.mulVec wSource ≠ crossTarget := hConflict wSource hSource
-  have hTargetAtSource : sigmaObsTarget.mulVec wSource = crossTarget := by simpa [hEq] using hTarget
-  exact hNotTargetAtSource hTargetAtSource
+/-- Source and target ERM solutions differ explicitly under concrete LD structural shifts. -/
+theorem source_target_erm_differ_concrete :
+    wSource_opt ≠ wTarget_opt := by
+  intro h
+  have h_eval_source : wSource_opt 0 = 0.8 := rfl
+  have h_eval_target : wTarget_opt 0 = 80 / 99 := rfl
+  have h_eq : (0.8 : ℝ) = 80 / 99 := by
+    calc
+      (0.8 : ℝ) = wSource_opt 0 := h_eval_source.symm
+      _ = wTarget_opt 0 := by rw [h]
+      _ = 80 / 99 := h_eval_target
+  norm_num at h_eq
 
 /-- Multi-locus tag/causal architecture used in statistical genetics portability formulas. -/
 structure MultiLocusTagModel (p q : ℕ) where
@@ -785,12 +796,13 @@ theorem portability_ratio_lt_one_of_drop
 theorem portability_ratio_lt_one_of_positive_drift
     (V_A V_E fstS fstT : ℝ)
     (hVA : 0 < V_A)
+    (hVE : 0 < V_E)
     (hfst : fstS < fstT)
-    (hmono : StrictMono (fun x : ℝ => x / (x + V_E)))
+    (hfstT_le_one : fstT ≤ 1)
     (hsrc_pos : 0 < presentDayR2 V_A V_E fstS) :
     presentDayR2 V_A V_E fstT / presentDayR2 V_A V_E fstS < 1 := by
   have hdrop : presentDayR2 V_A V_E fstT < presentDayR2 V_A V_E fstS :=
-    drift_degrades_R2 V_A V_E fstS fstT hVA hfst hmono
+    drift_degrades_R2 V_A V_E fstS fstT hVA hVE hfst hfstT_le_one
   exact portability_ratio_lt_one_of_drop (presentDayR2 V_A V_E fstS)
     (presentDayR2 V_A V_E fstT) hsrc_pos hdrop
 


### PR DESCRIPTION
- Replaced `h_nonlin` hypothesis in `ld_decay_implies_nonlinear_calibration_sketch` with formal algebraic properties of exponential decay.
- Rewrote `drift_degrades_R2` to prove monotonicity rather than passing it as a loose hypothesis.
- Rewrote `source_erm_is_ld_specific` and `source_target_erm_differ` as concrete evaluations instead of tautological wrappers.
- Verified successful proof compilation.

---
*PR created automatically by Jules for task [6587082427726513069](https://jules.google.com/task/6587082427726513069) started by @SauersML*