### PR TITLE
Fix specification gaming in haplotype phase prediction metrics

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -243,10 +243,36 @@ noncomputable def dosagePhaseMisspecificationError
     (1 - freq_cis) *
       (interaction_trans - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2
 
+/-- A generic phase predictor capable of assigning different effects to cis and trans. -/
+structure PhasePredictor where
+  pred_cis : ℝ
+  pred_trans : ℝ
+
+/-- The generalized phase prediction error evaluated against a generic phase predictor. -/
+noncomputable def generalizedPhasePredictionError
+    (freq_cis interaction_cis interaction_trans : ℝ)
+    (m : PhasePredictor) : ℝ :=
+  freq_cis * (interaction_cis - m.pred_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - m.pred_trans) ^ 2
+
+/-- A perfectly phase-aware haplotype predictor assigns exactly the true interactions. -/
+structure PerfectPhasePredictor (interaction_cis interaction_trans : ℝ) extends PhasePredictor where
+  h_cis : pred_cis = interaction_cis
+  h_trans : pred_trans = interaction_trans
+
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
 noncomputable def haplotypePhasePredictionError : ℝ :=
   0
+
+theorem generalizedPhasePredictionError_eq_zero
+    {interaction_cis interaction_trans : ℝ}
+    (freq_cis : ℝ)
+    (m : PerfectPhasePredictor interaction_cis interaction_trans) :
+    generalizedPhasePredictionError freq_cis interaction_cis interaction_trans m.toPhasePredictor = haplotypePhasePredictionError := by
+  unfold generalizedPhasePredictionError haplotypePhasePredictionError
+  rw [m.h_cis, m.h_trans]
+  ring
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -255,11 +281,29 @@ noncomputable def dosageTransportBias
   |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
     averagePhaseInteraction freq_cis_source interaction_cis interaction_trans|
 
+/-- The generalized transport bias of a phase predictor. -/
+noncomputable def generalizedTransportBias
+    (freq_cis_target interaction_cis interaction_trans : ℝ)
+    (m : PhasePredictor) : ℝ :=
+  | (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans) -
+    (freq_cis_target * m.pred_cis + (1 - freq_cis_target) * m.pred_trans) |
+
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
 noncomputable def haplotypeTransportBias : ℝ :=
   0
+
+theorem generalizedTransportBias_eq_zero
+    {interaction_cis interaction_trans : ℝ}
+    (freq_cis_target : ℝ)
+    (m : PerfectPhasePredictor interaction_cis interaction_trans) :
+    generalizedTransportBias freq_cis_target interaction_cis interaction_trans m.toPhasePredictor = haplotypeTransportBias := by
+  unfold generalizedTransportBias haplotypeTransportBias
+  rw [m.h_cis, m.h_trans]
+  have h_zero : freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans -
+    (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans) = 0 := by ring
+  rw [h_zero, abs_zero]
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -286,11 +330,13 @@ theorem dosageTransportBias_eq
 
 theorem compound_het_not_captured_by_dosage
     (freq_cis interaction_cis interaction_trans : ℝ)
+    (m : PerfectPhasePredictor interaction_cis interaction_trans)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    generalizedPhasePredictionError freq_cis interaction_cis interaction_trans m.toPhasePredictor <
+      dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, generalizedPhasePredictionError_eq_zero freq_cis m, haplotypePhasePredictionError]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -333,10 +379,11 @@ section HaplotypePGS
     effects differ. -/
 theorem haplotype_pgs_at_least_snp
     (freq_cis interaction_cis interaction_trans : ℝ)
+    (m : PerfectPhasePredictor interaction_cis interaction_trans)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    generalizedPhasePredictionError freq_cis interaction_cis interaction_trans m.toPhasePredictor ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, generalizedPhasePredictionError_eq_zero freq_cis m, haplotypePhasePredictionError]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -348,11 +395,12 @@ theorem haplotype_pgs_at_least_snp
     phase-aware haplotype model avoids this bias. -/
 theorem haplotype_pgs_more_portable_for_cis
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
+    (m : PerfectPhasePredictor interaction_cis interaction_trans)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
-      freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+    generalizedTransportBias freq_cis_target interaction_cis interaction_trans m.toPhasePredictor <
+      dosageTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans := by
+  rw [dosageTransportBias_eq, generalizedTransportBias_eq_zero freq_cis_target m, haplotypeTransportBias]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Fixes vacuous verification (specification gaming) in `HaplotypeTheory.lean`.
The previous formalization proved that phase-aware models achieve 0 error and 0 transport bias by simply defining the associated error and bias metrics as hardcoded `0`s (trivial witness).

This PR introduces a proper formal mechanism:
- Defines `PhasePredictor` interface with `pred_cis` and `pred_trans`.
- Creates generalized mathematical bounds for prediction error and transport bias parameterized by arbitrary predictors.
- Defines `PerfectPhasePredictor` that captures exact cis/trans values.
- Adds `_eq_zero` compatibility theorems to prove that a perfect predictor algebraically computes to 0 error.
- Updates all major proofs in the file to properly construct and evaluate these models algebraically rather than tautologically relying on `0`.

---
*PR created automatically by Jules for task [17682889919414399453](https://jules.google.com/task/17682889919414399453) started by @SauersML*