### PR TITLE
Fix vacuous verification in architecture classification and selection models

### DIFF
--- a/proofs/Calibrator/PolygenicArchitecture.lean
+++ b/proofs/Calibrator/PolygenicArchitecture.lean
@@ -445,12 +445,23 @@ theorem predicted_le_source (r2_source rg fst_ld bias_tech : ℝ)
     Traits can be classified by their architecture:
     - Highly polygenic, no selection → best portability
     - Moderately polygenic, weak selection → moderate portability
-    - Oligogenic or strong selection → poor portability -/
+    - Oligogenic or strong selection → poor portability
+
+    This is modelled by showing that smaller per-variant variance
+    (more polygenic) leads to better portability. -/
 theorem architecture_classification
-    (port_high_poly port_moderate port_oligo : ℝ)
-    (h₁ : port_oligo < port_moderate)
-    (h₂ : port_moderate < port_high_poly) :
-    port_oligo < port_high_poly := by linarith
+    (h2 V_E m_oligo m_poly : ℝ)
+    (h_h2 : 0 < h2) (h_VE : 0 < V_E)
+    (h_oligo : 0 < m_oligo) (h_poly : 0 < m_poly)
+    (h_more_loci : m_oligo < m_poly) :
+    (h2 / m_poly) / (h2 / m_poly + V_E) < (h2 / m_oligo) / (h2 / m_oligo + V_E) := by
+  have h_per_oligo : 0 < h2 / m_oligo := div_pos h_h2 h_oligo
+  have h_per_poly : 0 < h2 / m_poly := div_pos h_h2 h_poly
+  have h_less : h2 / m_poly < h2 / m_oligo := div_lt_div_of_pos_left h_h2 h_oligo h_more_loci
+  have h_den_poly : 0 < h2 / m_poly + V_E := add_pos h_per_poly h_VE
+  have h_den_oligo : 0 < h2 / m_oligo + V_E := add_pos h_per_oligo h_VE
+  rw [div_lt_div_iff₀ h_den_poly h_den_oligo]
+  nlinarith
 
 /-- **General portability upper bound from rg and Fst.**
     Traits with: (1) low r_g, (2) high FST at causal loci,

--- a/proofs/Calibrator/SelectionArchitecture.lean
+++ b/proofs/Calibrator/SelectionArchitecture.lean
@@ -622,13 +622,24 @@ section ArchitecturePredictions
 
 /- **Trait classes can be ranked by regime-specific portability parameters.** -/
 
-/-- Portability ordering follows from any transitive ranking of regime-level
-    portability values. -/
+/-- **Exponential decay model of portability under selection.**
+    Portability decays exponentially with time t at a rate proportional to 2s. -/
+noncomputable def portabilityUnderSelection (s t : ℝ) : ℝ :=
+  Real.exp (- (2 * s * t))
+
+/-- Portability ordering follows from the selection coefficients.
+    Stronger selection coefficients lead to strictly lower portability
+    over the same positive time interval. -/
 theorem portability_ordering
-    (r2_high r2_mid r2_low : ℝ)
-    (h_high : r2_mid < r2_high)
-    (h_mid : r2_low < r2_mid) :
-    r2_low < r2_high := by linarith
+    (s_weak s_strong t : ℝ)
+    (h_strong : s_weak < s_strong)
+    (h_t : 0 < t) :
+    portabilityUnderSelection s_strong t < portabilityUnderSelection s_weak t := by
+  unfold portabilityUnderSelection
+  apply Real.exp_lt_exp.mpr
+  have h_2 : (0 : ℝ) < 2 := by linarith
+  have h_2t : 0 < 2 * t := mul_pos h_2 h_t
+  nlinarith
 
 /-- **Selection coefficient determines portability timescale.**
     The characteristic timescale for portability decay is 1/(2s) generations,


### PR DESCRIPTION
I have investigated the codebase for "specification gaming" (where natural language definitions are modelled simply as trivial inequalities). I targeted two such inequalities, `portability_ordering` and `architecture_classification` which were written exactly as `r2_low < r2_mid -> r2_mid < r2_high -> r2_low < r2_high`. I replaced these with correct mathematical bounds based on actual architecture modeling using exponential decay and variance.

---
*PR created automatically by Jules for task [4736656777599010569](https://jules.google.com/task/4736656777599010569) started by @SauersML*