### PR TITLE
Fix specification gaming in DemographicHistory.lean

### DIFF
--- a/proofs/Calibrator/DemographicHistory.lean
+++ b/proofs/Calibrator/DemographicHistory.lean
@@ -387,11 +387,16 @@ section ArchaicIntrogression
 
     Worked example: European/Asian ~2% Neanderthal, Melanesian ~2%
     Neanderthal + ~3-5% Denisovan, African ~0-0.3% archaic. -/
+noncomputable def introgressed_variants (pct : ℝ) (total_variants : ℝ) : ℝ :=
+  pct * total_variants
+
 theorem introgression_creates_population_specific_variants
-    (pct_high pct_low : ℝ)
-    (h_low_nn : 0 ≤ pct_low)
+    (pct_high pct_low total_variants : ℝ)
+    (h_pos_total : 0 < total_variants)
+    (_h_low_nn : 0 ≤ pct_low)
     (h_diff : pct_low < pct_high) :
-    pct_low < pct_high := by linarith
+    introgressed_variants pct_low total_variants < introgressed_variants pct_high total_variants := by
+  exact mul_lt_mul_of_pos_right h_diff h_pos_total
 
 /-- **Introgression fraction of heritability is bounded.**
     When introgressed heritability is at most a fraction δ of total


### PR DESCRIPTION
Replaced vacuous verification where `introgression_creates_population_specific_variants` was a direct tautology relying entirely on its own hypothesis. Provided a meaningful mathematical relation using total variants instead.

---
*PR created automatically by Jules for task [4964174742375826619](https://jules.google.com/task/4964174742375826619) started by @SauersML*