### PR TITLE
Fix vacuous verification in haplotype theory error definitions

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -243,10 +243,30 @@ noncomputable def dosagePhaseMisspecificationError
     (1 - freq_cis) *
       (interaction_trans - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2
 
+/-- Structural error when predicting true phase interactions with an arbitrary predictor. -/
+noncomputable def phasePredictionError
+    (freq_cis true_cis true_trans pred_cis pred_trans : ℝ) : ℝ :=
+  freq_cis * (true_cis - pred_cis) ^ 2 +
+    (1 - freq_cis) * (true_trans - pred_trans) ^ 2
+
+/-- Structural transport bias when applying arbitrary phase predictions to a target population. -/
+noncomputable def phaseTransportBias
+    (freq_cis_target true_cis true_trans pred_cis pred_trans : ℝ) : ℝ :=
+  |averagePhaseInteraction freq_cis_target true_cis true_trans -
+    averagePhaseInteraction freq_cis_target pred_cis pred_trans|
+
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+noncomputable def haplotypePhasePredictionError
+    (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  phasePredictionError freq_cis interaction_cis interaction_trans interaction_cis interaction_trans
+
+/-- A phase-aware haplotype predictor has exactly zero structural phase-misspecification error. -/
+theorem haplotypePhasePredictionError_eq_zero
+    (freq_cis interaction_cis interaction_trans : ℝ) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans = 0 := by
+  unfold haplotypePhasePredictionError phasePredictionError
+  ring
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +278,19 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias
+    (freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  phaseTransportBias freq_cis_target interaction_cis interaction_trans interaction_cis interaction_trans
+
+/-- A phase-aware haplotype model has exactly zero transport bias under portable phase effects. -/
+theorem haplotypeTransportBias_eq_zero
+    (freq_cis_target interaction_cis interaction_trans : ℝ) :
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans = 0 := by
+  unfold haplotypeTransportBias phaseTransportBias
+  have h_abs : |(0 : ℝ)| = 0 := abs_zero
+  have h_diff : averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
+      averagePhaseInteraction freq_cis_target interaction_cis interaction_trans = 0 := by ring
+  rw [h_diff, h_abs]
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -288,9 +319,9 @@ theorem compound_het_not_captured_by_dosage
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -334,9 +365,9 @@ section HaplotypePGS
 theorem haplotype_pgs_at_least_snp
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -350,9 +381,9 @@ theorem haplotype_pgs_more_portable_for_cis
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans < dosageTransportBias
       freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+  rw [dosageTransportBias_eq, haplotypeTransportBias_eq_zero]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Replaced hardcoded `0` trivial witnesses in `haplotypePhasePredictionError` and `haplotypeTransportBias` with mathematically robust generic functions (`phasePredictionError` and `phaseTransportBias`). Derived new zero-equivalence theorems that construct the `0` evaluations naturally from correct model assumptions. Modified dependent theorems to utilize these new derived results instead of the tautological definitions. This successfully eliminates specification gaming while strengthening the rigorous foundation of the population genetics Lean 4 formalization.

---
*PR created automatically by Jules for task [6540880625667382594](https://jules.google.com/task/6540880625667382594) started by @SauersML*