### PR TITLE
Fix trivial witness specification gaming in same_source_r2_different_portability_two_locus_witness

### DIFF
--- a/proofs/Calibrator/StatisticalGeneticsMethodology.lean
+++ b/proofs/Calibrator/StatisticalGeneticsMethodology.lean
@@ -384,32 +384,84 @@ The resulting target `R²` and target/source portability ratio change.
 
 section SourceR2Insufficiency
 
-/-- Concrete two-locus witness that source deployed `R²` does not determine
-target portability.
+/-- Rigorous state model for locus-resolved transport across populations.
+    Captures scenarios where overall source variance is identical but
+    locus-specific transport (stable vs. broken) dictates different portability. -/
+structure TransportState (L : Type) [Fintype L] where
+  sourceSignal : L → ℝ
+  stableTransport : L → ℝ
+  brokenTransport : L → ℝ
+  noise : ℝ
+  h_noise_pos : 0 < noise
+  h_signal_nonneg : ∀ l, 0 ≤ sourceSignal l
+  h_stable_nonneg : ∀ l, 0 ≤ stableTransport l
+  h_broken_nonneg : ∀ l, 0 ≤ brokenTransport l
+  h_broken_le_stable : ∀ l, brokenTransport l ≤ stableTransport l
+  h_broken_lt_stable_strict : ∃ l, 0 < sourceSignal l ∧ brokenTransport l < stableTransport l
 
-Both source loci contribute one unit of source signal, so the source deployed
-`R²` at residual scale `1` is `2/3`. If both loci transport perfectly, the
-target/source portability ratio is `1`. If one locus loses all transported
-signal while the other remains intact, the target/source portability ratio
-drops to `3/4`.
+/-- The total additive genetic variance in the source population. -/
+noncomputable def TransportState.sourceVariance {L : Type} [Fintype L] (state : TransportState L) : ℝ :=
+  ∑ l, state.sourceSignal l
 
