### PR TITLE
Refactor tautological theorems to mathematical rigor

### DIFF
--- a/proofs/Calibrator/CausalInference.lean
+++ b/proofs/Calibrator/CausalInference.lean
@@ -93,13 +93,107 @@ theorem selection_dominant_for_immune
 
 /-- **Interaction effects between pathways.**
     Pathways are not fully independent: LD changes interact
-    with MAF changes (LD × MAF interaction). -/
+    with MAF changes (LD × MAF interaction). Removing LD and MAF
+    differences simultaneously improves R² more than the sum of
+    their individual improvements due to non-linearities in expectedR2. -/
 theorem pathway_interactions_exist
-    (sum_individual total_with_interactions interaction : ℝ)
-    (h_interaction : total_with_interactions = sum_individual + interaction)
-    (h_nonzero : interaction ≠ 0) :
-    total_with_interactions ≠ sum_individual := by
-  rw [h_interaction]; intro h; apply h_nonzero; linarith
+    (vSignal V_E V_ld V_maf : ℝ)
+    (h_sig : 0 < vSignal) (h_VE : 0 < V_E)
+    (h_ld : 0 < V_ld) (h_maf : 0 < V_maf) :
+    let base_noise := V_E + V_ld + V_maf
+    let gain_ld := expectedR2 vSignal (V_E + V_maf) - expectedR2 vSignal base_noise
+    let gain_maf := expectedR2 vSignal (V_E + V_ld) - expectedR2 vSignal base_noise
+    let gain_both := expectedR2 vSignal V_E - expectedR2 vSignal base_noise
+    gain_ld + gain_maf < gain_both := by
+  simp only
+  unfold expectedR2
+  -- Algebraically, we want to show:
+  -- (v/(V_E + V_maf) - v/(V_E + V_ld + V_maf)) + (v/(V_E + V_ld) - v/(V_E + V_ld + V_maf))
+  -- < v/V_E - v/(V_E + V_ld + V_maf)
+  -- This is equivalent to:
+  -- v/(V_E + V_maf) + v/(V_E + V_ld) - v/(V_E + V_ld + V_maf) < v/V_E
+  have h1 : 0 < V_E := h_VE
+  have h2 : 0 < V_E + V_ld := by linarith
+  have h3 : 0 < V_E + V_maf := by linarith
+  have h4 : 0 < V_E + V_ld + V_maf := by linarith
+  -- Since expectedR2 is v / (v + noise) = 1 / (1 + noise/v),
+  -- let's do direct cross multiplication
+  -- Actually, the convexity of f(x) = v / (v+x) implies this interaction.
+  -- Rather than pure algebra, we can use the identity:
+  -- gain_both - (gain_ld + gain_maf) = v*V_ld*V_maf * (some positive stuff)
+  have h_base : vSignal / (vSignal + (V_E + V_ld + V_maf)) > 0 := div_pos h_sig (by linarith)
+  -- Left side
+  have lhs_eq : vSignal / (vSignal + (V_E + V_maf)) - vSignal / (vSignal + (V_E + V_ld + V_maf)) +
+                (vSignal / (vSignal + (V_E + V_ld)) - vSignal / (vSignal + (V_E + V_ld + V_maf))) =
+                vSignal * V_ld / ((vSignal + V_E + V_maf) * (vSignal + V_E + V_ld + V_maf)) +
+                vSignal * V_maf / ((vSignal + V_E + V_ld) * (vSignal + V_E + V_ld + V_maf)) := by
+    -- (v/(A) - v/(A+L)) + (v/(B) - v/(B+M))
+    -- where A = v+E+M, A+L = v+E+M+L
+    -- v/A - v/(A+L) = v*L / (A*(A+L))
+    have hA : 0 < vSignal + (V_E + V_maf) := by linarith
+    have hAL : 0 < vSignal + (V_E + V_ld + V_maf) := by linarith
+    have step1 : vSignal / (vSignal + (V_E + V_maf)) - vSignal / (vSignal + (V_E + V_ld + V_maf)) =
+                 vSignal * V_ld / ((vSignal + V_E + V_maf) * (vSignal + V_E + V_ld + V_maf)) := by
+      have hA_simp : vSignal + (V_E + V_maf) = vSignal + V_E + V_maf := by ring
+      have hAL_simp : vSignal + (V_E + V_ld + V_maf) = vSignal + V_E + V_ld + V_maf := by ring
+      rw [hA_simp, hAL_simp]
+      have : vSignal + V_E + V_ld + V_maf = (vSignal + V_E + V_maf) + V_ld := by ring
+      rw [this]
+      have step1_inner : vSignal / (vSignal + V_E + V_maf) - vSignal / ((vSignal + V_E + V_maf) + V_ld) =
+                         vSignal * V_ld / ((vSignal + V_E + V_maf) * ((vSignal + V_E + V_maf) + V_ld)) := by
+        field_simp [ne_of_gt (by linarith : 0 < vSignal + V_E + V_maf), ne_of_gt (by linarith : 0 < vSignal + V_E + V_maf + V_ld)]
+        ring
+      exact step1_inner
+    have hB : 0 < vSignal + (V_E + V_ld) := by linarith
+    have hBM : 0 < vSignal + (V_E + V_ld + V_maf) := by linarith
+    have step2 : vSignal / (vSignal + (V_E + V_ld)) - vSignal / (vSignal + (V_E + V_ld + V_maf)) =
+                 vSignal * V_maf / ((vSignal + V_E + V_ld) * (vSignal + V_E + V_ld + V_maf)) := by
+      have hB_simp : vSignal + (V_E + V_ld) = vSignal + V_E + V_ld := by ring
+      have hBM_simp : vSignal + (V_E + V_ld + V_maf) = vSignal + V_E + V_ld + V_maf := by ring
+      rw [hB_simp, hBM_simp]
+      field_simp [ne_of_gt (by linarith : 0 < vSignal + V_E + V_ld), ne_of_gt (by linarith : 0 < vSignal + V_E + V_ld + V_maf)]
+      ring
+    rw [step1, step2]
+  -- Right side
+  have rhs_eq : vSignal / (vSignal + V_E) - vSignal / (vSignal + (V_E + V_ld + V_maf)) =
+                vSignal * (V_ld + V_maf) / ((vSignal + V_E) * (vSignal + V_E + V_ld + V_maf)) := by
+    have hC : 0 < vSignal + V_E := by linarith
+    have hC_LM : 0 < vSignal + (V_E + V_ld + V_maf) := by linarith
+    have hC_LM_simp : vSignal + (V_E + V_ld + V_maf) = vSignal + V_E + V_ld + V_maf := by ring
+    rw [hC_LM_simp]
+    field_simp [ne_of_gt hC, ne_of_gt (by linarith : 0 < vSignal + V_E + V_ld + V_maf)]
+    ring
+  rw [lhs_eq, rhs_eq]
+  -- Now we compare:
+  -- v*L / (A*AL) + v*M / (B*BM) < v*(L+M) / (C*CLM)
+  -- Note AL = BM = CLM = vSignal + V_E + V_ld + V_maf
+  -- So we just need: v*L/A + v*M/B < v*(L+M)/C
+  -- where A = v+E+M, B = v+E+L, C = v+E
+  -- Since A > C and B > C, L/A < L/C and M/B < M/C
+  have hA : 0 < vSignal + V_E + V_maf := by linarith
+  have hB : 0 < vSignal + V_E + V_ld := by linarith
+  have hC : 0 < vSignal + V_E := by linarith
+  have hAL : 0 < vSignal + V_E + V_ld + V_maf := by linarith
+  have ineq1 : vSignal * V_ld / ((vSignal + V_E + V_maf) * (vSignal + V_E + V_ld + V_maf)) <
+               vSignal * V_ld / ((vSignal + V_E) * (vSignal + V_E + V_ld + V_maf)) := by
+    apply (div_lt_div_iff₀ (mul_pos hA hAL) (mul_pos hC hAL)).mpr
+    have h_num : 0 < vSignal * V_ld := mul_pos h_sig h_ld
+    have h_ineq : (vSignal + V_E) * (vSignal + V_E + V_ld + V_maf) < (vSignal + V_E + V_maf) * (vSignal + V_E + V_ld + V_maf) := by
+      apply mul_lt_mul_of_pos_right (by linarith) hAL
+    exact mul_lt_mul_of_pos_left h_ineq h_num
+  have ineq2 : vSignal * V_maf / ((vSignal + V_E + V_ld) * (vSignal + V_E + V_ld + V_maf)) <
+               vSignal * V_maf / ((vSignal + V_E) * (vSignal + V_E + V_ld + V_maf)) := by
+    apply (div_lt_div_iff₀ (mul_pos hB hAL) (mul_pos hC hAL)).mpr
+    have h_num : 0 < vSignal * V_maf := mul_pos h_sig h_maf
+    have h_ineq : (vSignal + V_E) * (vSignal + V_E + V_ld + V_maf) < (vSignal + V_E + V_ld) * (vSignal + V_E + V_ld + V_maf) := by
+      apply mul_lt_mul_of_pos_right (by linarith) hAL
+    exact mul_lt_mul_of_pos_left h_ineq h_num
+  have h_sum : vSignal * (V_ld + V_maf) / ((vSignal + V_E) * (vSignal + V_E + V_ld + V_maf)) =
+               vSignal * V_ld / ((vSignal + V_E) * (vSignal + V_E + V_ld + V_maf)) +
+               vSignal * V_maf / ((vSignal + V_E) * (vSignal + V_E + V_ld + V_maf)) := by
+    rw [mul_add, add_div]
+  rw [h_sum]
+  exact add_lt_add ineq1 ineq2
 
 end PathDecomposition
 
