### PR TITLE
Refactor blocked_cv_less_biased to remove vacuous verification

### DIFF
--- a/proofs/Calibrator/StatisticalGeneticsMethodology.lean
+++ b/proofs/Calibrator/StatisticalGeneticsMethodology.lean
@@ -173,19 +173,74 @@ theorem overlap_bias
     R² must be evaluated in each target population separately.
     A single combined evaluation mixes portability with demographics. -/
 
+/-- **Model for Cross-Validation Variance Estimates.**
+    Captures the true variance, noise, and confounding due to family structure. -/
+structure CVVarianceModel where
+  true_variance : ℝ
+  noise_variance : ℝ
+  family_confounding : ℝ
+  h_true_pos : 0 < true_variance
+  h_noise_pos : 0 < noise_variance
+  h_family_pos : 0 < family_confounding
+
+/-- The true underlying R² without family confounding. -/
+noncomputable def cv_true_r2 (m : CVVarianceModel) : ℝ :=
+  m.true_variance / (m.true_variance + m.noise_variance)
+
+/-- The biased R² estimate when some proportion `confounding_retained`
+    of family confounding remains in the variance estimate. -/
+noncomputable def cv_biased_r2 (m : CVVarianceModel) (confounding_retained : ℝ) : ℝ :=
+  (m.true_variance + confounding_retained * m.family_confounding) /
+  (m.true_variance + confounding_retained * m.family_confounding + m.noise_variance)
+
+/-- Retained family confounding always results in an upward bias in the R² estimate. -/
+theorem cv_biased_r2_ge_true (m : CVVarianceModel) (c : ℝ) (hc : 0 ≤ c) :
+    cv_true_r2 m ≤ cv_biased_r2 m c := by
+  unfold cv_true_r2 cv_biased_r2
+  have h_den1 : 0 < m.true_variance + m.noise_variance := by linarith [m.h_true_pos, m.h_noise_pos]
+  have h_cf : 0 ≤ c * m.family_confounding := mul_nonneg hc (le_of_lt m.h_family_pos)
+  have h_den2 : 0 < m.true_variance + c * m.family_confounding + m.noise_variance := by linarith [m.h_true_pos, m.h_noise_pos, h_cf]
+  rw [div_le_div_iff₀ h_den1 h_den2]
+  nlinarith [m.h_true_pos, m.h_noise_pos, m.h_family_pos, hc]
+
 /-- **Blocked cross-validation for family structure.**
     When evaluating PGS in populations with family structure,
     standard CV overestimates R² due to shared segments.
     Family-blocked CV is closer to the true R² because it removes
-    the upward bias from family sharing, so its absolute error is smaller. -/
+    more of the upward bias from family sharing, so its absolute error is strictly smaller.
+    This replaces a prior tautological theorem with a rigorous structural bound. -/
 theorem blocked_cv_less_biased
-    (r2_standard_cv r2_blocked_cv r2_true : ℝ)
-    (h_standard_biased : r2_true < r2_standard_cv)
-    (h_blocked_between : r2_true ≤ r2_blocked_cv)
-    (h_blocked_closer_to_true : r2_blocked_cv < r2_standard_cv) :
-    |r2_blocked_cv - r2_true| < |r2_standard_cv - r2_true| := by
+    (m : CVVarianceModel)
+    (c_blocked c_standard : ℝ)
+    (hc_blocked_nonneg : 0 ≤ c_blocked)
+    (hc_lt : c_blocked < c_standard) :
+    |cv_biased_r2 m c_blocked - cv_true_r2 m| < |cv_biased_r2 m c_standard - cv_true_r2 m| := by
+  have hc_standard_nonneg : 0 ≤ c_standard := by linarith
+  have h1 : cv_true_r2 m ≤ cv_biased_r2 m c_blocked := cv_biased_r2_ge_true m c_blocked hc_blocked_nonneg
+  have h2 : cv_true_r2 m ≤ cv_biased_r2 m c_standard := cv_biased_r2_ge_true m c_standard hc_standard_nonneg
+
   rw [abs_of_nonneg (by linarith), abs_of_nonneg (by linarith)]
-  linarith
+
+  have h_cf1 : 0 ≤ c_blocked * m.family_confounding := mul_nonneg hc_blocked_nonneg (le_of_lt m.h_family_pos)
+  have h_cf2 : 0 ≤ c_standard * m.family_confounding := mul_nonneg hc_standard_nonneg (le_of_lt m.h_family_pos)
+
+  have h_den1 : 0 < m.true_variance + c_blocked * m.family_confounding + m.noise_variance := by linarith [m.h_true_pos, m.h_noise_pos, h_cf1]
+  have h_den2 : 0 < m.true_variance + c_standard * m.family_confounding + m.noise_variance := by linarith [m.h_true_pos, m.h_noise_pos, h_cf2]
+
+  apply sub_lt_sub_right
+  unfold cv_biased_r2
+  rw [div_lt_div_iff₀ h_den1 h_den2]
+  calc
+    (m.true_variance + c_blocked * m.family_confounding) * (m.true_variance + c_standard * m.family_confounding + m.noise_variance)
+    _ = (m.true_variance + c_blocked * m.family_confounding) * (m.true_variance + c_standard * m.family_confounding) +
+        (m.true_variance + c_blocked * m.family_confounding) * m.noise_variance := by ring
+    _ < (m.true_variance + c_blocked * m.family_confounding) * (m.true_variance + c_standard * m.family_confounding) +
+        (m.true_variance + c_standard * m.family_confounding) * m.noise_variance := by
+        apply add_lt_add_left
+        apply mul_lt_mul_of_pos_right
+        · nlinarith [m.h_family_pos, hc_lt]
+        · exact m.h_noise_pos
+    _ = (m.true_variance + c_standard * m.family_confounding) * (m.true_variance + c_blocked * m.family_confounding + m.noise_variance) := by ring
 
 /- **Time-split validation for discovery bias.**
     If the PGS discovery includes newer data, temporal validation


### PR DESCRIPTION
Refactor blocked_cv_less_biased to remove vacuous verification

Replaced the tautological setup of the `blocked_cv_less_biased` theorem
with a mathematically rigorous structural model (`CVVarianceModel`).

Defined `cv_true_r2` and `cv_biased_r2` to model how retained family
confounding influences the R² estimate. Proved `cv_biased_r2_ge_true` to
show upward bias resulting from retained confounding. Finally,
restructured `blocked_cv_less_biased` to show that smaller retained
confounding mathematically ensures a strictly smaller absolute error from
the true R², rather than assuming this conclusion in the hypothesis.

---
*PR created automatically by Jules for task [5716500949634535415](https://jules.google.com/task/5716500949634535415) started by @SauersML*