### PR TITLE
Fix vacuous verification in Haplotype Theory predictions

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -243,10 +243,26 @@ noncomputable def dosagePhaseMisspecificationError
     (1 - freq_cis) *
       (interaction_trans - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2
 
-/-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
-structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+/-- A phase-aware haplotype predictor that tracks cis/trans configuration. -/
+structure HaplotypePhaseModel where
+  predicted_cis : ℝ
+  predicted_trans : ℝ
+
+/-- A phase-aware haplotype predictor that tracks cis/trans configuration has a
+structural phase-misspecification error dependent on its predictions. -/
+noncomputable def haplotypePhasePredictionError (m : HaplotypePhaseModel)
+    (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - m.predicted_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - m.predicted_trans) ^ 2
+
+theorem haplotypePhasePredictionError_eq_zero (m : HaplotypePhaseModel)
+    (freq_cis interaction_cis interaction_trans : ℝ)
+    (h_cis : m.predicted_cis = interaction_cis)
+    (h_trans : m.predicted_trans = interaction_trans) :
+    haplotypePhasePredictionError m freq_cis interaction_cis interaction_trans = 0 := by
+  unfold haplotypePhasePredictionError
+  rw [h_cis, h_trans, sub_self, sub_self]
+  ring
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -255,11 +271,23 @@ noncomputable def dosageTransportBias
   |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
     averagePhaseInteraction freq_cis_source interaction_cis interaction_trans|
 
-/-- A phase-aware haplotype model transports without this structural bias when
-the cis/trans effects themselves are portable and only configuration
-frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+/-- A phase-aware haplotype model transports with a bias dependent on its predictions. -/
+noncomputable def haplotypeTransportBias (m : HaplotypePhaseModel)
+    (freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
+    averagePhaseInteraction freq_cis_target m.predicted_cis m.predicted_trans|
+
+theorem haplotypeTransportBias_eq_zero (m : HaplotypePhaseModel)
+    (freq_cis_target interaction_cis interaction_trans : ℝ)
+    (h_cis : m.predicted_cis = interaction_cis)
+    (h_trans : m.predicted_trans = interaction_trans) :
+    haplotypeTransportBias m freq_cis_target interaction_cis interaction_trans = 0 := by
+  unfold haplotypeTransportBias
+  rw [h_cis, h_trans]
+  have h_abs : |(0 : ℝ)| = 0 := abs_zero
+  have h_sub : averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
+    averagePhaseInteraction freq_cis_target interaction_cis interaction_trans = 0 := sub_self _
+  rw [h_sub, h_abs]
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -284,13 +312,16 @@ theorem dosageTransportBias_eq
     ring
   rw [h_factor, abs_mul]
 
-theorem compound_het_not_captured_by_dosage
+theorem compound_het_not_captured_by_dosage (m : HaplotypePhaseModel)
     (freq_cis interaction_cis interaction_trans : ℝ)
+    (h_cis : m.predicted_cis = interaction_cis)
+    (h_trans : m.predicted_trans = interaction_trans)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError m freq_cis interaction_cis interaction_trans < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  rw [haplotypePhasePredictionError_eq_zero m freq_cis interaction_cis interaction_trans h_cis h_trans]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -331,12 +362,15 @@ section HaplotypePGS
     structural error, while a dosage-only SNP score has nonnegative error, and
     strictly positive error whenever both cis and trans states occur and their
     effects differ. -/
-theorem haplotype_pgs_at_least_snp
+theorem haplotype_pgs_at_least_snp (m : HaplotypePhaseModel)
     (freq_cis interaction_cis interaction_trans : ℝ)
+    (h_cis : m.predicted_cis = interaction_cis)
+    (h_trans : m.predicted_trans = interaction_trans)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError m freq_cis interaction_cis interaction_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  rw [haplotypePhasePredictionError_eq_zero m freq_cis interaction_cis interaction_trans h_cis h_trans]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -346,13 +380,16 @@ theorem haplotype_pgs_at_least_snp
     transporting a dosage-only approximation incurs structural bias whenever
     the target phase-configuration frequency differs from the source. A
     phase-aware haplotype model avoids this bias. -/
-theorem haplotype_pgs_more_portable_for_cis
+theorem haplotype_pgs_more_portable_for_cis (m : HaplotypePhaseModel)
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
+    (h_cis : m.predicted_cis = interaction_cis)
+    (h_trans : m.predicted_trans = interaction_trans)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
+    haplotypeTransportBias m freq_cis_target interaction_cis interaction_trans < dosageTransportBias
       freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+  rw [dosageTransportBias_eq]
+  rw [haplotypeTransportBias_eq_zero m freq_cis_target interaction_cis interaction_trans h_cis h_trans]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
This commit addresses specification gaming (vacuous verification) within `proofs/Calibrator/HaplotypeTheory.lean`. The `haplotypePhasePredictionError` and `haplotypeTransportBias` defs were previously tautological (`:= 0`), making downstream proofs artificially trivial. They have been refactored to actually compute the expected structural error based on predicted cis and trans effects versus ground truth. Their triviality under perfect modeling is now proven via dedicated compatibility theorems, ensuring rigour in the dependent lemmas.

---
*PR created automatically by Jules for task [4539094200094646828](https://jules.google.com/task/4539094200094646828) started by @SauersML*