### PR TITLE
Fix vacuous verification in demographic, portability, and interval proofs

### DIFF
--- a/proofs/Calibrator/DemographicHistory.lean
+++ b/proofs/Calibrator/DemographicHistory.lean
@@ -387,11 +387,18 @@ section ArchaicIntrogression
 
     Worked example: European/Asian ~2% Neanderthal, Melanesian ~2%
     Neanderthal + ~3-5% Denisovan, African ~0-0.3% archaic. -/
+noncomputable def introgressed_variants (pct total_archaic_variants : ℝ) : ℝ :=
+  pct * total_archaic_variants
+
 theorem introgression_creates_population_specific_variants
-    (pct_high pct_low : ℝ)
+    (pct_high pct_low total_archaic_variants : ℝ)
     (h_low_nn : 0 ≤ pct_low)
-    (h_diff : pct_low < pct_high) :
-    pct_low < pct_high := by linarith
+    (h_diff : pct_low < pct_high)
+    (h_total_pos : 0 < total_archaic_variants) :
+    introgressed_variants pct_low total_archaic_variants <
+      introgressed_variants pct_high total_archaic_variants := by
+  unfold introgressed_variants
+  exact mul_lt_mul_of_pos_right h_diff h_total_pos
 
 /-- **Introgression fraction of heritability is bounded.**
     When introgressed heritability is at most a fraction δ of total

--- a/proofs/Calibrator/PredictionIntervalTheory.lean
+++ b/proofs/Calibrator/PredictionIntervalTheory.lean
@@ -346,13 +346,23 @@ theorem conformal_coverage_guarantee
     0 < 1 / ((n : ℝ) + 1) := by
   positivity
 
-/-- **Conformal coverage gap vanishes with larger calibration set.** -/
+/-- Expected marginal coverage probability of a conformal prediction interval.
+    For a calibration set of size n, the exact distribution-free coverage
+    is lower-bounded by 1 - α - 1/(n+1) (or exactly 1-α if n+1 divides into 1-α).
+    Here we model the standard finite-sample lower bound. -/
+noncomputable def conformal_coverage_bound (α : ℝ) (n : ℕ) : ℝ :=
+  1 - α - 1 / ((n : ℝ) + 1)
+
+/-- **Conformal coverage bound strictly increases with larger calibration set.** -/
 theorem conformal_gap_decreases
-    (n₁ n₂ : ℕ) (h_n₁ : 0 < n₁) (h_n₂ : 0 < n₂) (h_more : n₁ < n₂) :
-    1 / ((n₂ : ℝ) + 1) < 1 / ((n₁ : ℝ) + 1) := by
-  apply div_lt_div_of_pos_left one_pos
-  · positivity
-  · exact_mod_cast Nat.add_lt_add_right h_more 1
+    (α : ℝ) (n₁ n₂ : ℕ) (h_n₁ : 0 < n₁) (h_n₂ : 0 < n₂) (h_more : n₁ < n₂) :
+    conformal_coverage_bound α n₁ < conformal_coverage_bound α n₂ := by
+  unfold conformal_coverage_bound
+  have h_gap : 1 / ((n₂ : ℝ) + 1) < 1 / ((n₁ : ℝ) + 1) := by
+    apply div_lt_div_of_pos_left one_pos
+    · positivity
+    · exact_mod_cast Nat.add_lt_add_right h_more 1
+  linarith
 
 /-- **Conformal score quantile yields adaptive width.**
     The conformal prediction interval at level (1-α) has halfwidth equal to

--- a/proofs/Calibrator/RareVariantPortability.lean
+++ b/proofs/Calibrator/RareVariantPortability.lean
@@ -384,12 +384,32 @@ theorem negative_selection_constraint
 /-- **The α model: E[β²] ∝ [p(1-p)]^(1+α).**
     α = 0: neutral (no relationship between MAF and effect)
     α = -1: LDAK (β² ∝ 1/[p(1-p)])
-    Higher α → rarer variants have larger effects → more population-specific signal. -/
+    When 1+α < 0 (i.e., α < -1), rarer variants have larger expected effect sizes.
+    Here we prove that when `α < -1` and `p_rare < p_common` (with `p_common ≤ 1/2`),
+    the expected effect variance multiplier `(p(1-p))^(1+α)` is strictly larger for
+    the rare variant than for the common variant. -/
+noncomputable def expected_effect_multiplier (p α : ℝ) : ℝ :=
+  (p * (1 - p)) ^ (1 + α)
+
 theorem alpha_model_portability_impact
-    (α port : ℝ)
-    (h_relation : α < 0 → port < 1)
-    (h_negative : α < 0) :
-    port < 1 := h_relation h_negative
+    (α p_rare p_common : ℝ)
+    (h_α_strong : α < -1)
+    (h_rare_pos : 0 < p_rare)
+    (h_rare_lt_common : p_rare < p_common)
+    (h_common_le_half : p_common ≤ 1 / 2) :
+    expected_effect_multiplier p_common α < expected_effect_multiplier p_rare α := by
+  unfold expected_effect_multiplier
+  have h_het_rare_pos : 0 < p_rare * (1 - p_rare) := by
+    apply mul_pos h_rare_pos
+    linarith
+  have h_het_common_pos : 0 < p_common * (1 - p_common) := by
+    apply mul_pos (by linarith)
+    linarith
+  have h_het_lt : p_rare * (1 - p_rare) < p_common * (1 - p_common) := by
+    have h_rare_le_half : p_rare ≤ 1 / 2 := by linarith
+    nlinarith [sq_nonneg (p_common - 1/2), sq_nonneg (p_rare - 1/2)]
+  have h_exp_neg : 1 + α < 0 := by linarith
+  exact Real.rpow_lt_rpow_of_exponent_neg h_het_rare_pos h_het_lt h_exp_neg
 
 /-- **Rare variant PGS R² increases slowly with sample size.**
     For rare variants, R²_rare ∝ n × MAF × β².


### PR DESCRIPTION
This PR eliminates specification gaming and vacuous verification across three Lean proof files.

1.  **`DemographicHistory.lean`**: The theorem `introgression_creates_population_specific_variants` was previously a simple tautology (`pct_low < pct_high → pct_low < pct_high`). It has been refactored to define an `introgressed_variants` function and proves the inequality over actual variant counts, grounding the theorem.
2.  **`RareVariantPortability.lean`**: The theorem `alpha_model_portability_impact` was previously begging the question via modus ponens. It has been replaced with a mathematically rigorous formalization of the expected effect multiplier model (`(p(1-p))^(1+α)`). It properly proves that rarer variants have strictly larger expected effect sizes when the constraint is sufficiently negative (`α < -1`), accurately reflecting the biological context.
3.  **`PredictionIntervalTheory.lean`**: The theorem `conformal_gap_decreases` was previously just a generic algebra lemma. It has been grounded by defining the actual finite-sample conformal coverage lower bound `1 - α - 1/(n+1)` and proving that this bound strictly increases with larger calibration set sizes.

---
*PR created automatically by Jules for task [6999289717647129278](https://jules.google.com/task/6999289717647129278) started by @SauersML*