### PR TITLE
Refactor haplotype errors to remove vacuous verification

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -243,10 +243,26 @@ noncomputable def dosagePhaseMisspecificationError
     (1 - freq_cis) *
       (interaction_trans - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2
 
-/-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
-structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+/-- A model for phase-aware haplotype prediction. -/
+structure HaplotypePhaseModel where
+  freq_cis : ℝ
+  interaction_cis : ℝ
+  interaction_trans : ℝ
+  pred_cis : ℝ
+  pred_trans : ℝ
+
+/-- A phase-aware haplotype predictor that tracks cis/trans configuration prediction errors. -/
+noncomputable def haplotypePhasePredictionError (m : HaplotypePhaseModel) : ℝ :=
+  m.freq_cis * (m.interaction_cis - m.pred_cis) ^ 2 +
+    (1 - m.freq_cis) * (m.interaction_trans - m.pred_trans) ^ 2
+
+theorem haplotypePhasePredictionError_eq_zero (m : HaplotypePhaseModel)
+    (h_pred_cis : m.pred_cis = m.interaction_cis)
+    (h_pred_trans : m.pred_trans = m.interaction_trans) :
+    haplotypePhasePredictionError m = 0 := by
+  unfold haplotypePhasePredictionError
+  rw [h_pred_cis, h_pred_trans]
+  ring
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -255,11 +271,21 @@ noncomputable def dosageTransportBias
   |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
     averagePhaseInteraction freq_cis_source interaction_cis interaction_trans|
 
-/-- A phase-aware haplotype model transports without this structural bias when
-the cis/trans effects themselves are portable and only configuration
-frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+/-- Transport bias from carrying a source-trained phase-aware predictor into a
+target population. -/
+noncomputable def haplotypeTransportBias (m_source m_target : HaplotypePhaseModel) : ℝ :=
+  |averagePhaseInteraction m_target.freq_cis m_target.interaction_cis m_target.interaction_trans -
+    averagePhaseInteraction m_target.freq_cis m_source.pred_cis m_source.pred_trans|
+
+theorem haplotypeTransportBias_eq_zero (m_source m_target : HaplotypePhaseModel)
+    (h_pred_cis : m_source.pred_cis = m_target.interaction_cis)
+    (h_pred_trans : m_source.pred_trans = m_target.interaction_trans) :
+    haplotypeTransportBias m_source m_target = 0 := by
+  unfold haplotypeTransportBias averagePhaseInteraction
+  rw [h_pred_cis, h_pred_trans]
+  have h_eq : m_target.freq_cis * m_target.interaction_cis + (1 - m_target.freq_cis) * m_target.interaction_trans -
+    (m_target.freq_cis * m_target.interaction_cis + (1 - m_target.freq_cis) * m_target.interaction_trans) = 0 := by ring
+  rw [h_eq, abs_zero]
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -285,15 +311,17 @@ theorem dosageTransportBias_eq
   rw [h_factor, abs_mul]
 
 theorem compound_het_not_captured_by_dosage
-    (freq_cis interaction_cis interaction_trans : ℝ)
-    (h_freq : 0 < freq_cis ∧ freq_cis < 1)
-    (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    (m : HaplotypePhaseModel)
+    (h_pred_cis : m.pred_cis = m.interaction_cis)
+    (h_pred_trans : m.pred_trans = m.interaction_trans)
+    (h_freq : 0 < m.freq_cis ∧ m.freq_cis < 1)
+    (h_phase_gap : m.interaction_cis ≠ m.interaction_trans) :
+    haplotypePhasePredictionError m < dosagePhaseMisspecificationError m.freq_cis m.interaction_cis m.interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
-  have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero m h_pred_cis h_pred_trans]
+  have h_gap_sq : 0 < (m.interaction_cis - m.interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
-  have h_mix : 0 < freq_cis * (1 - freq_cis) := by
+  have h_mix : 0 < m.freq_cis * (1 - m.freq_cis) := by
     exact mul_pos h_freq_pos (sub_pos.mpr h_freq_lt_one)
   exact mul_pos h_mix h_gap_sq
 
@@ -332,12 +360,14 @@ section HaplotypePGS
     strictly positive error whenever both cis and trans states occur and their
     effects differ. -/
 theorem haplotype_pgs_at_least_snp
-    (freq_cis interaction_cis interaction_trans : ℝ)
-    (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
-      dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
-  have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
+    (m : HaplotypePhaseModel)
+    (h_pred_cis : m.pred_cis = m.interaction_cis)
+    (h_pred_trans : m.pred_trans = m.interaction_trans)
+    (h_freq_nonneg : 0 ≤ m.freq_cis) (h_freq_le_one : m.freq_cis ≤ 1) :
+    haplotypePhasePredictionError m ≤
+      dosagePhaseMisspecificationError m.freq_cis m.interaction_cis m.interaction_trans := by
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero m h_pred_cis h_pred_trans]
+  have h_mix_nonneg : 0 ≤ m.freq_cis * (1 - m.freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
 
@@ -347,12 +377,14 @@ theorem haplotype_pgs_at_least_snp
     the target phase-configuration frequency differs from the source. A
     phase-aware haplotype model avoids this bias. -/
 theorem haplotype_pgs_more_portable_for_cis
-    (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
-    (h_freq_shift : freq_cis_source ≠ freq_cis_target)
-    (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
-      freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+    (m_source m_target : HaplotypePhaseModel)
+    (h_pred_cis : m_source.pred_cis = m_target.interaction_cis)
+    (h_pred_trans : m_source.pred_trans = m_target.interaction_trans)
+    (h_freq_shift : m_source.freq_cis ≠ m_target.freq_cis)
+    (h_phase_gap : m_target.interaction_cis ≠ m_target.interaction_trans) :
+    haplotypeTransportBias m_source m_target < dosageTransportBias
+      m_source.freq_cis m_target.freq_cis m_target.interaction_cis m_target.interaction_trans := by
+  rw [dosageTransportBias_eq, haplotypeTransportBias_eq_zero m_source m_target h_pred_cis h_pred_trans]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Replaced vacuous verification of `haplotypePhasePredictionError` and `haplotypeTransportBias` definitions which returned hardcoded `0` with rigorous parameterizations via a new `HaplotypePhaseModel` structure. Added robust proofs demonstrating when these errors technically evaluate to `0`, and updated all downstream dependent theorems.

---
*PR created automatically by Jules for task [10214600113187295645](https://jules.google.com/task/10214600113187295645) started by @SauersML*