### PR TITLE
Refactor differential_ascertainment_artifact to remove vacuous proof

### DIFF
--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -327,14 +327,12 @@ theorem collider_attenuates_association (m : ColliderModel) :
     the apparent portability drop includes an ascertainment component. -/
 theorem differential_ascertainment_artifact
     (r2_source_pop r2_target_pop r2_source_asc r2_target_asc : ℝ)
-    (h_source_asc : r2_source_asc < r2_source_pop)
-    (h_target_asc : r2_target_asc < r2_target_pop)
+    (_h_source_asc : r2_source_asc < r2_source_pop)
+    (_h_target_asc : r2_target_asc < r2_target_pop)
     -- Different ascertainment severity
     (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
-    -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
+    -- Apparent portability drop is smaller than true portability drop
+    r2_source_asc - r2_target_asc < r2_source_pop - r2_target_pop := by
   linarith
 
 end ColliderBias


### PR DESCRIPTION
Refactored `differential_ascertainment_artifact` in `proofs/Calibrator/StratificationConfounding.lean` to remove a vacuous proof of contradiction (`False`) and instead correctly assert the strict inequality bounding the portability artifact directly, resolving a specification gaming issue.

---
*PR created automatically by Jules for task [9081088193890843355](https://jules.google.com/task/9081088193890843355) started by @SauersML*