### PR TITLE
Fix vacuous verification of haplotype errors and biases

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -233,6 +233,40 @@ noncomputable def averagePhaseInteraction
     (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
   freq_cis * interaction_cis + (1 - freq_cis) * interaction_trans
 
+/-- A generalized phase predictor that can apply different effects depending on the
+cis/trans configuration. -/
+structure PhasePredictor where
+  effect_cis : ℝ
+  effect_trans : ℝ
+
+/-- Expected prediction error of a generic phase predictor against the true causal
+cis/trans effects. -/
+noncomputable def expectedPhaseError
+    (pred : PhasePredictor) (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - pred.effect_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - pred.effect_trans) ^ 2
+
+/-- Structural bias when evaluating a generic phase predictor trained on a source
+population but applied to a target population. -/
+noncomputable def expectedPhaseBias
+    (pred : PhasePredictor) (freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
+    averagePhaseInteraction freq_cis_target pred.effect_cis pred.effect_trans|
+
+/-- A dosage-only predictor assigns the same average effect to both cis and trans
+configurations, matching the source population's average phase interaction. -/
+noncomputable def dosagePredictor
+    (freq_cis_source interaction_cis interaction_trans : ℝ) : PhasePredictor where
+  effect_cis := averagePhaseInteraction freq_cis_source interaction_cis interaction_trans
+  effect_trans := averagePhaseInteraction freq_cis_source interaction_cis interaction_trans
+
+/-- A true haplotype-aware predictor can assign the correct individual effects
+to the cis and trans configurations. -/
+noncomputable def haplotypePredictor
+    (interaction_cis interaction_trans : ℝ) : PhasePredictor where
+  effect_cis := interaction_cis
+  effect_trans := interaction_trans
+
 /-- Structural error from using a dosage-only predictor that cannot distinguish
 cis from trans configurations. The best dosage-only predictor within a fixed
 dosage class uses the population-average interaction, leaving this residual
@@ -245,8 +279,16 @@ noncomputable def dosagePhaseMisspecificationError
 
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+noncomputable def haplotypePhasePredictionError
+    (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  expectedPhaseError (haplotypePredictor interaction_cis interaction_trans)
+    freq_cis interaction_cis interaction_trans
+
+theorem haplotypePhasePredictionError_eq_zero
+    (freq_cis interaction_cis interaction_trans : ℝ) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans = 0 := by
+  unfold haplotypePhasePredictionError expectedPhaseError haplotypePredictor
+  ring
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +300,17 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias
+    (freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  expectedPhaseBias (haplotypePredictor interaction_cis interaction_trans)
+    freq_cis_target interaction_cis interaction_trans
+
+theorem haplotypeTransportBias_eq_zero
+    (freq_cis_target interaction_cis interaction_trans : ℝ) :
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans = 0 := by
+  unfold haplotypeTransportBias expectedPhaseBias haplotypePredictor averagePhaseInteraction
+  ring_nf
+  exact abs_zero
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -288,9 +339,10 @@ theorem compound_het_not_captured_by_dosage
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans <
+      dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -334,9 +386,9 @@ section HaplotypePGS
 theorem haplotype_pgs_at_least_snp
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -350,9 +402,9 @@ theorem haplotype_pgs_more_portable_for_cis
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
-      freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans <
+      dosageTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans := by
+  rw [dosageTransportBias_eq, haplotypeTransportBias_eq_zero]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
The previous definitions of `haplotypePhasePredictionError` and `haplotypeTransportBias` suffered from "trivial witness" specification gaming by being hardcoded directly to the constant `0`. This commit resolves the vacuous verification by introducing a generalized `PhasePredictor` structure and formally defining what it means to be a `haplotypePredictor`. We then compute the expected phase error and transport bias against this explicit model, mathematically proving via algebra (`ring`) that the ideal predictor's error and bias are structurally zero. Dependent theorems have been rigorously updated to apply these proofs.

---
*PR created automatically by Jules for task [16938679724320414626](https://jules.google.com/task/16938679724320414626) started by @SauersML*