### PR TITLE
Fix PGSCalibrationTheory compilation errors

### DIFF
--- a/proofs/Calibrator/PGSCalibrationTheory.lean
+++ b/proofs/Calibrator/PGSCalibrationTheory.lean
@@ -1141,7 +1141,7 @@ theorem positive_nri_iff_reclassifiedBandEventPrevalence_below_cohort_prevalence
         (π * (1 - π)) * thresholdBandRate μevent threshold δ <
           (π * (1 - π)) * thresholdBandRate μnonevent threshold δ := by
       simpa [mul_assoc] using h_scaled
-    exact lt_of_mul_lt_mul_left' h_scaled'
+    exact (mul_lt_mul_iff_of_pos_left h_scale_pos).mp h_scaled'
 
 /-- **Finite-horizon longitudinal treatment model.**
     `discount t` encodes the time value of health at follow-up time `t`. -/
@@ -1598,7 +1598,7 @@ theorem abs_treatmentMargin_error_le_componentwise_calibration_bound
                               (predictedPath.treatmentBenefit t -
                                 truePath.treatmentBenefit t)) +
                             (-(predictedPath.treatmentHarm t -
-                              truePath.treatmentHarm t))| := by ring
+                              truePath.treatmentHarm t))| := by ring_nf
                       _ ≤
                           |(predictedPath.eventProb t - truePath.eventProb t) *
                               truePath.treatmentBenefit t +


### PR DESCRIPTION
This commit fixes two specific build errors/warnings in `proofs/Calibrator/PGSCalibrationTheory.lean`:
1. It replaces `lt_of_mul_lt_mul_left'` with `(mul_lt_mul_iff_of_pos_left ...).mp` to properly handle multiplication reflection over the real numbers.
2. It changes a `ring` tactic call to `ring_nf` to correctly place the expression in normal form as recommended by the compiler.

---
*PR created automatically by Jules for task [17834224811164070740](https://jules.google.com/task/17834224811164070740) started by @SauersML*