### PR TITLE
Fix Lean compilation errors

### DIFF
--- a/proofs/Calibrator/EquityAndImplementation.lean
+++ b/proofs/Calibrator/EquityAndImplementation.lean
@@ -217,8 +217,11 @@ theorem r2_concave_in_n
     ((n + dn) * h2 + M) * (n * h2) = dn * h2 * M := by ring
   rw [lhs_eq, rhs_eq]
   -- Goal: dn*h2*M / (h3*h2') < dn*h2*M / (h2'*h1)
-  apply div_lt_div_of_pos_left (mul_pos (mul_pos h_dn h_h2) h_M) (mul_pos h2' h1) _
-  -- Need: h2'*h1 < h3*h2', i.e., h2'*(h3 - h1) > 0
+  have h_num_pos : 0 < dn * h2 * M := mul_pos (mul_pos h_dn h_h2) h_M
+  have h_lhs_den_pos : 0 < ((n + 2 * dn) * h2 + M) * ((n + dn) * h2 + M) := mul_pos h3 h2'
+  have h_rhs_den_pos : 0 < ((n + dn) * h2 + M) * (n * h2 + M) := mul_pos h2' h1
+  apply div_lt_div_of_pos_left h_num_pos h_rhs_den_pos
+  -- Need h2'*h1 < h3*h2', which is true because h1 < h3 and h2' > 0
   nlinarith [mul_pos h2' (show 0 < 2 * dn * h2 from by nlinarith [mul_pos h_dn h_h2])]
 
 /-- **Marginal value of diversity.**

--- a/proofs/Calibrator/MultiAncestryTheory.lean
+++ b/proofs/Calibrator/MultiAncestryTheory.lean
@@ -40,8 +40,8 @@ theorem multi_ancestry_reduces_fst
     (h_single_lt : fst_single < 1) :
     neutralPortabilityRatio 0 fst_multi > neutralPortabilityRatio 0 fst_single := by
   unfold neutralPortabilityRatio
-  simp
-  linarith
+  have h1 : 1 - fst_multi > 1 - fst_single := sub_lt_sub_left h_multi_closer 1
+  nlinarith
 
 /-- **Diminishing returns from more similar samples.**
     At small Fst, the derivative d(R²)/d(Fst) is steep.
@@ -57,7 +57,7 @@ theorem portability_concave_in_fst_reduction
     neutralPortabilityRatio 0 (fst₂ - Δ) - neutralPortabilityRatio 0 fst₂ =
     neutralPortabilityRatio 0 (fst₁ - Δ) - neutralPortabilityRatio 0 fst₁ := by
   unfold neutralPortabilityRatio
-  simp
+  ring
 
 /-- **Optimal GWAS allocation.**
     Given a fixed total sample size N, how should samples be allocated


### PR DESCRIPTION
Fixes multiple compilation errors in Lean proof files across `AncestrySpecificArchitecture.lean`, `EquityAndImplementation.lean`, and `MultiAncestryTheory.lean`. The issues included type mismatches in multiplication positivity proofs, incorrect usages of `sub_lt_sub_left`, and unresolved goals in limits. All files now successfully compile.

---
*PR created automatically by Jules for task [9021267802244555177](https://jules.google.com/task/9021267802244555177) started by @SauersML*