### PR TITLE
Refactor ex post facto let bindings in VarianceComponents and StatisticalGeneticsMethodology

### DIFF
--- a/proofs/Calibrator/StatisticalGeneticsMethodology.lean
+++ b/proofs/Calibrator/StatisticalGeneticsMethodology.lean
@@ -48,18 +48,18 @@ noncomputable def incrementalR2 (r2_full r2_covariates : ℝ) : ℝ :=
     We encode this as: the full model's R² is at least the
     covariate-only model's R², which is a consequence of OLS
     minimizing sum of squared residuals over a nested subspace. -/
+noncomputable def modelR2 (rss tss : ℝ) : ℝ :=
+  1 - rss / tss
+
 theorem incremental_r2_nonneg
     (rss_full rss_cov tss : ℝ)
     (h_tss : 0 < tss)
-    (h_rss_full : 0 ≤ rss_full)
-    (h_rss_cov : 0 ≤ rss_cov)
+    (_h_rss_full : 0 ≤ rss_full)
+    (_h_rss_cov : 0 ≤ rss_cov)
     -- Nested model property: full model has no more residual than submodel
     (h_nested : rss_full ≤ rss_cov) :
-    let r2_full := 1 - rss_full / tss
-    let r2_cov := 1 - rss_cov / tss
-    0 ≤ incrementalR2 r2_full r2_cov := by
-  simp only
-  unfold incrementalR2
+    0 ≤ incrementalR2 (modelR2 rss_full tss) (modelR2 rss_cov tss) := by
+  unfold modelR2 incrementalR2
   -- (1 - rss_full/tss) - (1 - rss_cov/tss) = (rss_cov - rss_full)/tss ≥ 0
   have : rss_cov / tss - rss_full / tss = (rss_cov - rss_full) / tss := by ring
   linarith [div_nonneg (by linarith : 0 ≤ rss_cov - rss_full) (le_of_lt h_tss)]

--- a/proofs/Calibrator/VarianceComponents.lean
+++ b/proofs/Calibrator/VarianceComponents.lean
@@ -301,15 +301,21 @@ theorem greml_underestimates_with_poor_tagging
 
     We derive: h²_GREML > h²_true whenever V_strat > 0, because
     (V_A + V_strat)/V_P > V_A/V_P when V_P > 0. -/
+noncomputable def stratifiedVP (V_A V_strat V_E : ℝ) : ℝ :=
+  V_A + V_strat + V_E
+
+noncomputable def trueHeritability (V_A V_strat V_E : ℝ) : ℝ :=
+  V_A / stratifiedVP V_A V_strat V_E
+
+noncomputable def gremlHeritability (V_A V_strat V_E : ℝ) : ℝ :=
+  (V_A + V_strat) / stratifiedVP V_A V_strat V_E
+
 theorem stratification_inflates_greml
     (V_A V_strat V_E : ℝ)
-    (h_VA : 0 ≤ V_A) (h_strat_pos : 0 < V_strat) (h_VE : 0 ≤ V_E)
-    (h_total : 0 < V_A + V_strat + V_E) :
-    let V_P := V_A + V_strat + V_E
-    let h2_true := V_A / V_P
-    let h2_greml := (V_A + V_strat) / V_P
-    h2_true < h2_greml := by
-  simp only
+    (_h_VA : 0 ≤ V_A) (h_strat_pos : 0 < V_strat) (_h_VE : 0 ≤ V_E)
+    (h_total : 0 < stratifiedVP V_A V_strat V_E) :
+    trueHeritability V_A V_strat V_E < gremlHeritability V_A V_strat V_E := by
+  unfold trueHeritability gremlHeritability
   exact div_lt_div_of_pos_right (by linarith) h_total
 
 end GREML


### PR DESCRIPTION
Refactored theorems `stratification_inflates_greml` and `incremental_r2_nonneg` to remove specification gaming where definitions were created directly inside the theorem statement (using `let`). The definitions have been hoisted to global scope as `noncomputable def`s to ensure the proofs evaluate general laws rather than locally-bound tautologies. Unused linter warnings have also been suppressed according to standard practices. All Lean proofs have been successfully verified and project compilation passes cleanly.

---
*PR created automatically by Jules for task [13402492134485899024](https://jules.google.com/task/13402492134485899024) started by @SauersML*