### PR TITLE
Fix compilation issues in Calibrator proofs

### DIFF
--- a/proofs/Calibrator/Conclusions.lean
+++ b/proofs/Calibrator/Conclusions.lean
@@ -657,7 +657,7 @@ theorem laml_fixed_beta_gradient_is_exact
       (0.5 * Real.log (Matrix.det (Hessian_fn S_basis X W (Function.update rho i r) b)) +
       -0.5 * Real.log (Matrix.det (S_lambda_fn S_basis (Function.update rho i r))))) := by
     ext r
-    ring
+    ring_nf
   rw [h_sub_to_add, h_add1, h_add2, h_deriv_pen, h_deriv_log_H, h_deriv_log_S]
   simp [matrixInvAlg_eq_inv]
   rw [← h_b]
@@ -877,12 +877,12 @@ theorem bernoulliKLReal_nonneg (p q : ℝ) (hp0 : 0 < p) (hp1 : p < 1) (hq0 : 0 
     linarith [mul_le_mul_of_nonneg_left h2 (le_of_lt hp1_pos)]
   have h_log_inv1 : Real.log (p / q) = - Real.log (q / p) := by
     rw [Real.log_div (hp0.ne') (hq0.ne'), Real.log_div (hq0.ne') (hp0.ne')]
-    ring
+    ring_nf
   have h_log_inv2 : Real.log ((1 - p) / (1 - q)) = - Real.log ((1 - q) / (1 - p)) := by
     have h1p : 1 - p ≠ 0 := by linarith
     have h1q : 1 - q ≠ 0 := by linarith
     rw [Real.log_div h1p h1q, Real.log_div h1q h1p]
-    ring
+    ring_nf
   rw [h_log_inv1, h_log_inv2]
   calc
     p * -Real.log (q / p) + (1 - p) * -Real.log ((1 - q) / (1 - p))
@@ -1246,7 +1246,7 @@ theorem brierBernoulliRisk_eq_iff (η q : ℝ) :
     nlinarith [sq_eq_zero_iff.mp hsq]
   · intro h
     subst h
-    ring
+    ring_nf
 
 /-- Pointwise Bernoulli log-risk (cross-entropy form). -/
 noncomputable def logBernoulliRisk (η q : ℝ) : ℝ :=
@@ -1273,7 +1273,7 @@ theorem logBernoulliRisk_eq_iff (η q : ℝ)
     exact h_kl_zero_iff.mp hkl
   · intro hq
     subst hq
-    ring
+    ring_nf
 
 /-- Population log-risk alias: `R_log(q) = E[ℓ_log(Y,q(Z))]` with Bernoulli truth `η(Z)`. -/
 noncomputable def Rlog {Z : Type*} [MeasurableSpace Z] (μ : Measure Z)

--- a/proofs/Calibrator/Models.lean
+++ b/proofs/Calibrator/Models.lean
@@ -735,7 +735,7 @@ theorem sum_to_zero_after_projection
       _ = ∑ x_1, (B * Z) x x_1 * β x_1 * W x x := by
           refine Finset.sum_congr rfl ?_
           intro x_1 _
-          ring
+          ring_nf
   rw [h_swap]
   rw [Finset.sum_comm]
 
@@ -748,7 +748,7 @@ theorem sum_to_zero_after_projection
           = ∑ x, β y * ((B * Z) x y * W x x) := by
               refine Finset.sum_congr rfl ?_
               intro x _
-              ring
+              ring_nf
       _ = β y * ∑ x, (B * Z) x y * W x x := by
               simp [Finset.mul_sum]
   simp [h_factor]
@@ -845,7 +845,7 @@ lemma sum_mulVec_mul_eq_sum_mul_transpose_mulVec
   · intro _; simp
   · intro ⟨i, j⟩ _
     simp only [Equiv.prodComm_apply, Prod.swap_prod_mk]
-    ring
+    ring_nf
 
 /-- The penalty transforms as a congruence under reparameterization.
 
@@ -1520,7 +1520,7 @@ theorem F_resid_subset_F_PC_lin (k : ℕ) [Fintype (Fin k)] :
     rw [Finset.mul_sum]
     apply Finset.sum_congr rfl
     intro i hi
-    ring
+    ring_nf
   rw [hform s x]
   apply congrArg phiUnit
   calc
@@ -1548,7 +1548,7 @@ theorem F_PC_lin_subset_F_full (k : ℕ) [Fintype (Fin k)] :
     unfold T sigma
     have ha0 : a ≠ 0 := ha.ne'
     field_simp [ha0]
-    ring
+    ring_nf
 
 theorem F_rawPRS_subset_F_PC_lin_subset_F_full (k : ℕ) [Fintype (Fin k)] :
     F_rawPRS k ⊆ F_PC_lin k ∧ F_PC_lin k ⊆ F_full k := by

--- a/proofs/Calibrator/PGSCalibrationTheory.lean
+++ b/proofs/Calibrator/PGSCalibrationTheory.lean
@@ -269,7 +269,7 @@ theorem auc_independent_of_calibration
         intro a b hab
         linarith)
   · unfold calibrationInTheLarge
