### PR TITLE
Refactor AncestrySpecificArchitecture proofs to eliminate specification gaming

### DIFF
--- a/proofs/Calibrator/AncestrySpecificArchitecture.lean
+++ b/proofs/Calibrator/AncestrySpecificArchitecture.lean
@@ -219,10 +219,12 @@ theorem gwas_h2_le_true (h2_true avg_r2_tag : ℝ)
     Source LD is tagged better in source-derived GWAS than target LD.
     This creates a technical portability artifact. -/
 theorem tagging_creates_portability_artifact
-    (h2_source_gwas h2_target_gwas h2_true : ℝ)
-    (h_source_better : h2_target_gwas < h2_source_gwas)
-    (h_true : h2_source_gwas ≤ h2_true) :
-    h2_target_gwas < h2_true := by linarith
+    (h2_true avg_r2_tag_source avg_r2_tag_target : ℝ)
+    (h_h2_pos : 0 < h2_true)
+    (h_tag_better : avg_r2_tag_target < avg_r2_tag_source) :
+    gwasHeritability h2_true avg_r2_tag_target < gwasHeritability h2_true avg_r2_tag_source := by
+  unfold gwasHeritability
+  exact mul_lt_mul_of_pos_left h_tag_better h_h2_pos
 
 end LDTagging
 
@@ -368,16 +370,6 @@ theorem fst_decreases_with_migration (m₁ m₂ Ne : ℝ)
   rw [div_lt_div_iff₀ (by nlinarith) (by nlinarith)]
   nlinarith
 
-/-- **Shared selection homogenizes architecture.**
-    If both populations experience the same selective pressure
-    (e.g., both urbanizing), the genetic architecture converges
-    for environment-sensitive traits. -/
-theorem shared_selection_improves_portability
-    (rg_before rg_after : ℝ)
-    (h_improves : rg_before < rg_after)
-    (h_le : rg_after ≤ 1) :
-    rg_before < 1 := by linarith
-
 /-!
 ### Derivation: portabilityFromArchitecture = rg² × (1 - Fst) × tagging_ratio
 
@@ -473,6 +465,24 @@ theorem portability_bounded_by_rg_sq
   unfold portabilityFromArchitecture
   have h1 : (1 - fst) * tagging_ratio ≤ 1 := by nlinarith [mul_nonneg (by linarith : 0 ≤ 1 - fst) h_tag]
   nlinarith [sq_nonneg rg, mul_nonneg (sq_nonneg rg) (mul_nonneg (by linarith : 0 ≤ 1 - fst) h_tag)]
+
+/-- **Shared selection homogenizes architecture.**
+    If both populations experience the same selective pressure
+    (e.g., both urbanizing), the genetic architecture converges
+    for environment-sensitive traits. -/
+theorem shared_selection_improves_portability
+    (rg_before rg_after fst tagging_ratio : ℝ)
+    (h_pos_before : 0 < rg_before)
+    (h_improves : rg_before < rg_after)
+    (h_fst : fst < 1)
+    (h_tag : 0 < tagging_ratio) :
+    portabilityFromArchitecture rg_before fst tagging_ratio <
+    portabilityFromArchitecture rg_after fst tagging_ratio := by
+  unfold portabilityFromArchitecture
+  have h_rg_sq : rg_before^2 < rg_after^2 := by nlinarith
+  have h_mul1 : rg_before^2 * (1 - fst) < rg_after^2 * (1 - fst) := by
+    exact mul_lt_mul_of_pos_right h_rg_sq (by linarith)
+  exact mul_lt_mul_of_pos_right h_mul1 h_tag
 
 end ArchitectureConvergence
 


### PR DESCRIPTION
This PR refactors two theorems in `proofs/Calibrator/AncestrySpecificArchitecture.lean` that suffered from specification gaming (where the conclusion was trivially derived from a tautological setup that ignored the actual domain models).

1. `tagging_creates_portability_artifact` now correctly takes `avg_r2_tag_source` and `avg_r2_tag_target` and proves that differing tagging efficiencies propagate strictly through the `gwasHeritability` definition.
2. `shared_selection_improves_portability` was completely disconnected from the actual portability model. It has been updated to use the `portabilityFromArchitecture` formula directly, proving that an increase in genetic correlation strictly increases computed portability, assuming constant tagging and Fst.

All proofs compile without errors.

---
*PR created automatically by Jules for task [1161012032579229311](https://jules.google.com/task/1161012032579229311) started by @SauersML*