### PR TITLE
Fix vacuous verification in HaplotypeTheory

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -233,33 +233,63 @@ noncomputable def averagePhaseInteraction
     (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
   freq_cis * interaction_cis + (1 - freq_cis) * interaction_trans
 
+structure PhasePredictor where
+  cisPred : ℝ
+  transPred : ℝ
+
+noncomputable def expectedPhasePrediction (m : PhasePredictor) (freq_cis : ℝ) : ℝ :=
+  freq_cis * m.cisPred + (1 - freq_cis) * m.transPred
+
+noncomputable def phasePredictionError (m : PhasePredictor) (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - m.cisPred) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - m.transPred) ^ 2
+
+noncomputable def phaseTransportBias (m_source : PhasePredictor) (freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  |expectedPhasePrediction ⟨interaction_cis, interaction_trans⟩ freq_cis_target -
+    expectedPhasePrediction m_source freq_cis_target|
+
+noncomputable def dosagePredictor (freq_cis_source interaction_cis interaction_trans : ℝ) : PhasePredictor :=
+  ⟨averagePhaseInteraction freq_cis_source interaction_cis interaction_trans,
+   averagePhaseInteraction freq_cis_source interaction_cis interaction_trans⟩
+
+noncomputable def idealHaplotypePredictor (interaction_cis interaction_trans : ℝ) : PhasePredictor :=
+  ⟨interaction_cis, interaction_trans⟩
+
 /-- Structural error from using a dosage-only predictor that cannot distinguish
 cis from trans configurations. The best dosage-only predictor within a fixed
 dosage class uses the population-average interaction, leaving this residual
 phase-misspecification error. -/
 noncomputable def dosagePhaseMisspecificationError
     (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
-  freq_cis * (interaction_cis - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2 +
-    (1 - freq_cis) *
-      (interaction_trans - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2
+  phasePredictionError (dosagePredictor freq_cis interaction_cis interaction_trans) freq_cis interaction_cis interaction_trans
 
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+noncomputable def haplotypePhasePredictionError (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  phasePredictionError (idealHaplotypePredictor interaction_cis interaction_trans) freq_cis interaction_cis interaction_trans
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
 noncomputable def dosageTransportBias
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
-  |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
-    averagePhaseInteraction freq_cis_source interaction_cis interaction_trans|
+  phaseTransportBias (dosagePredictor freq_cis_source interaction_cis interaction_trans) freq_cis_target interaction_cis interaction_trans
 
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias (_freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  phaseTransportBias (idealHaplotypePredictor interaction_cis interaction_trans) freq_cis_target interaction_cis interaction_trans
+
+theorem haplotypePhasePredictionError_eq_zero (freq_cis interaction_cis interaction_trans : ℝ) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans = 0 := by
+  unfold haplotypePhasePredictionError phasePredictionError idealHaplotypePredictor
+  ring
+
+theorem haplotypeTransportBias_eq_zero (_freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ) :
+    haplotypeTransportBias _freq_cis_source freq_cis_target interaction_cis interaction_trans = 0 := by
+  unfold haplotypeTransportBias phaseTransportBias idealHaplotypePredictor expectedPhasePrediction
+  ring_nf
+  exact abs_zero
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -267,7 +297,7 @@ theorem dosagePhaseMisspecificationError_eq
     (freq_cis interaction_cis interaction_trans : ℝ) :
     dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans =
       freq_cis * (1 - freq_cis) * (interaction_cis - interaction_trans) ^ 2 := by
-  unfold dosagePhaseMisspecificationError averagePhaseInteraction
+  unfold dosagePhaseMisspecificationError phasePredictionError dosagePredictor averagePhaseInteraction
   ring
 
 /-- The structural dosage transport bias is exactly the shift in phase
@@ -276,10 +306,11 @@ theorem dosageTransportBias_eq
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ) :
     dosageTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans =
       |freq_cis_target - freq_cis_source| * |interaction_cis - interaction_trans| := by
-  unfold dosageTransportBias averagePhaseInteraction
+  unfold dosageTransportBias phaseTransportBias dosagePredictor expectedPhasePrediction averagePhaseInteraction
   have h_factor :
       freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans -
-        (freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans) =
+        (freq_cis_target * (freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans) +
+        (1 - freq_cis_target) * (freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans)) =
         (freq_cis_target - freq_cis_source) * (interaction_cis - interaction_trans) := by
     ring
   rw [h_factor, abs_mul]
@@ -288,9 +319,9 @@ theorem compound_het_not_captured_by_dosage
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -334,9 +365,9 @@ section HaplotypePGS
 theorem haplotype_pgs_at_least_snp
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -350,9 +381,9 @@ theorem haplotype_pgs_more_portable_for_cis
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
+    haplotypeTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans < dosageTransportBias
       freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+  rw [dosageTransportBias_eq, haplotypeTransportBias_eq_zero]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Eliminated specification gaming in `HaplotypeTheory.lean` where ideal errors were hardcoded to `0`. Replaced them with the robust `PhasePredictor` struct and fully functional calculation proofs. All related theorems were updated.

---
*PR created automatically by Jules for task [17074087090705791636](https://jules.google.com/task/17074087090705791636) started by @SauersML*