### PR TITLE
Refactor Haplotype Theory bias predictors to algebraic models

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -233,64 +233,108 @@ noncomputable def averagePhaseInteraction
     (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
   freq_cis * interaction_cis + (1 - freq_cis) * interaction_trans
 
-/-- Structural error from using a dosage-only predictor that cannot distinguish
-cis from trans configurations. The best dosage-only predictor within a fixed
-dosage class uses the population-average interaction, leaving this residual
-phase-misspecification error. -/
-noncomputable def dosagePhaseMisspecificationError
-    (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
-  freq_cis * (interaction_cis - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2 +
-    (1 - freq_cis) *
-      (interaction_trans - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2
+/-- A generalized phase predictor that predicts effects for cis and trans
+configurations. -/
+structure PhasePredictor where
+  /-- Predicted interaction effect for cis configuration -/
+  pred_cis : ℝ
+  /-- Predicted interaction effect for trans configuration -/
+  pred_trans : ℝ
 
-/-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
-structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+/-- The dosage-only predictor uses the population-average interaction for
+both configurations. -/
+noncomputable def dosagePredictor
+    (freq_cis interaction_cis interaction_trans : ℝ) : PhasePredictor :=
+  { pred_cis := averagePhaseInteraction freq_cis interaction_cis interaction_trans,
+    pred_trans := averagePhaseInteraction freq_cis interaction_cis interaction_trans }
 
-/-- Transport bias from carrying a source-trained dosage approximation into a
-target population whose cis/trans configuration frequency differs. -/
-noncomputable def dosageTransportBias
-    (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
-  |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
-    averagePhaseInteraction freq_cis_source interaction_cis interaction_trans|
+/-- The ideal haplotype predictor accurately captures both cis and trans effects. -/
+noncomputable def idealHaplotypePredictor
+    (interaction_cis interaction_trans : ℝ) : PhasePredictor :=
+  { pred_cis := interaction_cis,
+    pred_trans := interaction_trans }
 
-/-- A phase-aware haplotype model transports without this structural bias when
-the cis/trans effects themselves are portable and only configuration
-frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+/-- Expected squared prediction error for a given phase predictor. -/
+noncomputable def PhasePredictor.misspecificationError
+    (p : PhasePredictor) (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - p.pred_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - p.pred_trans) ^ 2
+
+/-- Transport bias from carrying a source-trained predictor into a
+target population, defined as the difference in average PREDICTED effects
+across populations due to configuration frequency shifts, compared to the
+difference in average TRUE effects. -/
+noncomputable def PhasePredictor.transportBias
+    (p : PhasePredictor) (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  |(averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
+    averagePhaseInteraction freq_cis_source interaction_cis interaction_trans) -
+   (averagePhaseInteraction freq_cis_target p.pred_cis p.pred_trans -
+    averagePhaseInteraction freq_cis_source p.pred_cis p.pred_trans)|
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
 theorem dosagePhaseMisspecificationError_eq
     (freq_cis interaction_cis interaction_trans : ℝ) :
-    dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans =
+    (dosagePredictor freq_cis interaction_cis interaction_trans).misspecificationError
+      freq_cis interaction_cis interaction_trans =
       freq_cis * (1 - freq_cis) * (interaction_cis - interaction_trans) ^ 2 := by
-  unfold dosagePhaseMisspecificationError averagePhaseInteraction
+  unfold PhasePredictor.misspecificationError dosagePredictor averagePhaseInteraction
+  ring
+
+/-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
+structural phase-misspecification error. -/
+theorem haplotypePhasePredictionError_eq
+    (freq_cis interaction_cis interaction_trans : ℝ) :
+    (idealHaplotypePredictor interaction_cis interaction_trans).misspecificationError
+      freq_cis interaction_cis interaction_trans = 0 := by
+  unfold PhasePredictor.misspecificationError idealHaplotypePredictor
   ring
 
 /-- The structural dosage transport bias is exactly the shift in phase
 configuration frequency times the cis/trans interaction gap. -/
 theorem dosageTransportBias_eq
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ) :
-    dosageTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans =
+    (dosagePredictor freq_cis_source interaction_cis interaction_trans).transportBias
+      freq_cis_source freq_cis_target interaction_cis interaction_trans =
       |freq_cis_target - freq_cis_source| * |interaction_cis - interaction_trans| := by
-  unfold dosageTransportBias averagePhaseInteraction
+  unfold PhasePredictor.transportBias dosagePredictor averagePhaseInteraction
   have h_factor :
       freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans -
-        (freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans) =
+        (freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans) -
+        (freq_cis_target * (freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans) +
+          (1 - freq_cis_target) * (freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans) -
+          (freq_cis_source * (freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans) +
+            (1 - freq_cis_source) * (freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans))) =
         (freq_cis_target - freq_cis_source) * (interaction_cis - interaction_trans) := by
     ring
   rw [h_factor, abs_mul]
+
+/-- A phase-aware haplotype model transports without this structural bias when
+the cis/trans effects themselves are portable and only configuration
+frequencies differ. -/
+theorem haplotypeTransportBias_eq
+    (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ) :
+    (idealHaplotypePredictor interaction_cis interaction_trans).transportBias
+      freq_cis_source freq_cis_target interaction_cis interaction_trans = 0 := by
+  unfold PhasePredictor.transportBias idealHaplotypePredictor averagePhaseInteraction
+  have h_inner :
+    freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans -
+      (freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans) -
+      (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans -
+        (freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans)) = 0 := by ring
+  rw [h_inner]
+  exact abs_zero
 
 theorem compound_het_not_captured_by_dosage
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    (idealHaplotypePredictor interaction_cis interaction_trans).misspecificationError
+      freq_cis interaction_cis interaction_trans <
+    (dosagePredictor freq_cis interaction_cis interaction_trans).misspecificationError
+      freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -334,9 +378,11 @@ section HaplotypePGS
 theorem haplotype_pgs_at_least_snp
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
-      dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+    (idealHaplotypePredictor interaction_cis interaction_trans).misspecificationError
+      freq_cis interaction_cis interaction_trans ≤
+    (dosagePredictor freq_cis interaction_cis interaction_trans).misspecificationError
+      freq_cis interaction_cis interaction_trans := by
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -350,9 +396,11 @@ theorem haplotype_pgs_more_portable_for_cis
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
+    (idealHaplotypePredictor interaction_cis interaction_trans).transportBias
+      freq_cis_source freq_cis_target interaction_cis interaction_trans <
+    (dosagePredictor freq_cis_source interaction_cis interaction_trans).transportBias
       freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+  rw [dosageTransportBias_eq, haplotypeTransportBias_eq]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Replaced vacuous `0` hardcodings for haplotype transport and misspecification errors with a rigorous mathematical structure that algebraically computes the errors from generalized input configurations, proving the zero-bias behavior structurally instead of relying on a trivial witness.

---
*PR created automatically by Jules for task [16295043024213656334](https://jules.google.com/task/16295043024213656334) started by @SauersML*