@@ -437,24 +531,39 @@ theorem e_value_ge_one (rr : ℝ) (h_rr : 1 ≤ rr) :
 
 /-- **Sensitivity to LD reference mismatch.**
     Portability estimates are sensitive to the choice of LD reference.
-    Using in-sample LD vs. external reference can change R² by δ. -/
+    Using an external LD reference introduces additional variance (V_ld_error)
+    compared to in-sample LD, which strictly decreases the expected R². -/
 theorem ld_reference_sensitivity
-    (r2_in_sample r2_external delta : ℝ)
-    (h_diff : r2_in_sample = r2_external + delta)
-    (h_delta : 0 < |delta|) :
-    r2_in_sample ≠ r2_external := by
-  rw [h_diff]; intro h; have : delta = 0 := by linarith
-  exact absurd (this ▸ h_delta) (by simp)
+    (vSignal V_E V_ld_error : ℝ)
+    (h_sig : 0 < vSignal) (h_VE : 0 < V_E) (h_error : 0 < V_ld_error) :
+    let r2_external := expectedR2 vSignal (V_E + V_ld_error)
+    let r2_in_sample := expectedR2 vSignal V_E
+    r2_external < r2_in_sample := by
+  simp only
+  unfold expectedR2
+  have h_denom_ext : 0 < vSignal + (V_E + V_ld_error) := by linarith
+  have h_denom_in : 0 < vSignal + V_E := by linarith
+  rw [div_lt_div_iff₀ h_denom_ext h_denom_in]
+  nlinarith
 
 /-- **Sensitivity to phenotype definition.**
     Different phenotype definitions (self-report vs clinical,
     ICD-9 vs ICD-10) can change portability estimates.
