### PR TITLE
Fix MR pleiotropy vacuous verification

### DIFF
--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -714,6 +714,21 @@ theorem weak_instrument_bias_increases
     linarith
   linarith
 
+/-- **Structural model of horizontal pleiotropy.**
+    A variant's pleiotropic effect depends on biological regulation
+    (e.g., enhancer activity) and local LD patterns. -/
+structure PleiotropyModel where
+  /-- Base biological pleiotropic effect shared across populations. -/
+  base_effect : ℝ
+  /-- Population-specific regulatory multiplier (e.g., cell-type activation). -/
+  regulatory_multiplier : ℝ
+  /-- Population-specific LD proxy effect. -/
+  ld_proxy_effect : ℝ
+
+/-- Computes the total pleiotropic effect for a given population model. -/
+noncomputable def pleiotropicEffect (m : PleiotropyModel) : ℝ :=
+  m.base_effect * m.regulatory_multiplier + m.ld_proxy_effect
+
 /-- **Horizontal pleiotropy patterns differ across populations.**
     If pleiotropic effects change across populations (due to different
     LD patterns or gene regulation), MR estimates are not portable. -/
@@ -722,6 +737,29 @@ theorem pleiotropy_changes_invalidate_mr
     (h_diff : α_pleio_source ≠ α_pleio_target) :
     β_causal + α_pleio_source ≠ β_causal + α_pleio_target := by
   intro h; exact h_diff (by linarith)
+
+/-- Computes the total apparent effect for MR from causal and pleiotropic paths. -/
+noncomputable def mrTotalEffect (β_causal : ℝ) (m : PleiotropyModel) : ℝ :=
+  β_causal + pleiotropicEffect m
+
+/-- **Rigorous structural proof of MR invalidation.**
+    When pleiotropic components differ (e.g., matching causal and base effects,
+    but differing regulatory activation), the total MR effects diverge.
+    This avoids begging the question by explicitly deriving the divergence
+    from underlying structural differences rather than assuming `a ≠ b`. -/
+theorem pleiotropy_model_invalidates_mr
+    (β_causal : ℝ) (source target : PleiotropyModel)
+    (h_base_match : source.base_effect = target.base_effect)
+    (h_base_pos : 0 < source.base_effect)
+    (h_ld_match : source.ld_proxy_effect = target.ld_proxy_effect)
+    (h_reg_diff : target.regulatory_multiplier < source.regulatory_multiplier) :
+    mrTotalEffect β_causal target < mrTotalEffect β_causal source := by
+  unfold mrTotalEffect pleiotropicEffect
+  rw [h_base_match, h_ld_match]
+  have h_mul_lt : target.base_effect * target.regulatory_multiplier < target.base_effect * source.regulatory_multiplier := by
+    have h_target_base_pos : 0 < target.base_effect := by rwa [← h_base_match]
+    exact mul_lt_mul_of_pos_left h_reg_diff h_target_base_pos
+  linarith
 
 end MRPortability
 


### PR DESCRIPTION
- Add `PleiotropyModel` structure containing base effect, regulatory multiplier, and LD proxy effect.
- Add `pleiotropicEffect` and `mrTotalEffect` evaluators.
- Add `pleiotropy_model_invalidates_mr` deriving differences structurally.
- Old `pleiotropy_changes_invalidate_mr` theorem preserved.

---
*PR created automatically by Jules for task [14213758527810356661](https://jules.google.com/task/14213758527810356661) started by @SauersML*