### PR TITLE
Fix vacuous verification in HaplotypeTheory by parameterizing prediction errors

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -245,8 +245,19 @@ noncomputable def dosagePhaseMisspecificationError
 
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+noncomputable def haplotypePhasePredictionError
+    (freq_cis interaction_cis interaction_trans true_interaction_cis true_interaction_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - true_interaction_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - true_interaction_trans) ^ 2
+
+theorem haplotypePhasePredictionError_eq_zero
+    (freq_cis interaction_cis interaction_trans true_interaction_cis true_interaction_trans : ℝ)
+    (h_cis : interaction_cis = true_interaction_cis)
+    (h_trans : interaction_trans = true_interaction_trans) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans true_interaction_cis true_interaction_trans = 0 := by
+  unfold haplotypePhasePredictionError
+  rw [h_cis, h_trans, sub_self, sub_self]
+  ring
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +269,20 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias
+    (freq_cis_target interaction_cis interaction_trans true_interaction_cis true_interaction_trans : ℝ) : ℝ :=
+  |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
+    averagePhaseInteraction freq_cis_target true_interaction_cis true_interaction_trans|
+
+theorem haplotypeTransportBias_eq_zero
+    (freq_cis_target interaction_cis interaction_trans true_interaction_cis true_interaction_trans : ℝ)
+    (h_cis : interaction_cis = true_interaction_cis)
+    (h_trans : interaction_trans = true_interaction_trans) :
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans true_interaction_cis true_interaction_trans = 0 := by
+  unfold haplotypeTransportBias averagePhaseInteraction
+  rw [h_cis, h_trans]
+  ring_nf
+  exact abs_zero
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -285,12 +308,15 @@ theorem dosageTransportBias_eq
   rw [h_factor, abs_mul]
 
 theorem compound_het_not_captured_by_dosage
-    (freq_cis interaction_cis interaction_trans : ℝ)
+    (freq_cis interaction_cis interaction_trans true_interaction_cis true_interaction_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
-    (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    (h_phase_gap : interaction_cis ≠ interaction_trans)
+    (h_cis : interaction_cis = true_interaction_cis)
+    (h_trans : interaction_trans = true_interaction_trans) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans true_interaction_cis true_interaction_trans < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  rw [haplotypePhasePredictionError_eq_zero _ _ _ _ _ h_cis h_trans]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -332,11 +358,14 @@ section HaplotypePGS
     strictly positive error whenever both cis and trans states occur and their
     effects differ. -/
 theorem haplotype_pgs_at_least_snp
-    (freq_cis interaction_cis interaction_trans : ℝ)
-    (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    (freq_cis interaction_cis interaction_trans true_interaction_cis true_interaction_trans : ℝ)
+    (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1)
+    (h_cis : interaction_cis = true_interaction_cis)
+    (h_trans : interaction_trans = true_interaction_trans) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans true_interaction_cis true_interaction_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  rw [haplotypePhasePredictionError_eq_zero _ _ _ _ _ h_cis h_trans]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -347,12 +376,15 @@ theorem haplotype_pgs_at_least_snp
     the target phase-configuration frequency differs from the source. A
     phase-aware haplotype model avoids this bias. -/
 theorem haplotype_pgs_more_portable_for_cis
-    (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
+    (freq_cis_source freq_cis_target interaction_cis interaction_trans true_interaction_cis true_interaction_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
-    (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
+    (h_phase_gap : interaction_cis ≠ interaction_trans)
+    (h_cis : interaction_cis = true_interaction_cis)
+    (h_trans : interaction_trans = true_interaction_trans) :
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans true_interaction_cis true_interaction_trans < dosageTransportBias
       freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+  rw [dosageTransportBias_eq]
+  rw [haplotypeTransportBias_eq_zero _ _ _ _ _ h_cis h_trans]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
This PR addresses 'specification gaming' via vacuous verification (the trivial witness pattern) in `proofs/Calibrator/HaplotypeTheory.lean`.

1. `haplotypePhasePredictionError` and `haplotypeTransportBias` were previously defined as hardcoded `0` values. This allowed dependent theorems to technically pass verification via simple definitions, but failed to actually model the underlying haplotype conditions that lead to zero error.
2. I refactored both definitions into formal parameterized mathematical properties.
  - `haplotypePhasePredictionError` is now the explicit phase misspecification variance between assumed and true interactions.
  - `haplotypeTransportBias` is now the explicit difference in average phase interaction based on target allele frequencies and true underlying biological interactions.
3. Added compatibility theorems (`haplotypePhasePredictionError_eq_zero`, `haplotypeTransportBias_eq_zero`) that rigorously prove the errors become zero under the exact mathematical condition that the inferred interactions perfectly match the true causal interactions.
4. Updated dependent theorems to dynamically rewrite these properties using equality hypotheses instead of relying on the trivial zero definitions.

The code compiles locally with `lake build`.

---
*PR created automatically by Jules for task [5549784749234932662](https://jules.google.com/task/5549784749234932662) started by @SauersML*