-    ring
+    ring_nf
 
 /-- **Prevalence shift changes calibration.**
     Prevalence shift changes calibration: if prevalence changes from
@@ -909,7 +909,7 @@ theorem recalibration_needs_target_cohort
     h_events h_info h_target]
   unfold requiredTargetCohortSizeForRecalibration
   rw [div_le_iff₀ h_prev]
-  simp [mul_comm, mul_left_comm]
+  simp [mul_comm]
 
 /-- At fixed parameter count, per-event information, and target precision,
     lower event prevalence strictly increases the total target cohort size
@@ -1141,7 +1141,7 @@ theorem positive_nri_iff_reclassifiedBandEventPrevalence_below_cohort_prevalence
         (π * (1 - π)) * thresholdBandRate μevent threshold δ <
           (π * (1 - π)) * thresholdBandRate μnonevent threshold δ := by
       simpa [mul_assoc] using h_scaled
-    exact lt_of_mul_lt_mul_left' h_scaled'
+    exact (mul_lt_mul_iff_of_pos_left h_scale_pos).mp h_scaled'
 
 /-- **Finite-horizon longitudinal treatment model.**
     `discount t` encodes the time value of health at follow-up time `t`. -/
@@ -1240,7 +1240,7 @@ theorem qalyLoss_eq_qalyDecisionRegretMargin
         exact max_eq_right (by linarith)
       unfold qalyLoss qalyGainUnderDecision qalyDecisionRegretMargin
       rw [if_pos h_true, if_pos h_pred, if_pos h_pred, h_max]
-      ring
+      ring_nf
     · have h_true_nonpos : treatmentMargin model truePath ≤ 0 := not_lt.mp h_true
       have h_max :
           max (-treatmentMargin model truePath) 0 =
@@ -1248,7 +1248,7 @@ theorem qalyLoss_eq_qalyDecisionRegretMargin
         exact max_eq_left (by linarith)
       unfold qalyLoss qalyGainUnderDecision qalyDecisionRegretMargin
       rw [if_neg h_true, if_pos h_pred, if_pos h_pred, h_max]
-      ring
+      ring_nf
   · by_cases h_true : receivesTreatment model truePath
     · have h_max :
           max (treatmentMargin model truePath) 0 =
@@ -1256,13 +1256,13 @@ theorem qalyLoss_eq_qalyDecisionRegretMargin
         exact max_eq_left (le_of_lt h_true)
       unfold qalyLoss qalyGainUnderDecision qalyDecisionRegretMargin
       rw [if_pos h_true, if_neg h_pred, if_neg h_pred, h_max]
-      ring
+      ring_nf
     · have h_true_nonpos : treatmentMargin model truePath ≤ 0 := not_lt.mp h_true
       have h_max : max (treatmentMargin model truePath) 0 = 0 := by
         exact max_eq_right h_true_nonpos
       unfold qalyLoss qalyGainUnderDecision qalyDecisionRegretMargin
       rw [if_neg h_true, if_neg h_pred, if_neg h_pred, h_max]
-      ring
+      ring_nf
 
 /-- QALY loss is always nonnegative under the longitudinal regret model. -/
 theorem qalyLoss_nonneg
@@ -1303,12 +1303,12 @@ theorem qalyLoss_eq_zero_of_same_decision
   by_cases h_true : receivesTreatment model truePath
   · have h_pred : receivesTreatment model predictedPath := h_decision.mpr h_true
     rw [if_pos h_true, if_pos h_pred]
-    ring
+    ring_nf
   · have h_pred : ¬ receivesTreatment model predictedPath := by
       intro h_pred
       exact h_true (h_decision.mp h_pred)
     rw [if_neg h_true, if_neg h_pred]
-    ring
+    ring_nf
 
 /-- **A margin error smaller than the true decision margin preserves the
     treatment decision.**
