### PR TITLE
Fix vacuous verification in MultiTraitPGS and StatisticalGeneticsMethodology

### DIFF
--- a/proofs/Calibrator/MultiTraitPGS.lean
+++ b/proofs/Calibrator/MultiTraitPGS.lean
@@ -214,16 +214,37 @@ theorem rg_bounds_portability_ratio
   rwa [div_le_iff₀ h_r2_s] at h_bound
 
 /-- **Traits with high cross-population r_g have good portability.**
-    When r_g is high (e.g., ~0.95), R² portability is bounded by ~0.90. -/
+    When r_g is bounded below by a high value (e.g., ~0.95), R² portability
+    is bounded below by the square of that value if we assume the standard R² proportionality.
+    (Assuming r2_target / r2_source = rg_cross^2 for full shared genetic architecture). -/
 theorem high_cross_rg
-    (rg lb : ℝ) (h_rg : lb < rg) (h_lb_nn : 0 ≤ lb) (h_rg_le : rg ≤ 1) :
-    lb^2 < rg^2 := by nlinarith [sq_nonneg (rg - lb)]
+    (r2_source r2_target rg_cross lb : ℝ)
+    (h_r2_s : 0 < r2_source)
+    (h_rg : lb < rg_cross)
+    (h_lb_nn : 0 ≤ lb)
+    (h_rg_le : rg_cross ≤ 1)
+    (h_target_eq : r2_target / r2_source = rg_cross^2) :
+    lb^2 * r2_source < r2_target := by
+  have h_sq : lb^2 < rg_cross^2 := by nlinarith [sq_nonneg (rg_cross - lb)]
+  have h_mul : lb^2 * r2_source < rg_cross^2 * r2_source := (mul_lt_mul_iff_of_pos_right h_r2_s).mpr h_sq
+  have h_target_val : r2_target = rg_cross^2 * r2_source := (div_eq_iff h_r2_s.ne').mp h_target_eq
+  rwa [← h_target_val] at h_mul
 
 /-- **Traits with low cross-population r_g have poor portability.**
-    When r_g is low (e.g., ~0.3), R² portability is bounded by ~0.09. -/
+    When r_g is bounded above by a low value (e.g., ~0.3), R² portability
+    is bounded above by the square of that value. -/
 theorem low_cross_rg
-    (rg ub : ℝ) (h_rg : rg ≤ ub) (h_rg_nn : 0 ≤ rg) (h_ub_nn : 0 ≤ ub) :
-    rg^2 ≤ ub^2 := by nlinarith [sq_nonneg rg, sq_nonneg (rg - ub)]
+    (r2_source r2_target rg_cross ub : ℝ)
+    (h_r2_s : 0 < r2_source)
+    (h_rg : rg_cross ≤ ub)
+    (h_rg_nn : 0 ≤ rg_cross)
+    (h_ub_nn : 0 ≤ ub)
+    (h_target_upper_bound : r2_target / r2_source ≤ rg_cross^2) :
+    r2_target ≤ ub^2 * r2_source := by
+  have h1 : r2_target ≤ rg_cross^2 * r2_source := (div_le_iff₀ h_r2_s).mp h_target_upper_bound
+  have h2 : rg_cross^2 ≤ ub^2 := by nlinarith [sq_nonneg rg_cross, sq_nonneg (rg_cross - ub)]
+  have h3 : rg_cross^2 * r2_source ≤ ub^2 * r2_source := mul_le_mul_of_nonneg_right h2 (le_of_lt h_r2_s)
+  linarith
 
 /-- **r_g can be underestimated due to power.**
     With low power in underrepresented-population GWAS, r_g estimates are

--- a/proofs/Calibrator/StatisticalGeneticsMethodology.lean
+++ b/proofs/Calibrator/StatisticalGeneticsMethodology.lean
@@ -158,16 +158,20 @@ section CrossValidation
 
 /-- **Overfitting bias from sample overlap.**
     If the GWAS sample overlaps with the evaluation sample,
-    R² is biased upward by approximately p/n where p is the
-    number of SNPs in the PGS. -/
+    the observed R² is biased upward by approximately p/n where p is the
+    number of independent SNPs in the PGS. We model the biased R²
+    as R²_true + p/n. -/
 theorem overlap_bias
-    (p_snps n_overlap : ℝ)
+    (r2_true r2_obs p_snps n_overlap : ℝ)
     (h_p : 0 < p_snps) (h_n : 0 < n_overlap)
-    (h_n_large : p_snps < n_overlap) :
-    0 < p_snps / n_overlap ∧ p_snps / n_overlap < 1 := by
+    (h_n_large : p_snps < n_overlap)
+    (h_bias_model : r2_obs = r2_true + p_snps / n_overlap) :
+    r2_true < r2_obs ∧ r2_obs - r2_true < 1 := by
+  have h_bias_pos : 0 < p_snps / n_overlap := div_pos h_p h_n
+  have h_bias_lt_one : p_snps / n_overlap < 1 := (div_lt_one h_n).mpr h_n_large
   constructor
-  · exact div_pos h_p h_n
-  · rw [div_lt_one h_n]; exact h_n_large
+  · linarith
+  · linarith
 
 /- **Portability assessment requires population-specific validation.**
     R² must be evaluated in each target population separately.
@@ -336,13 +340,22 @@ section GeneticCorrelationMethods
 /-- **Method comparison: different methods can give different ρ̂_g.**
     This matters because ρ̂_g predicts portability.
     When methods disagree, the range of estimates is positive,
-    introducing irreducible uncertainty in portability prediction. -/
+    introducing irreducible uncertainty in portability prediction.
+    If the true correlation ρ_g_true lies within the range spanned by
+    the estimators, the maximum estimation error is at least half the range. -/
 theorem method_disagreement_increases_uncertainty
-    (rho_ldsc rho_popcorn rho_sumher : ℝ)
+    (rho_ldsc rho_popcorn rho_sumher rho_g_true : ℝ)
     (h_order : rho_popcorn < rho_ldsc)
-    (h_order₂ : rho_ldsc < rho_sumher) :
-    -- The range of estimates is strictly positive
-    0 < rho_sumher - rho_popcorn := by linarith
+    (h_order₂ : rho_ldsc < rho_sumher)
+    (h_true_bounds : rho_popcorn ≤ rho_g_true ∧ rho_g_true ≤ rho_sumher) :
+    (rho_sumher - rho_popcorn) / 2 ≤ max (rho_g_true - rho_popcorn) (rho_sumher - rho_g_true) := by
+  have h_range : rho_sumher - rho_popcorn = (rho_g_true - rho_popcorn) + (rho_sumher - rho_g_true) := by ring
+  -- The maximum of two numbers is >= their average
+  have h_max_avg : (rho_g_true - rho_popcorn) + (rho_sumher - rho_g_true) ≤ 2 * max (rho_g_true - rho_popcorn) (rho_sumher - rho_g_true) := by
+    calc (rho_g_true - rho_popcorn) + (rho_sumher - rho_g_true)
+      _ ≤ max (rho_g_true - rho_popcorn) (rho_sumher - rho_g_true) + max (rho_g_true - rho_popcorn) (rho_sumher - rho_g_true) := add_le_add (le_max_left _ _) (le_max_right _ _)
+      _ = 2 * max (rho_g_true - rho_popcorn) (rho_sumher - rho_g_true) := by ring
+  linarith
 
 /-- **Genetic correlation varies across the genome.**
     ρ_g estimated from different genomic regions can vary,


### PR DESCRIPTION
Fix vacuous verification in MultiTraitPGS and StatisticalGeneticsMethodology

---
*PR created automatically by Jules for task [8689889893153162783](https://jules.google.com/task/8689889893153162783) started by @SauersML*