-    When the difference exceeds any threshold ε > 0, the estimates differ. -/
+    Broader definitions (e.g., self-report) often increase environmental
+    noise (V_noise) compared to strict definitions (e.g., clinical diagnosis),
+    leading to a measurable decrease in expected R². -/
 theorem phenotype_definition_matters
-    (port_def1 port_def2 ε : ℝ) (h_ε : 0 < ε)
-    (h_large_diff : ε < |port_def1 - port_def2|) :
-    port_def1 ≠ port_def2 := by
-  intro h; rw [h, sub_self, abs_zero] at h_large_diff; linarith
+    (vSignal V_E_clinical V_noise : ℝ)
+    (h_sig : 0 < vSignal) (h_VE : 0 < V_E_clinical) (h_noise : 0 < V_noise) :
+    let port_clinical := expectedR2 vSignal V_E_clinical
+    let port_self_report := expectedR2 vSignal (V_E_clinical + V_noise)
+    port_self_report < port_clinical := by
+  simp only
+  unfold expectedR2
+  have h_denom_sr : 0 < vSignal + (V_E_clinical + V_noise) := by linarith
+  have h_denom_cl : 0 < vSignal + V_E_clinical := by linarith
+  rw [div_lt_div_iff₀ h_denom_sr h_denom_cl]
+  nlinarith
 
 end SensitivityAnalysis
 

--- a/proofs/Calibrator/SampleOverlapBias.lean
+++ b/proofs/Calibrator/SampleOverlapBias.lean
@@ -34,27 +34,34 @@ individual-level noise.
 
 section OverlapInflation
 
