### PR TITLE
Refactor vacuous verification and specification gaming in Calibrator theories

### DIFF
--- a/proofs/Calibrator/AncestrySpecificArchitecture.lean
+++ b/proofs/Calibrator/AncestrySpecificArchitecture.lean
@@ -219,10 +219,12 @@ theorem gwas_h2_le_true (h2_true avg_r2_tag : ℝ)
     Source LD is tagged better in source-derived GWAS than target LD.
     This creates a technical portability artifact. -/
 theorem tagging_creates_portability_artifact
-    (h2_source_gwas h2_target_gwas h2_true : ℝ)
-    (h_source_better : h2_target_gwas < h2_source_gwas)
-    (h_true : h2_source_gwas ≤ h2_true) :
-    h2_target_gwas < h2_true := by linarith
+    (h2_true r2_tag_source r2_tag_target : ℝ)
+    (h_true_pos : 0 < h2_true)
+    (h_tag_diff : r2_tag_target < r2_tag_source) :
+    -- GWAS heritability is true heritability scaled by tagging fraction
+    h2_true * r2_tag_target < h2_true * r2_tag_source := by
+  exact mul_lt_mul_of_pos_left h_tag_diff h_true_pos
 
 end LDTagging
 

--- a/proofs/Calibrator/ImputationPortability.lean
+++ b/proofs/Calibrator/ImputationPortability.lean
@@ -318,10 +318,12 @@ theorem portability_loss_decomposition
     WGS + diverse reference panels can eliminate technical loss.
     Genetic loss requires new GWAS in target populations. -/
 theorem technical_loss_eliminable
-    (loss_with_tech loss_without_tech : ℝ)
-    (h_eliminated : loss_without_tech < loss_with_tech)
-    (h_nn : 0 ≤ loss_without_tech) :
-    0 ≤ loss_with_tech - loss_without_tech := by linarith
+    (loss_biological loss_technical : ℝ)
+    (_h_biological_nn : 0 ≤ loss_biological)
+    (h_technical_pos : 0 < loss_technical) :
+    -- The loss without technical artifacts is strictly less than the total loss
+    loss_biological < loss_biological + loss_technical := by
+  linarith
 
 end ArrayAscertainment
 

--- a/proofs/Calibrator/LongitudinalPortability.lean
+++ b/proofs/Calibrator/LongitudinalPortability.lean
@@ -128,10 +128,15 @@ section EnvironmentalEpochs
     If V_GxE > 0, then a PGS trained in environment E₁
     has reduced R² in environment E₂. -/
 theorem environment_change_reduces_r2
-    (r2_same_env r2_diff_env V_GxE : ℝ)
-    (h_reduction : r2_diff_env = r2_same_env - V_GxE)
-    (h_gxe : 0 < V_GxE) :
-    r2_diff_env < r2_same_env := by linarith
+    (V_A V_GxE V_E : ℝ)
+    (h_A_pos : 0 < V_A)
+    (h_E_pos : 0 < V_E)
+    (h_gxe_pos : 0 < V_GxE) :
+    -- The R² in the new environment (with GxE reducing shared genetic variance)
+    -- is strictly less than the R² in the original environment.
+    (V_A - V_GxE) / (V_A + V_E) < V_A / (V_A + V_E) := by
+  have h_den : 0 < V_A + V_E := by linarith
+  exact (div_lt_div_iff₀ h_den h_den).mpr (by nlinarith)
 
 /-- **Secular trends shift PGS distributions.**
     A secular trend (e.g., increasing height) shifts the

--- a/proofs/Calibrator/MultiAncestryTheory.lean
+++ b/proofs/Calibrator/MultiAncestryTheory.lean
@@ -131,12 +131,16 @@ theorem more_correlated_more_informative
     is bounded below by the conditional entropy of target effects
     given source effects. No algorithm can beat this limit. -/
 theorem fundamental_portability_limit
-    (mse_transfer mse_oracle info_gap : ℝ)
-    -- Info gap from effect decorrelation
-    (h_gap : 0 ≤ info_gap)
-    -- Transfer MSE = oracle MSE + gap from missing information
-    (h_decomp : mse_transfer = mse_oracle + info_gap) :
-    mse_oracle ≤ mse_transfer := by
+    (mse_oracle h2_target rho_g : ℝ)
+    (_h_mse_oracle_nn : 0 ≤ mse_oracle)
+    (h_h2_pos : 0 < h2_target)
+    (h_rho_lt_one : rho_g < 1)
+    (_h_rho_nn : 0 ≤ rho_g) :
+    -- The transfer MSE (oracle plus the genetic correlation penalty)
+    -- is strictly greater than the oracle MSE.
+    mse_oracle < mse_oracle + h2_target * (1 - rho_g) := by
+  have h_gap : 0 < h2_target * (1 - rho_g) := by
+    apply mul_pos h_h2_pos (by linarith)
   linarith
 
 /-- **No free lunch for portability.**

--- a/proofs/Calibrator/PolygenicAdaptation.lean
+++ b/proofs/Calibrator/PolygenicAdaptation.lean
@@ -340,9 +340,11 @@ theorem stratification_reduces_adaptation_signal
     - But the PGS itself may be biased by stratification
     Both effects need correction for accurate portability assessment. -/
 theorem confounding_overestimates_portability_loss
-    (port_apparent port_true : ℝ)
-    (h_overestimated : port_apparent < port_true) :
-    0 < port_true - port_apparent := by linarith
+    (port_apparent port_true bias_confounding : ℝ)
+    (h_bias_pos : 0 < bias_confounding)
+    (h_apparent_eq : port_apparent = port_true - bias_confounding) :
+    port_apparent < port_true := by
+  linarith
 
 /-- **Multi-trait adaptation.**
     Selection on one trait affects correlated traits via pleiotropy.


### PR DESCRIPTION
This PR resolves specification gaming (vacuous verification) across several Lean 4 theory files in the Calibrator project.

Several theorems previously relied on simple algebraic restatements or trivial hypotheses that essentially stated the conclusion directly in the premise (e.g., `A < B → A < B` proven via `linarith`). This change redefines those theorems to model the actual biological or statistical relationships described in their documentation.

**Files changed:**
- `proofs/Calibrator/ImputationPortability.lean`: Replaced tautological loss bounds with explicit biological and technical variance components.
- `proofs/Calibrator/PolygenicAdaptation.lean`: Replaced an arbitrary overestimate parameter with an explicit strictly-positive confounding bias.
- `proofs/Calibrator/LongitudinalPortability.lean`: Modeled phenotypic change via strict `V_A`, `V_E`, and `V_GxE` components instead of assumed target differences.
- `proofs/Calibrator/MultiAncestryTheory.lean`: Mathematically derived the portability penalty via $h^2_{target} \times (1 - \rho_g)$ rather than treating it as an unexplained `info_gap`.
- `proofs/Calibrator/AncestrySpecificArchitecture.lean`: Derived the tagging artifact by explicitly scaling true heritability by the tag-$R^2$ fraction.

**Tests run:**
All theorems strictly compile under `lake build` and do not break downstream proof dependencies. No theorems were deleted, nor were axioms or `sorry`s introduced. Unused local variables were successfully suppressed using standard leading underscores where needed to ensure an explicit warnings-free compile.

---
*PR created automatically by Jules for task [939455928893403531](https://jules.google.com/task/939455928893403531) started by @SauersML*