### PR TITLE
Fix PGSCalibrationTheory build errors

### DIFF
--- a/proofs/Calibrator/PGSCalibrationTheory.lean
+++ b/proofs/Calibrator/PGSCalibrationTheory.lean
@@ -1141,7 +1141,7 @@ theorem positive_nri_iff_reclassifiedBandEventPrevalence_below_cohort_prevalence
         (π * (1 - π)) * thresholdBandRate μevent threshold δ <
           (π * (1 - π)) * thresholdBandRate μnonevent threshold δ := by
       simpa [mul_assoc] using h_scaled
-    exact lt_of_mul_lt_mul_left' h_scaled'
+    exact (mul_lt_mul_iff_of_pos_left h_scale_pos).mp h_scaled'
 
 /-- **Finite-horizon longitudinal treatment model.**
     `discount t` encodes the time value of health at follow-up time `t`. -/
@@ -1598,7 +1598,7 @@ theorem abs_treatmentMargin_error_le_componentwise_calibration_bound
                               (predictedPath.treatmentBenefit t -
                                 truePath.treatmentBenefit t)) +
                             (-(predictedPath.treatmentHarm t -
-                              truePath.treatmentHarm t))| := by ring
+                              truePath.treatmentHarm t))| := by ring_nf
                       _ ≤
                           |(predictedPath.eventProb t - truePath.eventProb t) *
                               truePath.treatmentBenefit t +


### PR DESCRIPTION
This branch fixes build errors in `proofs/Calibrator/PGSCalibrationTheory.lean`. 
The `lt_of_mul_lt_mul_left'` lemma failed to synthesize `MulLeftReflectLT ℝ`, so it was replaced with the robust `(mul_lt_mul_iff_of_pos_left h_scale_pos).mp`. Additionally, a `ring` tactic that failed to close a goal was replaced with `ring_nf`.

---
*PR created automatically by Jules for task [5059564533257984342](https://jules.google.com/task/5059564533257984342) started by @SauersML*