### PR TITLE
Refactor vacuous definitions in HaplotypeTheory.lean

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -233,20 +233,39 @@ noncomputable def averagePhaseInteraction
     (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
   freq_cis * interaction_cis + (1 - freq_cis) * interaction_trans
 
+/-- A general phase prediction error. -/
+noncomputable def phasePredictionError
+    (freq_cis actual_cis actual_trans predicted_cis predicted_trans : ℝ) : ℝ :=
+  freq_cis * (actual_cis - predicted_cis) ^ 2 +
+    (1 - freq_cis) * (actual_trans - predicted_trans) ^ 2
+
 /-- Structural error from using a dosage-only predictor that cannot distinguish
 cis from trans configurations. The best dosage-only predictor within a fixed
 dosage class uses the population-average interaction, leaving this residual
 phase-misspecification error. -/
 noncomputable def dosagePhaseMisspecificationError
     (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
-  freq_cis * (interaction_cis - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2 +
-    (1 - freq_cis) *
-      (interaction_trans - averagePhaseInteraction freq_cis interaction_cis interaction_trans) ^ 2
+  phasePredictionError freq_cis interaction_cis interaction_trans
+    (averagePhaseInteraction freq_cis interaction_cis interaction_trans)
+    (averagePhaseInteraction freq_cis interaction_cis interaction_trans)
 
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+noncomputable def haplotypePhasePredictionError (freq_cis interaction_cis interaction_trans : ℝ) : ℝ :=
+  phasePredictionError freq_cis interaction_cis interaction_trans interaction_cis interaction_trans
+
+theorem haplotypePhasePredictionError_eq_zero
+    (freq_cis interaction_cis interaction_trans : ℝ) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans = 0 := by
+  unfold haplotypePhasePredictionError phasePredictionError
+  ring
+
+noncomputable def transportBias
+    (freq_cis_target freq_cis_source
+     actual_cis_target actual_trans_target
+     predicted_cis predicted_trans : ℝ) : ℝ :=
+  |phasePredictionError freq_cis_target actual_cis_target actual_trans_target predicted_cis predicted_trans -
+   phasePredictionError freq_cis_source actual_cis_target actual_trans_target predicted_cis predicted_trans|
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +277,20 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ) : ℝ :=
+  transportBias freq_cis_target freq_cis_source interaction_cis interaction_trans interaction_cis interaction_trans
+
+theorem haplotypeTransportBias_eq_zero
+    (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ) :
+    haplotypeTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans = 0 := by
+  unfold haplotypeTransportBias transportBias phasePredictionError
+  have h_inner : freq_cis_target * (interaction_cis - interaction_cis) ^ 2 +
+      (1 - freq_cis_target) * (interaction_trans - interaction_trans) ^ 2 -
+      (freq_cis_source * (interaction_cis - interaction_cis) ^ 2 +
+        (1 - freq_cis_source) * (interaction_trans - interaction_trans) ^ 2) = 0 := by
+    ring
+  rw [h_inner]
+  exact abs_zero
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -267,7 +298,7 @@ theorem dosagePhaseMisspecificationError_eq
     (freq_cis interaction_cis interaction_trans : ℝ) :
     dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans =
       freq_cis * (1 - freq_cis) * (interaction_cis - interaction_trans) ^ 2 := by
-  unfold dosagePhaseMisspecificationError averagePhaseInteraction
+  unfold dosagePhaseMisspecificationError phasePredictionError averagePhaseInteraction
   ring
 
 /-- The structural dosage transport bias is exactly the shift in phase
@@ -288,9 +319,9 @@ theorem compound_het_not_captured_by_dosage
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -334,9 +365,9 @@ section HaplotypePGS
 theorem haplotype_pgs_at_least_snp
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError_eq_zero]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -350,9 +381,9 @@ theorem haplotype_pgs_more_portable_for_cis
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
+    haplotypeTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans < dosageTransportBias
       freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+  rw [dosageTransportBias_eq, haplotypeTransportBias_eq_zero]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
This PR fixes instances of "ex post facto construction" specification gaming within `proofs/Calibrator/HaplotypeTheory.lean`.

The bounding values for structural errors of haplotype-based models (`haplotypePhasePredictionError` and `haplotypeTransportBias`) were trivially set to `0`. This commit refactors these into robust parameterized definitions measuring discrepancies based on explicit trait configurations (`phasePredictionError` and `transportBias`), and defines theorems actively proving they equate to zero under correct estimation, which guarantees that downstream comparison theorem `compound_het_not_captured_by_dosage` is actually deriving a rigorous inequality rather than relying on a mathematically vacuous statement.

---
*PR created automatically by Jules for task [14956550647371394661](https://jules.google.com/task/14956550647371394661) started by @SauersML*