### PR TITLE
Fix specification gaming and vacuous theorems

### DIFF
--- a/proofs/Calibrator/DemographicHistory.lean
+++ b/proofs/Calibrator/DemographicHistory.lean
@@ -727,6 +727,12 @@ theorem bottleneck_worsens_portability
     fst_mismatch < fst_mismatch + bottleneckExcessLD Ne_b Ne_stable t_b := by
   linarith [bottleneck_excess_ld_pos Ne_b Ne_stable t_b hNb hNs h_bottle ht]
 
+noncomputable def targetR2_stable (R2_source fst : ℝ) : ℝ :=
+  R2_source * (1 - fst)
+
+noncomputable def targetR2_bottleneck (R2_source fst Ne_b Ne_stable : ℝ) (t_b : ℕ) : ℝ :=
+  R2_source * ((1 - fst) - bottleneckExcessLD Ne_b Ne_stable t_b)
+
 /-- **Portability ratio under bottleneck** is strictly worse than under stable demography.
     Derived: portability ∝ (1 - Fst) for stable populations. For bottlenecked populations,
     portability ∝ (1 - Fst) · (1 - excessLD_correction). Since bottleneckExcessLD > 0,
@@ -738,10 +744,9 @@ theorem bottleneck_reduces_portability_ratio
     (hR2 : 0 < R2_source)
     (hNb : 2 < Ne_b) (hNs : 2 < Ne_stable) (h_bottle : Ne_b < Ne_stable)
     (ht : 0 < t_b)
-    (hfst : 0 ≤ fst) (hfst1 : fst < 1)
-    (h_pen_bound : bottleneckExcessLD Ne_b Ne_stable t_b < 1 - fst) :
-    R2_source * ((1 - fst) - bottleneckExcessLD Ne_b Ne_stable t_b) <
-    R2_source * (1 - fst) := by
+    (hfst : 0 ≤ fst) (hfst1 : fst < 1) :
+    targetR2_bottleneck R2_source fst Ne_b Ne_stable t_b < targetR2_stable R2_source fst := by
+  unfold targetR2_bottleneck targetR2_stable
   apply mul_lt_mul_of_pos_left _ hR2
   linarith [bottleneck_excess_ld_pos Ne_b Ne_stable t_b hNb hNs h_bottle ht]
 

--- a/proofs/Calibrator/VarianceComponents.lean
+++ b/proofs/Calibrator/VarianceComponents.lean
@@ -252,15 +252,32 @@ on LD and population structure assumptions.
 
 section GREML
 
+/-- Models the GREML estimate when the GRM captures both true additive variance
+    and variance due to LD differences. -/
+noncomputable def gremlLDEstimate (V_A V_LD V_P : ℝ) : ℝ :=
+  (V_A + V_LD) / V_P
+
+/-- The true SNP heritability. -/
+noncomputable def trueSNPHeritability (V_A V_P : ℝ) : ℝ :=
+  V_A / V_P
+
 /-- **GREML h² estimate depends on LD structure.**
     GREML estimates h²_SNP = trace(GRM⁻¹ × Σ_pheno) / n.
-    When LD differs between training and evaluation, the estimate is biased. -/
+    When LD differs between training and evaluation (V_LD ≠ 0),
+    the GREML estimate is biased. -/
 theorem greml_ld_sensitive
-    (h2_estimated h2_true ld_bias : ℝ)
-    (h_bias : h2_estimated = h2_true + ld_bias)
-    (h_ld_nonzero : ld_bias ≠ 0) :
-    h2_estimated ≠ h2_true := by
-  rw [h_bias]; intro h; apply h_ld_nonzero; linarith
+    (V_A V_LD V_P : ℝ)
+    (h_VP_pos : 0 < V_P)
+    (h_VLD_nonzero : V_LD ≠ 0) :
+    gremlLDEstimate V_A V_LD V_P ≠ trueSNPHeritability V_A V_P := by
+  unfold gremlLDEstimate trueSNPHeritability
+  intro h
+  have h_mul : V_A + V_LD = V_A := by
+    have h_eq : (V_A + V_LD) / V_P * V_P = V_A / V_P * V_P := by rw [h]
+    have hp : V_P ≠ 0 := ne_of_gt h_VP_pos
+    rwa [div_mul_cancel₀ (V_A + V_LD) hp, div_mul_cancel₀ V_A hp] at h_eq
+  apply h_VLD_nonzero
+  linarith
 
 /-- **GREML underestimates h² when causal variants are poorly tagged.**
     The true SNP heritability is `V_A / V_P`, while GREML only captures


### PR DESCRIPTION
Fix specification gaming and vacuous theorems.

- Refactored `greml_ld_sensitive` in `VarianceComponents.lean` to explicitly model `gremlLDEstimate` and `trueSNPHeritability` instead of hardcoding `h_bias : h2_estimated = h2_true + ld_bias`.
- Refactored `bottleneck_reduces_portability_ratio` in `DemographicHistory.lean` to define explicit `targetR2_stable` and `targetR2_bottleneck` representations, and removed unused tautological bound hypothesis.

---
*PR created automatically by Jules for task [6253164785842208060](https://jules.google.com/task/6253164785842208060) started by @SauersML*