-/-- **R² inflation from complete overlap.**
-    If the validation sample IS the discovery sample,
-    the apparent R² converges to h²_SNP (not R²_PGS).
-    Inflation = h²_SNP / R²_true_PGS - 1. -/
-noncomputable def overlapInflation (r2_true r2_observed : ℝ) : ℝ :=
-  r2_observed / r2_true - 1
-
-/-- Inflation is positive when observed exceeds true. -/
-theorem overlap_inflation_positive (r2_true r2_observed : ℝ)
-    (h_true : 0 < r2_true) (h_inflated : r2_true < r2_observed) :
-    0 < overlapInflation r2_true r2_observed := by
-  unfold overlapInflation
-  rw [sub_pos, one_lt_div₀ h_true]
-  exact h_inflated
-
 /-- **Partial overlap inflation.**
     With fraction f of validation in discovery:
     R²_observed ≈ R²_true + f × (h² - R²_true) / n_GWAS.
     The inflation is proportional to f. -/
 noncomputable def partialOverlapR2 (r2_true h2 : ℝ) (f : ℝ) (n_gwas : ℕ) : ℝ :=
   r2_true + f * (h2 - r2_true) / n_gwas
+
+/-- **R² inflation from complete overlap.**
+    If the validation sample IS the discovery sample,
+    the apparent R² converges to h²_SNP (not R²_PGS).
+    Inflation = R²_observed / R²_true - 1. -/
+noncomputable def overlapInflation (r2_true h2 f : ℝ) (n_gwas : ℕ) : ℝ :=
+  (partialOverlapR2 r2_true h2 f n_gwas) / r2_true - 1
+
+/-- Inflation is strictly positive when there is overlap and true R² < h². -/
+theorem overlap_inflation_positive (r2_true h2 f : ℝ) (n_gwas : ℕ)
+    (h_true : 0 < r2_true) (h_h2_gap : r2_true < h2)
+    (h_f_pos : 0 < f) (h_n_pos : 0 < n_gwas) :
+    0 < overlapInflation r2_true h2 f n_gwas := by
+  unfold overlapInflation partialOverlapR2
+  have h_gap_pos : 0 < h2 - r2_true := sub_pos.mpr h_h2_gap
+  have h_frac_pos : 0 < f * (h2 - r2_true) / n_gwas := by
+    apply div_pos
+    · exact mul_pos h_f_pos h_gap_pos
+    · exact Nat.cast_pos.mpr h_n_pos
+  rw [sub_pos]
+  rw [add_div, div_self (ne_of_gt h_true)]
+  exact lt_add_of_pos_right 1 (div_pos h_frac_pos h_true)
 
 /-- Zero overlap gives unbiased estimate. -/
 theorem no_overlap_unbiased (r2_true h2 : ℝ) (n_gwas : ℕ) :
@@ -221,15 +228,23 @@ section CrypticRelatedness
 /-- **Kinship-based inflation.**
     If individuals in validation are related to those in discovery
     (kinship coefficient K), the PGS benefits from shared
-    family-level environment and rare genetic variants. -/
-noncomputable def kinshipInflation (r2_true K h2_family : ℝ) : ℝ :=
-  r2_true + K * h2_family
+    family-level environment and rare genetic variants.
+    We model this as an effective sample overlap where the fraction
+    of overlap behaves proportionally to K. -/
+noncomputable def kinshipInflation (r2_true K h2_family : ℝ) (n_gwas : ℕ) : ℝ :=
+  partialOverlapR2 r2_true h2_family K n_gwas
 
-/-- Kinship inflation exceeds true R² when K > 0. -/
-theorem kinship_inflates (r2_true K h2_family : ℝ)
-    (h_K : 0 < K) (h_h2 : 0 < h2_family) :
-    r2_true < kinshipInflation r2_true K h2_family := by
-  unfold kinshipInflation; linarith [mul_pos h_K h_h2]
+/-- Kinship inflation exceeds true R² when K > 0 and true R² < family h². -/
+theorem kinship_inflates (r2_true K h2_family : ℝ) (n_gwas : ℕ)
+    (h_K : 0 < K) (h_h2_gap : r2_true < h2_family) (h_n_pos : 0 < n_gwas) :
+    r2_true < kinshipInflation r2_true K h2_family n_gwas := by
+  unfold kinshipInflation partialOverlapR2
+  have h_gap_pos : 0 < h2_family - r2_true := sub_pos.mpr h_h2_gap
+  have h_frac_pos : 0 < K * (h2_family - r2_true) / n_gwas := by
+    apply div_pos
+    · exact mul_pos h_K h_gap_pos
+    · exact Nat.cast_pos.mpr h_n_pos
+  linarith
 
 /-- **GRM-based exclusion: bias-variance tradeoff.**
     Removing individuals with GRM off-diagonal > threshold reduces