-This formalizes the biological point that equal source `R²` does not determine
-cross-population portability without locus-resolved transport state. -/
-theorem same_source_r2_different_portability_two_locus_witness :
-    let sourceSignal : Fin 2 → ℝ := fun _ => 1
-    let stableTransport : Fin 2 → ℝ := fun _ => 1
-    let brokenTransport : Fin 2 → ℝ := fun i => if i = 0 then 1 else 0
-    let sourceVariance : ℝ := ∑ l, sourceSignal l
-    let stableTargetVariance : ℝ := ∑ l, sourceSignal l * stableTransport l
-    let brokenTargetVariance : ℝ := ∑ l, sourceSignal l * brokenTransport l
-    let sourceR2 := TransportedMetrics.r2FromSignalVariance sourceVariance 1
-    let stableTargetR2 := TransportedMetrics.r2FromSignalVariance stableTargetVariance 1
-    let brokenTargetR2 := TransportedMetrics.r2FromSignalVariance brokenTargetVariance 1
+/-- The target variance if all transport factors are stable. -/
+noncomputable def TransportState.stableTargetVariance {L : Type} [Fintype L] (state : TransportState L) : ℝ :=
+  ∑ l, state.sourceSignal l * state.stableTransport l
+
+/-- The target variance if some transport factors are broken. -/
+noncomputable def TransportState.brokenTargetVariance {L : Type} [Fintype L] (state : TransportState L) : ℝ :=
+  ∑ l, state.sourceSignal l * state.brokenTransport l
+
+/-- Under a broken transport state, the target variance is strictly less than
+    under a stable transport state, holding source signal constant. -/
+lemma target_variance_strictMono {L : Type} [Fintype L] (state : TransportState L) :
+    state.brokenTargetVariance < state.stableTargetVariance := by
+  dsimp [TransportState.brokenTargetVariance, TransportState.stableTargetVariance]
+  apply Finset.sum_lt_sum
+  · intro i _
+    exact mul_le_mul_of_nonneg_left (state.h_broken_le_stable i) (state.h_signal_nonneg i)
+  · rcases state.h_broken_lt_stable_strict with ⟨l, hl_pos, hl_lt⟩
+    use l, Finset.mem_univ l
+    exact mul_lt_mul_of_pos_left hl_lt hl_pos
+
+/-- `R²` is strictly monotonically increasing with signal variance. -/
+lemma target_r2_strictMono_in_targetVariance
+    (vSignal1 vSignal2 vNoise : ℝ)
+    (h_pos : 0 < vNoise)
+    (h_nonneg1 : 0 ≤ vSignal1)
+    (h_lt : vSignal1 < vSignal2) :
+    TransportedMetrics.r2FromSignalVariance vSignal1 vNoise <
+    TransportedMetrics.r2FromSignalVariance vSignal2 vNoise := by
+  dsimp [TransportedMetrics.r2FromSignalVariance]
+  have h1 : 0 < vSignal1 + vNoise := add_pos_of_nonneg_of_pos h_nonneg1 h_pos
+  have h2 : 0 < vSignal2 + vNoise := add_pos_of_nonneg_of_pos (le_trans h_nonneg1 (le_of_lt h_lt)) h_pos
+  rw [div_lt_div_iff₀ h1 h2]
+  calc vSignal1 * (vSignal2 + vNoise)
+    _ = vSignal1 * vSignal2 + vSignal1 * vNoise := mul_add _ _ _
+    _ < vSignal1 * vSignal2 + vSignal2 * vNoise := add_lt_add_left (mul_lt_mul_of_pos_right h_lt h_pos) _
+    _ = vSignal2 * (vSignal1 + vNoise) := by ring
+
+/-- General theorem that source deployed `R²` does not determine target portability.
+    Instead of a trivial fixed witness, this relies on a structured mathematical model
+    where a strictly broken transport state leads to strictly lower target `R²`. -/
+theorem same_source_r2_different_portability_two_locus_witness
+    {L : Type} [Fintype L] (state : TransportState L)
+    (h_stable_eq_source : state.stableTargetVariance = state.sourceVariance) :
+    let sourceR2 := TransportedMetrics.r2FromSignalVariance state.sourceVariance state.noise
+    let stableTargetR2 := TransportedMetrics.r2FromSignalVariance state.stableTargetVariance state.noise
+    let brokenTargetR2 := TransportedMetrics.r2FromSignalVariance state.brokenTargetVariance state.noise
     sourceR2 = stableTargetR2 ∧
-    brokenTargetR2 < stableTargetR2 ∧
-    brokenTargetR2 / sourceR2 = (3 : ℝ) / 4 := by
-  simp [TransportedMetrics.r2FromSignalVariance]
-  norm_num
+    brokenTargetR2 < stableTargetR2 := by
+  intro sourceR2 stableTargetR2 brokenTargetR2
+  constructor
+  · dsimp [sourceR2, stableTargetR2]
+    rw [h_stable_eq_source]
+  · dsimp [brokenTargetR2, stableTargetR2]
+    have h_nonneg_broken : 0 ≤ state.brokenTargetVariance := by
+      apply Finset.sum_nonneg
+      intro i _
+      exact mul_nonneg (state.h_signal_nonneg i) (state.h_broken_nonneg i)
+    exact target_r2_strictMono_in_targetVariance _ _ state.noise
+      state.h_noise_pos h_nonneg_broken (target_variance_strictMono state)
 
 end SourceR2Insufficiency
 


### PR DESCRIPTION
Replaced the trivial witness setup using hardcoded `Fin 2` arrays of 1s and 0s in `same_source_r2_different_portability_two_locus_witness` with a fully generalized `TransportState` structure.

This structure allows the theorem to be mathematically rigorous, proving that whenever a locus-resolved transport factor drops (`brokenTargetVariance < stableTargetVariance`), the corresponding `$R^2$` drops, regardless of the concrete values of the variances. This completely resolves the vacuous verification identified in the prompt.

---
*PR created automatically by Jules for task [17007679509510487627](https://jules.google.com/task/17007679509510487627) started by @SauersML*