### PR TITLE
Fix ERM mismatch specification gaming

### DIFF
--- a/proofs/Calibrator/PortabilityDrift.lean
+++ b/proofs/Calibrator/PortabilityDrift.lean
@@ -609,7 +609,7 @@ def crossSource : Fin 2 → ℝ :=
 
 /-- Target cross-covariance vector paired with `sigmaObsTarget`. -/
 def crossTarget : Fin 2 → ℝ :=
-  ![0.8, 0.0]
+  ![0.8, 0.4]
 
 /-- Exact source OLS solution for the dense witness system. -/
 noncomputable def wSource_opt : Fin 2 → ℝ :=
@@ -617,7 +617,7 @@ noncomputable def wSource_opt : Fin 2 → ℝ :=
 
 /-- Exact target OLS solution for the dense witness system. -/
 noncomputable def wTarget_opt : Fin 2 → ℝ :=
-  ![80 / 99, -8 / 99]
+  ![76 / 99, 32 / 99]
 
 /-- A concrete proof that ERM mismatch occurs under LD shift, without relying on
     the abstract `hConflict` hypothesis, using dense 2x2 witnesses. -/


### PR DESCRIPTION
In `proofs/Calibrator/PortabilityDrift.lean`, the theorem `source_target_erm_differ_dense_witness_proved` previously used a target cross-covariance vector `crossTarget` of `![0.8, 0.0]` while the source vector was `![0.8, 0.4]`. This artificially forced a mismatch by altering the marginal correlation structure of the causal variants, which is an example of specification gaming (trivially modifying the target vector rather than illustrating true ERM mismatch due to LD shift alone).

This commit fixes the specification gaming by keeping `crossTarget` exactly the same as `crossSource` (`![0.8, 0.4]`). The optimal target OLS weights `wTarget_opt` are precisely recalculated to `![76 / 99, 32 / 99]`. Since `sigmaObsTarget` (the tag LD matrix) shifts from `!![1, 0.5; 0.5, 1]` to `!![1, 0.1; 0.1, 1]`, this accurately demonstrates that ERM mismatch occurs strictly due to LD shift. The mathematical proofs compiling with `norm_num` verify the consistency of the system.

---
*PR created automatically by Jules for task [198603645524821328](https://jules.google.com/task/198603645524821328) started by @SauersML*