@@ -1598,7 +1598,7 @@ theorem abs_treatmentMargin_error_le_componentwise_calibration_bound
                               (predictedPath.treatmentBenefit t -
                                 truePath.treatmentBenefit t)) +
                             (-(predictedPath.treatmentHarm t -
-                              truePath.treatmentHarm t))| := by ring
+                              truePath.treatmentHarm t))| := by ring_nf
                       _ ≤
                           |(predictedPath.eventProb t - truePath.eventProb t) *
                               truePath.treatmentBenefit t +
@@ -2201,7 +2201,7 @@ theorem qalyGainUnderDecision_threshold_eq_thresholdQalyGainUnderDecision
     unfold qalyGainUnderDecision
     rw [if_pos h_treat, treatmentMargin_thresholdClinicalPathway]
     simp [thresholdQalyGainUnderDecision, h, model.harm_eq_threshold]
-    ring
+    ring_nf
   · have h_not_treat :
         ¬ receivesTreatment (thresholdLongitudinalModel model)
           (thresholdClinicalPathway model decisionRisk) := by
@@ -2283,7 +2283,7 @@ theorem thresholdQalyLoss_eq_benefit_mul_thresholdDecisionRegretMargin
       have hmax : max (model.threshold - trueRisk) 0 = 0 := by
         exact max_eq_right (by linarith)
       rw [hmax]
-      ring
+      ring_nf
   · by_cases h_true_high : model.threshold < trueRisk
     · unfold thresholdDecisionRegretMargin
       rw [if_neg h_pred]
@@ -2303,7 +2303,7 @@ theorem thresholdQalyLoss_eq_benefit_mul_thresholdDecisionRegretMargin
       have hmax : max (trueRisk - model.threshold) 0 = 0 := by
         exact max_eq_right (by linarith)
       rw [hmax]
-      ring
+      ring_nf
 
 /-- Threshold-specialized QALY loss is always nonnegative. -/
 theorem thresholdQalyLoss_nonneg

--- a/proofs/Calibrator/Probability.lean
+++ b/proofs/Calibrator/Probability.lean
@@ -300,7 +300,7 @@ theorem HardyWeinbergModel.genotypeProb_sum (h : HardyWeinbergModel) :
     (∑ g : DiploidGenotype, h.genotypeProb g) = 1 := by
   have hsum : h.refFreq + h.altFreq = 1 := by
     unfold HardyWeinbergModel.refFreq
-    ring
+    ring_nf
   have hrewrite :
       (∑ g : DiploidGenotype, h.genotypeProb g) =
         ∑ i : Fin 3, h.genotypeProb (DiploidGenotype.equivFin3.symm i) := by
@@ -324,7 +324,7 @@ theorem HardyWeinbergModel.expectedAltAlleleCount_eq
     h.expectedAltAlleleCount = 2 * h.altFreq := by
   have hsum : h.refFreq + h.altFreq = 1 := by
     unfold HardyWeinbergModel.refFreq
-    ring
+    ring_nf
   unfold HardyWeinbergModel.expectedAltAlleleCount
   have hrewrite :
       (∑ g : DiploidGenotype, altAlleleCount g * h.genotypeProb g) =
@@ -342,7 +342,7 @@ theorem HardyWeinbergModel.expectedAltAlleleCount_eq
         altAlleleCount DiploidGenotype.homAlt * h.altFreq ^ 2
         = 2 * (h.refFreq * h.altFreq) + 2 * h.altFreq ^ 2 := by
           simp [altAlleleCount]
-          ring
+          ring_nf
     _ 
         = 2 * h.altFreq * (h.refFreq + h.altFreq) := by ring
     _ = 2 * h.altFreq := by rw [hsum]; ring
@@ -362,7 +362,7 @@ theorem HardyWeinbergModel.genotypeVariance_eq
     h.genotypeVariance = 2 * h.altFreq * h.refFreq := by
   have hsum : h.refFreq + h.altFreq = 1 := by
     unfold HardyWeinbergModel.refFreq
-    ring
+    ring_nf
   unfold HardyWeinbergModel.genotypeVariance HardyWeinbergModel.centeredAltAlleleCount
   rw [h.expectedAltAlleleCount_eq]
   have hrewrite :


### PR DESCRIPTION
Fix compilation error `failed to synthesize MulLeftReflectLT ℝ` and address linter warnings from compiler by replacing `ring` with `ring_nf` across multiple files.

---
*PR created automatically by Jules for task [10818693845740405523](https://jules.google.com/task/10818693845740405523) started by @SauersML*