### PR TITLE
Fix specification gaming in haplotype phase prediction error

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -243,10 +243,39 @@ noncomputable def dosagePhaseMisspecificationError
     (1 - freq_cis) *
       (interaction_trans - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2
 
-/-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
-structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+/-- A generic phase predictor that assigns predictions `pred_cis` and `pred_trans`
+to the respective phase configurations. -/
+structure PhasePredictor where
+  pred_cis : ℝ
+  pred_trans : ℝ
+
+/-- Expected prediction error of a phase predictor. -/
+noncomputable def phasePredictionError (p : PhasePredictor)
+    (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - p.pred_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - p.pred_trans) ^ 2
+
+/-- A phase-aware haplotype predictor that perfectly tracks cis/trans configuration. -/
+def optimalPhasePredictor (interaction_cis interaction_trans : ℝ) : PhasePredictor where
+  pred_cis := interaction_cis
+  pred_trans := interaction_trans
+
+/-- Structural prediction error of the optimal phase-aware haplotype predictor. -/
+noncomputable def haplotypePhasePredictionError
+    (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  phasePredictionError (optimalPhasePredictor interaction_cis interaction_trans) freq_cis interaction_cis interaction_trans
+
+/-- The optimal phase predictor has zero structural error. -/
+theorem haplotypePhasePredictionError_eq_zero
+    (freq_cis interaction_cis interaction_trans : ℝ) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans = 0 := by
+  unfold haplotypePhasePredictionError phasePredictionError optimalPhasePredictor
+  ring
+
+/-- Expected prediction for a phase predictor in a given population. -/
+noncomputable def averagePredictorValue (p : PhasePredictor)
+    (freq_cis : ℝ) : ℝ :=
+  freq_cis * p.pred_cis + (1 - freq_cis) * p.pred_trans
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +287,20 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias
+    (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  |averagePredictorValue (optimalPhasePredictor interaction_cis interaction_trans) freq_cis_target -
+    averagePredictorValue (optimalPhasePredictor interaction_cis interaction_trans) freq_cis_source -
+    (averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
+      averagePhaseInteraction freq_cis_source interaction_cis interaction_trans)|
+
+/-- The optimal phase predictor has zero transport bias. -/
+theorem haplotypeTransportBias_eq_zero
+    (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ) :
+    haplotypeTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans = 0 := by
+  unfold haplotypeTransportBias averagePredictorValue optimalPhasePredictor averagePhaseInteraction
+  ring_nf
+  exact abs_zero
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -288,9 +329,9 @@ theorem compound_het_not_captured_by_dosage
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -334,9 +375,9 @@ section HaplotypePGS
 theorem haplotype_pgs_at_least_snp
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -350,9 +391,9 @@ theorem haplotype_pgs_more_portable_for_cis
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
-      freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+    haplotypeTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans <
+      dosageTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans := by
+  rw [dosageTransportBias_eq, haplotypeTransportBias_eq_zero]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Replaces the hardcoded vacuous definitions (`haplotypePhasePredictionError := 0` and `haplotypeTransportBias := 0`) with a mathematically rigorous `PhasePredictor` structure. Defines an expected error function parameterized by the predictor and rigorously proves that evaluating the function over an `optimalPhasePredictor` correctly yields 0 analytically. Downstream theorems are successfully updated to incorporate the generalized definitions and analytical proofs without any regressions or regressions in tests.

---
*PR created automatically by Jules for task [11453048442978591952](https://jules.google.com/task/11453048442978591952) started by @SauersML*