### PR TITLE
Refactor: Eliminate inline `let` specification gaming

### DIFF
--- a/proofs/Calibrator/MultiAncestryTheory.lean
+++ b/proofs/Calibrator/MultiAncestryTheory.lean
@@ -25,6 +25,10 @@ section GWASDiversity
 /- **GWAS sample genetic distance from target.**
     d_GWAS(target) = weighted distance from target individual to GWAS centroid. -/
 
+/-- Multi-ancestry GWAS fraction Fst calculation. -/
+noncomputable def multiAncestryFst (d₁ d₂ α : ℝ) : ℝ :=
+  (1 - α) * d₁ + α * d₂
+
 /-- **Multi-ancestry GWAS reduces effective Fst.**
     A multi-ancestry GWAS with fraction α from a second ancestry
     at Fst distance d₂ from the target (and the primary ancestry at
@@ -41,10 +45,8 @@ theorem multi_ancestry_reduces_fst
     (h_d₂_closer : d₂ < d₁)
     (h_d₁_le_one : d₁ ≤ 1)
     (h_α_pos : 0 < α) :
-    let fst_single := d₁
-    let fst_multi := (1 - α) * d₁ + α * d₂
-    presentDayR2 V_A V_E fst_multi > presentDayR2 V_A V_E fst_single := by
-  simp only
+    presentDayR2 V_A V_E (multiAncestryFst d₁ d₂ α) > presentDayR2 V_A V_E d₁ := by
+  unfold multiAncestryFst
   have h_multi_lt_single : (1 - α) * d₁ + α * d₂ < d₁ := by
     nlinarith
   simpa using

--- a/proofs/Calibrator/PortabilityDrift.lean
+++ b/proofs/Calibrator/PortabilityDrift.lean
@@ -363,6 +363,25 @@ noncomputable def presentDayR2 (V_A V_E fst : ℝ) : ℝ :=
   let v := presentDayPGSVariance V_A fst
   v / (v + V_E)
 
+/-- Variance of a predictor evaluated over a DataGeneratingProcess. -/
+noncomputable def predictorVariance {k : ℕ} [Fintype (Fin k)] (dgp : DataGeneratingProcess k) (signal : Predictor k) : ℝ :=
+  let μ := dgp.jointMeasure
+  let mf : ℝ := ∫ pc, signal pc.1 pc.2 ∂μ
+  ∫ pc, (signal pc.1 pc.2 - mf) ^ 2 ∂μ
+
+/-- Variance of the true expectation function over a DataGeneratingProcess. -/
+noncomputable def expectationVariance {k : ℕ} [Fintype (Fin k)] (dgp : DataGeneratingProcess k) : ℝ :=
+  let μ := dgp.jointMeasure
+  let mg : ℝ := ∫ pc, dgp.trueExpectation pc.1 pc.2 ∂μ
+  ∫ pc, (dgp.trueExpectation pc.1 pc.2 - mg) ^ 2 ∂μ
+
+/-- Covariance between a predictor and the true expectation function over a DataGeneratingProcess. -/
+noncomputable def predictorExpectationCovariance {k : ℕ} [Fintype (Fin k)] (dgp : DataGeneratingProcess k) (signal : Predictor k) : ℝ :=
+  let μ := dgp.jointMeasure
+  let mf : ℝ := ∫ pc, signal pc.1 pc.2 ∂μ
+  let mg : ℝ := ∫ pc, dgp.trueExpectation pc.1 pc.2 ∂μ
+  ∫ pc, (signal pc.1 pc.2 - mf) * (dgp.trueExpectation pc.1 pc.2 - mg) ∂μ
+
 /-- Exact bridge theorem: the dashboard algebraic `presentDayR2` equals statistical
 `rsquared` when the relevant second-moment identities hold. -/
 theorem presentDayR2_eq_statistical_rsquared
@@ -370,21 +389,9 @@ theorem presentDayR2_eq_statistical_rsquared
     (dgp : DataGeneratingProcess k)
     (signal : Predictor k)
     (V_A V_E fst : ℝ)
-    (h_vf :
-      (let μ := dgp.jointMeasure
-       let mf : ℝ := ∫ pc, signal pc.1 pc.2 ∂μ
-       ∫ pc, (signal pc.1 pc.2 - mf) ^ 2 ∂μ) = presentDayPGSVariance V_A fst)
-    (h_vg :
-      (let μ := dgp.jointMeasure
-       let mg : ℝ := ∫ pc, dgp.trueExpectation pc.1 pc.2 ∂μ
-       ∫ pc, (dgp.trueExpectation pc.1 pc.2 - mg) ^ 2 ∂μ) =
-        presentDayPGSVariance V_A fst + V_E)
-    (h_cov :
-      (let μ := dgp.jointMeasure
-       let mf : ℝ := ∫ pc, signal pc.1 pc.2 ∂μ
-       let mg : ℝ := ∫ pc, dgp.trueExpectation pc.1 pc.2 ∂μ
-       ∫ pc, (signal pc.1 pc.2 - mf) * (dgp.trueExpectation pc.1 pc.2 - mg) ∂μ) =
-        presentDayPGSVariance V_A fst)
+    (h_vf : predictorVariance dgp signal = presentDayPGSVariance V_A fst)
+    (h_vg : expectationVariance dgp = presentDayPGSVariance V_A fst + V_E)
+    (h_cov : predictorExpectationCovariance dgp signal = presentDayPGSVariance V_A fst)
     (h_vsig_pos : 0 < presentDayPGSVariance V_A fst)
     (h_vtrue_pos : 0 < presentDayPGSVariance V_A fst + V_E) :
     presentDayR2 V_A V_E fst = rsquared dgp signal dgp.trueExpectation := by
@@ -400,6 +407,9 @@ theorem presentDayR2_eq_statistical_rsquared
       rsquared dgp signal dgp.trueExpectation = (presentDayPGSVariance V_A fst) ^ 2 /
           (presentDayPGSVariance V_A fst * (presentDayPGSVariance V_A fst + V_E)) := by
     unfold rsquared
+    unfold predictorVariance at h_vf
+    unfold expectationVariance at h_vg
+    unfold predictorExpectationCovariance at h_cov
     simp [h_vf, h_vg, h_cov, h_if_not]
   rw [h_rs]
   unfold presentDayR2


### PR DESCRIPTION
Extracted complex inline `let` definitions from theorem signatures and hypotheses into proper, reusable `noncomputable def`s.
- `multiAncestryFst` extracted from `multi_ancestry_reduces_fst` in `MultiAncestryTheory.lean`
- `predictorVariance`, `expectationVariance`, and `predictorExpectationCovariance` extracted from `presentDayR2_eq_statistical_rsquared` in `PortabilityDrift.lean`

This eliminates begging the question / specification gaming by ensuring bounds are mathematically reasoned over properly defined metrics, improving the rigorous structure of the proofs without changing the underlying validated math. The entire project builds successfully.

---
*PR created automatically by Jules for task [6454934608076385229](https://jules.google.com/task/6454934608076385229) started by @SauersML*