@@ -243,32 +258,61 @@ theorem kinship_inflates (r2_true K h2_family : ℝ)
     The tradeoff: stricter threshold → smaller inflation bound
     but fewer remaining samples for power. -/
 theorem grm_threshold_tradeoff
-    (r2_true h2_family K_strict K_lenient : ℝ)
+    (r2_true h2_family K_strict K_lenient : ℝ) (n_gwas : ℕ)
+    (h_gap : r2_true < h2_family)
     (h_strict_lt : K_strict < K_lenient)
-    (h_strict_pos : 0 < K_strict)
-    (h_lenient_pos : 0 < K_lenient)
-    (h_h2_pos : 0 < h2_family) :
+    (h_n_pos : 0 < n_gwas) :
     -- Stricter threshold gives smaller kinship inflation
-    kinshipInflation r2_true K_strict h2_family <
-      kinshipInflation r2_true K_lenient h2_family := by
-  unfold kinshipInflation
-  linarith [mul_lt_mul_of_pos_right h_strict_lt h_h2_pos]
+    kinshipInflation r2_true K_strict h2_family n_gwas <
+      kinshipInflation r2_true K_lenient h2_family n_gwas := by
+  unfold kinshipInflation partialOverlapR2
+  have h_gap_pos : 0 < h2_family - r2_true := sub_pos.mpr h_gap
+  have h_n_cast_pos : (0 : ℝ) < n_gwas := Nat.cast_pos.mpr h_n_pos
+  apply add_lt_add_left
+  apply div_lt_div_of_pos_right
+  · exact mul_lt_mul_of_pos_right h_strict_lt h_gap_pos
+  · exact h_n_cast_pos
 
 /-- **Cross-ancestry naturally avoids cryptic relatedness.**
     Individuals from different continental ancestries have
     near-zero kinship, eliminating kinship-based inflation.
-    When |K| < ε, the inflation |K × h²_family| < ε × h²_family,
-    so the bias is bounded by ε × h²_family. -/
+    When |K| < ε, the inflation component |K × (h² - R²) / n| < ε × 1 / 1 = ε,
+    so the bias is bounded by ε. -/
 theorem cross_ancestry_no_kinship_bias
-    (K_cross h2_family ε : ℝ)
+    (r2_true K_cross h2_family ε : ℝ) (n_gwas : ℕ)
     (h_ε_pos : 0 < ε)
     (h_K_small : |K_cross| < ε)
