### PR TITLE
Fix specification gaming in alpha models and introgression proofs

### DIFF
--- a/proofs/Calibrator/DemographicHistory.lean
+++ b/proofs/Calibrator/DemographicHistory.lean
@@ -380,6 +380,9 @@ end RecentExpansion
 
 section ArchaicIntrogression
 
+noncomputable def introgressed_variants (total_variants pct : ℝ) : ℝ :=
+  total_variants * pct
+
 /-- **Differential introgression creates population-specific variants.**
     When one population has a higher archaic introgression fraction than
     another, the resulting population-specific variants contribute to
@@ -388,10 +391,12 @@ section ArchaicIntrogression
     Worked example: European/Asian ~2% Neanderthal, Melanesian ~2%
     Neanderthal + ~3-5% Denisovan, African ~0-0.3% archaic. -/
 theorem introgression_creates_population_specific_variants
-    (pct_high pct_low : ℝ)
-    (h_low_nn : 0 ≤ pct_low)
+    (total_variants pct_high pct_low : ℝ)
+    (h_total_pos : 0 < total_variants)
     (h_diff : pct_low < pct_high) :
-    pct_low < pct_high := by linarith
+    introgressed_variants total_variants pct_low < introgressed_variants total_variants pct_high := by
+  unfold introgressed_variants
+  exact mul_lt_mul_of_pos_left h_diff h_total_pos
 
 /-- **Introgression fraction of heritability is bounded.**
     When introgressed heritability is at most a fraction δ of total

--- a/proofs/Calibrator/RareVariantPortability.lean
+++ b/proofs/Calibrator/RareVariantPortability.lean
@@ -386,10 +386,17 @@ theorem negative_selection_constraint
     α = -1: LDAK (β² ∝ 1/[p(1-p)])
     Higher α → rarer variants have larger effects → more population-specific signal. -/
 theorem alpha_model_portability_impact
-    (α port : ℝ)
-    (h_relation : α < 0 → port < 1)
-    (h_negative : α < 0) :
-    port < 1 := h_relation h_negative
+    (maf_rare maf_common α : ℝ)
+    (h_rare_pos : 0 < maf_rare)
+    (h_common_pos : 0 < maf_common)
+    (h_rare_lt_common : maf_rare < maf_common)
+    (h_alpha_neg : α < 0) :
+    (maf_rare / maf_common) ^ (1 + α) > maf_rare / maf_common := by
+  have h_ratio_pos : 0 < maf_rare / maf_common := div_pos h_rare_pos h_common_pos
+  have h_ratio_lt_one : maf_rare / maf_common < 1 := (div_lt_one h_common_pos).mpr h_rare_lt_common
+  have h_exp_lt_one : 1 + α < 1 := by linarith
+  nth_rw 2 [← Real.rpow_one (maf_rare / maf_common)]
+  exact Real.rpow_lt_rpow_of_exponent_gt h_ratio_pos h_ratio_lt_one h_exp_lt_one
 
 /-- **Rare variant PGS R² increases slowly with sample size.**
     For rare variants, R²_rare ∝ n × MAF × β².


### PR DESCRIPTION
This PR fixes two instances of "specification gaming" (tautological verification) where a theorem explicitly included the desired conclusion within its own hypothesis, rendering the proof a simple restatement.
1. `alpha_model_portability_impact` was an identity function returning a boolean inequality hypothesis. Now it computes the theoretical properties of the `alpha` model using the ratio of MAFs.
2. `introgression_creates_population_specific_variants` was completely vacuous `a < b : a < b := by linarith`. Now it bounds the number of specific variants generated by differing degrees of archaic introgression via the new `introgressed_variants` function.

Compiled and verified with Lean successfully. No new files were left behind.

---
*PR created automatically by Jules for task [17386665341958558748](https://jules.google.com/task/17386665341958558748) started by @SauersML*