### PR TITLE
Fix vacuous verification in Haplotype Theory

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -243,10 +243,18 @@ noncomputable def dosagePhaseMisspecificationError
     (1 - freq_cis) *
       (interaction_trans - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2
 
+/-- A phase-aware haplotype predictor that explicitly models the interaction
+effect for cis and trans configurations. -/
+structure PhaseAwarePredictor where
+  pred_cis : ℝ
+  pred_trans : ℝ
+
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
-structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+structural phase-misspecification error when predictions are perfect. -/
+noncomputable def haplotypePhasePredictionError
+    (pred : PhaseAwarePredictor) (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - pred.pred_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - pred.pred_trans) ^ 2
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +266,25 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias
+    (pred : PhaseAwarePredictor) (freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
+    averagePhaseInteraction freq_cis_target pred.pred_cis pred.pred_trans|
+
+/-- A perfect phase-aware haplotype predictor has zero prediction error. -/
+theorem haplotypePhasePredictionError_perfect_eq_zero
+    (interaction_cis interaction_trans freq_cis : ℝ) :
+    haplotypePhasePredictionError ⟨interaction_cis, interaction_trans⟩ freq_cis interaction_cis interaction_trans = 0 := by
+  unfold haplotypePhasePredictionError
+  ring
+
+/-- A perfect phase-aware haplotype predictor has zero transport bias. -/
+theorem haplotypeTransportBias_perfect_eq_zero
+    (interaction_cis interaction_trans freq_cis_target : ℝ) :
+    haplotypeTransportBias ⟨interaction_cis, interaction_trans⟩ freq_cis_target interaction_cis interaction_trans = 0 := by
+  unfold haplotypeTransportBias averagePhaseInteraction
+  ring_nf
+  exact abs_zero
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -288,9 +313,10 @@ theorem compound_het_not_captured_by_dosage
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError ⟨interaction_cis, interaction_trans⟩ freq_cis interaction_cis interaction_trans <
+      dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_perfect_eq_zero]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -334,9 +360,9 @@ section HaplotypePGS
 theorem haplotype_pgs_at_least_snp
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError ⟨interaction_cis, interaction_trans⟩ freq_cis interaction_cis interaction_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_perfect_eq_zero]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -350,9 +376,9 @@ theorem haplotype_pgs_more_portable_for_cis
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
-      freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+    haplotypeTransportBias ⟨interaction_cis, interaction_trans⟩ freq_cis_target interaction_cis interaction_trans <
+      dosageTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans := by
+  rw [dosageTransportBias_eq, haplotypeTransportBias_perfect_eq_zero]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Refactored `haplotypePhasePredictionError` and `haplotypeTransportBias` which were previously hardcoded to `0` (trivial witness specification gaming). Introduced a `PhaseAwarePredictor` structure that explicitly models cis and trans predictions, and computes the mathematical variance and bias dynamically. Updated dependent theorems in `proofs/Calibrator/HaplotypeTheory.lean` to instantiate perfect predictors, proving that when the predictions exactly match the interactions, the error evaluates to `0`. All proofs compile successfully.

---
*PR created automatically by Jules for task [7336254484423294952](https://jules.google.com/task/7336254484423294952) started by @SauersML*