-    (h_h2_pos : 0 < h2_family) (h_h2_le : h2_family ≤ 1) :
-    |K_cross * h2_family| < ε := by
-  calc |K_cross * h2_family| = |K_cross| * |h2_family| := abs_mul _ _
-    _ = |K_cross| * h2_family := by rw [abs_of_pos h_h2_pos]
-    _ ≤ |K_cross| * 1 := by nlinarith [abs_nonneg K_cross]
-    _ = |K_cross| := mul_one _
+    (h_gap_pos : 0 ≤ h2_family - r2_true)
+    (h_gap_le : h2_family - r2_true ≤ 1)
+    (h_n_ge : 1 ≤ (n_gwas : ℝ)) :
+    |kinshipInflation r2_true K_cross h2_family n_gwas - r2_true| < ε := by
+  unfold kinshipInflation partialOverlapR2
+  have h_diff : r2_true + K_cross * (h2_family - r2_true) / ↑n_gwas - r2_true =
+                K_cross * (h2_family - r2_true) / ↑n_gwas := by ring
+  rw [h_diff]
+  have h_n_pos_strict : (0 : ℝ) < ↑n_gwas := by linarith
+  have h_abs : |K_cross * (h2_family - r2_true) / ↑n_gwas| =
+               |K_cross| * (h2_family - r2_true) / ↑n_gwas := by
+    rw [abs_div, abs_mul, abs_of_nonneg h_gap_pos, abs_of_pos h_n_pos_strict]
+  rw [h_abs]
+  have h1 : |K_cross| * (h2_family - r2_true) ≤ |K_cross| * 1 := by
+    exact mul_le_mul_of_nonneg_left h_gap_le (abs_nonneg K_cross)
+  have h_bound1 : |K_cross| * (h2_family - r2_true) / ↑n_gwas ≤ |K_cross| * 1 / ↑n_gwas := by
+    exact div_le_div_of_nonneg_right h1 (le_of_lt h_n_pos_strict)
+  have h_bound2 : |K_cross| * 1 / ↑n_gwas ≤ |K_cross| * 1 / 1 := by
+    have h_inv : 1 / (n_gwas : ℝ) ≤ 1 := by
+      rw [one_div, inv_le_one₀]
+      · exact h_n_ge
+      · exact h_n_pos_strict
+    calc |K_cross| * 1 / ↑n_gwas
+      _ = |K_cross| * (1 / ↑n_gwas) := by ring
+      _ ≤ |K_cross| * 1 := by
+        exact mul_le_mul_of_nonneg_left h_inv (abs_nonneg K_cross)
+      _ = |K_cross| * 1 / 1 := by ring
+  calc |K_cross| * (h2_family - r2_true) / ↑n_gwas
+    _ ≤ |K_cross| * 1 / ↑n_gwas := h_bound1
+    _ ≤ |K_cross| * 1 / 1 := h_bound2
+    _ = |K_cross| := by ring
     _ < ε := h_K_small
 
 end CrypticRelatedness

--- a/proofs/Calibrator/VarianceComponents.lean
+++ b/proofs/Calibrator/VarianceComponents.lean
@@ -254,13 +254,17 @@ section GREML
 
 /-- **GREML h² estimate depends on LD structure.**
     GREML estimates h²_SNP = trace(GRM⁻¹ × Σ_pheno) / n.
-    When LD differs between training and evaluation, the estimate is biased. -/
+    When LD differs between training and evaluation, the estimate is biased.
+    Specifically, if LD structure causes the tagged variance to be inflated by V_ld_bias,
+    the resulting GREML estimate is strictly greater than the true h²_SNP. -/
 theorem greml_ld_sensitive
-    (h2_estimated h2_true ld_bias : ℝ)
-    (h_bias : h2_estimated = h2_true + ld_bias)
-    (h_ld_nonzero : ld_bias ≠ 0) :
-    h2_estimated ≠ h2_true := by
-  rw [h_bias]; intro h; apply h_ld_nonzero; linarith
+    (V_A_tagged V_P V_ld_bias : ℝ)
+    (h_VP_pos : 0 < V_P) (h_ld_bias_pos : 0 < V_ld_bias) :
+    let h2_true := V_A_tagged / V_P
+    let h2_estimated := (V_A_tagged + V_ld_bias) / V_P
+    h2_true < h2_estimated := by
+  simp only
+  exact div_lt_div_of_pos_right (by linarith) h_VP_pos
 
 /-- **GREML underestimates h² when causal variants are poorly tagged.**
     The true SNP heritability is `V_A / V_P`, while GREML only captures


### PR DESCRIPTION
This commit addresses several "vacuous verification" instances where theorems were tautologically defined:
- `CausalInference.lean`: Refactored `pathway_interactions_exist` to explicitly use `expectedR2` nonlinearities instead of a trivial sum equality.
- `CausalInference.lean`: Refactored `ld_reference_sensitivity` to compare in-sample vs external R² rather than trivial variable additions.
- `CausalInference.lean`: Refactored `phenotype_definition_matters` to use environmental noise modeling instead of absolute value differences.
- `VarianceComponents.lean`: Strengthened `greml_ld_sensitive` to explicitly bound estimation inflation due to LD bias.
- `SampleOverlapBias.lean`: Refactored `overlap_inflation_positive` to be derived directly from `partialOverlapR2`.
- `SampleOverlapBias.lean`: Refactored `kinship_inflates` and related metrics to use rigorous mathematical bounds over `kinshipInflation`.

All affected files successfully compile via `lake build`.

---
*PR created automatically by Jules for task [12339466978584952380](https://jules.google.com/task/12339466978584952380) started by @SauersML*