### PR TITLE
Refactor haplotype prediction error to eliminate specification gaming

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -233,6 +233,10 @@ noncomputable def averagePhaseInteraction
     (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
   freq_cis * interaction_cis + (1 - freq_cis) * interaction_trans
 
+structure HaplotypePhaseModel where
+  pred_cis : ℝ
+  pred_trans : ℝ
+
 /-- Structural error from using a dosage-only predictor that cannot distinguish
 cis from trans configurations. The best dosage-only predictor within a fixed
 dosage class uses the population-average interaction, leaving this residual
@@ -244,9 +248,20 @@ noncomputable def dosagePhaseMisspecificationError
       (interaction_trans - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2
 
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
-structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+structural phase-misspecification error when it perfectly matches the true effects. -/
+noncomputable def haplotypePhasePredictionError (m : HaplotypePhaseModel)
+    (interaction_cis interaction_trans _freq_cis : ℝ) : ℝ :=
+  _freq_cis * (m.pred_cis - interaction_cis) ^ 2 +
+    (1 - _freq_cis) * (m.pred_trans - interaction_trans) ^ 2
+
+theorem haplotypePhasePredictionError_eq_zero (m : HaplotypePhaseModel)
+    (interaction_cis interaction_trans _freq_cis : ℝ)
+    (h_cis : m.pred_cis = interaction_cis)
+    (h_trans : m.pred_trans = interaction_trans) :
+    haplotypePhasePredictionError m interaction_cis interaction_trans _freq_cis = 0 := by
+  unfold haplotypePhasePredictionError
+  rw [h_cis, h_trans]
+  ring
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +273,21 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias (m : HaplotypePhaseModel)
+    (freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  |(freq_cis_target * m.pred_cis + (1 - freq_cis_target) * m.pred_trans) -
+    averagePhaseInteraction freq_cis_target interaction_cis interaction_trans|
+
+theorem haplotypeTransportBias_eq_zero (m : HaplotypePhaseModel)
+    (freq_cis_target interaction_cis interaction_trans : ℝ)
+    (h_cis : m.pred_cis = interaction_cis)
+    (h_trans : m.pred_trans = interaction_trans) :
+    haplotypeTransportBias m freq_cis_target interaction_cis interaction_trans = 0 := by
+  unfold haplotypeTransportBias averagePhaseInteraction
+  rw [h_cis, h_trans]
+  have h_inner : freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans -
+    (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans) = 0 := by ring
+  rw [h_inner, abs_zero]
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -286,11 +314,15 @@ theorem dosageTransportBias_eq
 
 theorem compound_het_not_captured_by_dosage
     (freq_cis interaction_cis interaction_trans : ℝ)
+    (m : HaplotypePhaseModel)
+    (h_cis : m.pred_cis = interaction_cis)
+    (h_trans : m.pred_trans = interaction_trans)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError m interaction_cis interaction_trans freq_cis <
+      dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero m interaction_cis interaction_trans freq_cis h_cis h_trans]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -333,10 +365,13 @@ section HaplotypePGS
     effects differ. -/
 theorem haplotype_pgs_at_least_snp
     (freq_cis interaction_cis interaction_trans : ℝ)
+    (m : HaplotypePhaseModel)
+    (h_cis : m.pred_cis = interaction_cis)
+    (h_trans : m.pred_trans = interaction_trans)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError m interaction_cis interaction_trans freq_cis ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero m interaction_cis interaction_trans freq_cis h_cis h_trans]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -348,11 +383,14 @@ theorem haplotype_pgs_at_least_snp
     phase-aware haplotype model avoids this bias. -/
 theorem haplotype_pgs_more_portable_for_cis
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
+    (m : HaplotypePhaseModel)
+    (h_cis : m.pred_cis = interaction_cis)
+    (h_trans : m.pred_trans = interaction_trans)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
+    haplotypeTransportBias m freq_cis_target interaction_cis interaction_trans < dosageTransportBias
       freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+  rw [dosageTransportBias_eq, haplotypeTransportBias_eq_zero m freq_cis_target interaction_cis interaction_trans h_cis h_trans]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Eliminated specification gaming in HaplotypeTheory proofs by formalizing the structure of haplotype phase error instead of relying on trivial constant 0 definitions.

---
*PR created automatically by Jules for task [1991993768337786238](https://jules.google.com/task/1991993768337786238) started by @SauersML*