### PR TITLE
Refactor stratification artifacts to directly prove valid inequalities

### DIFF
--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -332,9 +332,7 @@ theorem differential_ascertainment_artifact
     -- Different ascertainment severity
     (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
     -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
+    r2_source_asc - r2_target_asc < r2_source_pop - r2_target_pop := by
   linarith
 
 end ColliderBias
@@ -520,8 +518,7 @@ theorem survivorship_attenuates_in_older (m : SurvivorshipAttenuationModel) :
 theorem differential_survivorship_artifact
     (r2_source_full r2_target_full Δ_surv_source Δ_surv_target : ℝ)
     (h_surv_s : 0 ≤ Δ_surv_source) (h_surv_t : 0 ≤ Δ_surv_target)
-    (h_diff : Δ_surv_target > Δ_surv_source)
-    (h_obs_s : r2_source_full - Δ_surv_source > 0) :
+    (h_diff : Δ_surv_target > Δ_surv_source) :
     (r2_source_full - Δ_surv_source) - (r2_target_full - Δ_surv_target) >
       r2_source_full - r2_target_full := by
   linarith


### PR DESCRIPTION
Removed specification gaming and vacuous verification from `differential_ascertainment_artifact` and `differential_survivorship_artifact` in `proofs/Calibrator/StratificationConfounding.lean`. Both proofs were using tautological, mathematically vacuous constructions (`invalid inequality → False`) where the invalid inequality was just a rearrangement of the other hypotheses.

Changes made:
1. Converted `differential_ascertainment_artifact` to directly state the correct inequality (`r2_source_asc - r2_target_asc < r2_source_pop - r2_target_pop`) without the indirect `→ False` formulation.
2. Converted `differential_survivorship_artifact` to directly state the valid inequality.
3. Removed the entirely unused `h_obs_s` hypothesis from `differential_survivorship_artifact` which was artificially restricting its scope for no logical reason.

Both theorems now compile cleanly via `linarith` as standard arithmetic bounds. Verified everything builds successfully via `lake build Calibrator.StratificationConfounding`.

---
*PR created automatically by Jules for task [1676807207196585646](https://jules.google.com/task/1676807207196585646) started by @SauersML*