### PR TITLE
Refactor haplotypePhasePredictionError and haplotypeTransportBias to avoid vacuous zero definition

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -243,10 +243,35 @@ noncomputable def dosagePhaseMisspecificationError
     (1 - freq_cis) *
       (interaction_trans - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2
 
+structure PhasePredictor where
+  /-- Prediction for cis configuration -/
+  pred_cis : ℝ
+  /-- Prediction for trans configuration -/
+  pred_trans : ℝ
+
+/-- Mean squared error of a generic phase predictor. -/
+noncomputable def PhasePredictor.misspecificationError (m : PhasePredictor)
+    (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - m.pred_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - m.pred_trans) ^ 2
+
+/-- The optimal haplotype predictor perfectly learns the phase-specific interactions. -/
+noncomputable def optimalHaplotypePredictor (interaction_cis interaction_trans : ℝ) : PhasePredictor :=
+  { pred_cis := interaction_cis
+  , pred_trans := interaction_trans }
+
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+noncomputable def haplotypePhasePredictionError
+    (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  (optimalHaplotypePredictor interaction_cis interaction_trans).misspecificationError
+    freq_cis interaction_cis interaction_trans
+
+theorem haplotypePhasePredictionError_eq
+    (freq_cis interaction_cis interaction_trans : ℝ) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans = 0 := by
+  unfold haplotypePhasePredictionError PhasePredictor.misspecificationError optimalHaplotypePredictor
+  ring
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -255,11 +280,28 @@ noncomputable def dosageTransportBias
   |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
     averagePhaseInteraction freq_cis_source interaction_cis interaction_trans|
 
+/-- Transport bias is the difference in average prediction when applying the
+same predictor to a new population compared to the true average risk. -/
+noncomputable def PhasePredictor.transportBias (m : PhasePredictor)
+    (freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  |(freq_cis_target * m.pred_cis + (1 - freq_cis_target) * m.pred_trans) -
+    (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans)|
+
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias
+    (freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  (optimalHaplotypePredictor interaction_cis interaction_trans).transportBias
+    freq_cis_target interaction_cis interaction_trans
+
+theorem haplotypeTransportBias_eq
+    (freq_cis_target interaction_cis interaction_trans : ℝ) :
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans = 0 := by
+  unfold haplotypeTransportBias PhasePredictor.transportBias optimalHaplotypePredictor
+  have h_zero : freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans -
+    (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans) = 0 := by ring
+  rw [h_zero, abs_zero]
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -288,9 +330,10 @@ theorem compound_het_not_captured_by_dosage
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans <
+      dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -334,9 +377,9 @@ section HaplotypePGS
 theorem haplotype_pgs_at_least_snp
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -350,9 +393,9 @@ theorem haplotype_pgs_more_portable_for_cis
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
-      freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans <
+      dosageTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans := by
+  rw [dosageTransportBias_eq, haplotypeTransportBias_eq]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Fixed a "trivial witness" specification gaming in `proofs/Calibrator/HaplotypeTheory.lean`. The constants `haplotypePhasePredictionError` and `haplotypeTransportBias` were vacuously defined as literally `0`. Introduced a `PhasePredictor` structure to formally model phase configuration prediction, with rigorous mathematical definitions for both misspecification and transport bias. Proved that an `optimalHaplotypePredictor` reduces these to `0`, successfully addressing the specification gaming without deleting theorems or breaking existing functionality. Verified with full compile.

---
*PR created automatically by Jules for task [454643605236847317](https://jules.google.com/task/454643605236847317) started by @SauersML*