### PR TITLE
Fix vacuous verification in haplotype prediction bias

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -245,8 +245,18 @@ noncomputable def dosagePhaseMisspecificationError
 
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+structure HaplotypePredictor where
+  cis_effect : ℝ
+  trans_effect : ℝ
+
+noncomputable def haplotypePhasePredictionError (h : HaplotypePredictor) (interaction_cis interaction_trans : ℝ) : ℝ :=
+  (h.cis_effect - interaction_cis) ^ 2 + (h.trans_effect - interaction_trans) ^ 2
+
+theorem haplotypePhasePredictionError_eq_zero (h : HaplotypePredictor) (interaction_cis interaction_trans : ℝ)
+    (h_cis : h.cis_effect = interaction_cis) (h_trans : h.trans_effect = interaction_trans) :
+    haplotypePhasePredictionError h interaction_cis interaction_trans = 0 := by
+  rw [haplotypePhasePredictionError, h_cis, h_trans, sub_self, sub_self]
+  ring
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +268,15 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias (h_source h_target : HaplotypePredictor) (freq_cis_target : ℝ) : ℝ :=
+  |averagePhaseInteraction freq_cis_target h_source.cis_effect h_source.trans_effect -
+    averagePhaseInteraction freq_cis_target h_target.cis_effect h_target.trans_effect|
+
+theorem haplotypeTransportBias_eq_zero (h_source h_target : HaplotypePredictor) (interaction_cis interaction_trans freq_cis_target : ℝ)
+    (h_perf_source : h_source.cis_effect = interaction_cis ∧ h_source.trans_effect = interaction_trans)
+    (h_perf_target : h_target.cis_effect = interaction_cis ∧ h_target.trans_effect = interaction_trans) :
+    haplotypeTransportBias h_source h_target freq_cis_target = 0 := by
+  rw [haplotypeTransportBias, h_perf_source.1, h_perf_source.2, h_perf_target.1, h_perf_target.2, sub_self, abs_zero]
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -285,12 +302,14 @@ theorem dosageTransportBias_eq
   rw [h_factor, abs_mul]
 
 theorem compound_het_not_captured_by_dosage
+    (h : HaplotypePredictor)
     (freq_cis interaction_cis interaction_trans : ℝ)
+    (h_cis : h.cis_effect = interaction_cis) (h_trans : h.trans_effect = interaction_trans)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError h interaction_cis interaction_trans < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero _ _ _ h_cis h_trans]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -332,11 +351,13 @@ section HaplotypePGS
     strictly positive error whenever both cis and trans states occur and their
     effects differ. -/
 theorem haplotype_pgs_at_least_snp
+    (h : HaplotypePredictor)
     (freq_cis interaction_cis interaction_trans : ℝ)
+    (h_cis : h.cis_effect = interaction_cis) (h_trans : h.trans_effect = interaction_trans)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError h interaction_cis interaction_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero _ _ _ h_cis h_trans]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -347,12 +368,15 @@ theorem haplotype_pgs_at_least_snp
     the target phase-configuration frequency differs from the source. A
     phase-aware haplotype model avoids this bias. -/
 theorem haplotype_pgs_more_portable_for_cis
+    (h_source h_target : HaplotypePredictor)
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
+    (h_perf_source : h_source.cis_effect = interaction_cis ∧ h_source.trans_effect = interaction_trans)
+    (h_perf_target : h_target.cis_effect = interaction_cis ∧ h_target.trans_effect = interaction_trans)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
+    haplotypeTransportBias h_source h_target freq_cis_target < dosageTransportBias
       freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+  rw [dosageTransportBias_eq, haplotypeTransportBias_eq_zero _ _ _ _ _ h_perf_source h_perf_target]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Fixes specification gaming ("trivial witness" / "begging the question") in `proofs/Calibrator/HaplotypeTheory.lean`.

The original code defined:
```lean
noncomputable def haplotypePhasePredictionError : ℝ := 0
noncomputable def haplotypeTransportBias : ℝ := 0
```
This allowed downstream theorems to prove inequalities vacuously, simply because the base definition was hardcoded to exactly `0` without any mathematical justification based on predictor parameters.

This commit introduces a new `HaplotypePredictor` structure encapsulating both `cis_effect` and `trans_effect`. The error/bias definitions are now proper mathematical functions mapping from this generic predictor structure to a squared phase mismatch or interaction gap. We then prove that these newly structured functions evaluate to `0` explicitly when the predictor parameters are perfectly set to match the true specific interaction mechanisms (`h.cis_effect = interaction_cis` etc), resolving the begging-the-question while preserving all dependent downstream inequalities.

---
*PR created automatically by Jules for task [6698182220756568930](https://jules.google.com/task/6698182220756568930) started by @SauersML*