### PR TITLE
Fix specification gaming in two-locus witness theorem

### DIFF
--- a/proofs/Calibrator/StatisticalGeneticsMethodology.lean
+++ b/proofs/Calibrator/StatisticalGeneticsMethodology.lean
@@ -411,6 +411,42 @@ theorem same_source_r2_different_portability_two_locus_witness :
   simp [TransportedMetrics.r2FromSignalVariance]
   norm_num
 
+structure ModelTransportState {n : ℕ} where
+  sourceSignal : Fin n → ℝ
+  stableTransport : Fin n → ℝ
+  brokenTransport : Fin n → ℝ
+  h_nonneg_signal : ∀ i, 0 ≤ sourceSignal i
+  h_nonneg_broken : ∀ i, 0 ≤ brokenTransport i
+  h_broken_le_stable : ∀ i, brokenTransport i ≤ stableTransport i
+  h_broken_lt_stable : ∃ i, brokenTransport i < stableTransport i ∧ 0 < sourceSignal i
+
+theorem same_source_r2_different_portability {n : ℕ} (mts : ModelTransportState (n := n))
+    (vResidual : ℝ) (h_vResidual : 0 < vResidual) :
+    let stableTargetVariance : ℝ := ∑ l, mts.sourceSignal l * mts.stableTransport l
+    let brokenTargetVariance : ℝ := ∑ l, mts.sourceSignal l * mts.brokenTransport l
+    TransportedMetrics.r2FromSignalVariance brokenTargetVariance vResidual <
+    TransportedMetrics.r2FromSignalVariance stableTargetVariance vResidual := by
+  intro stableTargetVariance brokenTargetVariance
+  have h_broken_lt_stable_var : brokenTargetVariance < stableTargetVariance := by
+    apply Finset.sum_lt_sum
+    · intro i _
+      exact mul_le_mul_of_nonneg_left (mts.h_broken_le_stable i) (mts.h_nonneg_signal i)
+    · rcases mts.h_broken_lt_stable with ⟨i, hi1, hi2⟩
+      use i
+      refine ⟨Finset.mem_univ i, ?_⟩
+      exact (mul_lt_mul_of_pos_left hi1 hi2)
+  have h_broken_nonneg : 0 ≤ brokenTargetVariance := by
+    apply Finset.sum_nonneg
+    intro i _
+    exact mul_nonneg (mts.h_nonneg_signal i) (mts.h_nonneg_broken i)
+  have h_stable_pos : 0 < stableTargetVariance := lt_of_le_of_lt h_broken_nonneg h_broken_lt_stable_var
+  unfold TransportedMetrics.r2FromSignalVariance
+  -- need to prove broken / (broken + vResidual) < stable / (stable + vResidual)
+  have denom_broken_pos : 0 < brokenTargetVariance + vResidual := by linarith
+  have denom_stable_pos : 0 < stableTargetVariance + vResidual := by linarith
+  rw [div_lt_div_iff₀ denom_broken_pos denom_stable_pos]
+  nlinarith
+
 end SourceR2Insufficiency
 
 end Calibrator


### PR DESCRIPTION
Addresses trivial witness specification gaming in `proofs/Calibrator/StatisticalGeneticsMethodology.lean`. 

The existing theorem `same_source_r2_different_portability_two_locus_witness` used hardcoded 2-dimensional constants (1 and 0) to demonstrate a mathematical property. We created a generalized structure `ModelTransportState {n : ℕ}` abstracting over arbitrary genetic architectures and added a rigorous mathematical theorem `same_source_r2_different_portability` ensuring the same bounded inequality purely from logical assumptions, successfully clearing the specification gaming while retaining the previous theorem. Build passes. No new files created.

---
*PR created automatically by Jules for task [4007315567925827223](https://jules.google.com/task/4007315567925827223) started by @SauersML*