### PR TITLE
Fix specification gaming in `introgression_creates_population_specific_variants`

### DIFF
--- a/proofs/Calibrator/DemographicHistory.lean
+++ b/proofs/Calibrator/DemographicHistory.lean
@@ -388,10 +388,12 @@ section ArchaicIntrogression
     Worked example: European/Asian ~2% Neanderthal, Melanesian ~2%
     Neanderthal + ~3-5% Denisovan, African ~0-0.3% archaic. -/
 theorem introgression_creates_population_specific_variants
-    (pct_high pct_low : ℝ)
-    (h_low_nn : 0 ≤ pct_low)
-    (h_diff : pct_low < pct_high) :
-    pct_low < pct_high := by linarith
+    (total_variance : ℝ) (shared_var_high shared_var_low intro_var_high intro_var_low : ℝ)
+    (h_total_high : total_variance = shared_var_high + intro_var_high)
+    (h_total_low : total_variance = shared_var_low + intro_var_low)
+    (h_intro_diff : intro_var_low < intro_var_high) :
+    shared_var_high < shared_var_low := by
+  linarith
 
 /-- **Introgression fraction of heritability is bounded.**
     When introgressed heritability is at most a fraction δ of total


### PR DESCRIPTION
Removed specification gaming from `introgression_creates_population_specific_variants` in `proofs/Calibrator/DemographicHistory.lean`. The previous theorem simply asserted `pct_low < pct_high` given the hypothesis `h_diff: pct_low < pct_high`. The new theorem proves a structural relationship where if total variance is the sum of shared and introgressed variance, a higher introgressed variance implies a lower shared variance. This adds rigorous mathematical meaning without resorting to tautology.

---
*PR created automatically by Jules for task [4749882507284064005](https://jules.google.com/task/4749882507284064005) started by @SauersML*