### PR TITLE
Fix vacuous verification in HaplotypeTheory

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -245,8 +245,10 @@ noncomputable def dosagePhaseMisspecificationError
 
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+noncomputable def haplotypePhasePredictionError
+    (freq_cis interaction_cis interaction_trans pred_cis pred_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - pred_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - pred_trans) ^ 2
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +260,10 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias
+    (freq_cis_target interaction_cis interaction_trans pred_cis pred_trans : ℝ) : ℝ :=
+  |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
+    (freq_cis_target * pred_cis + (1 - freq_cis_target) * pred_trans)|
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -285,12 +289,19 @@ theorem dosageTransportBias_eq
   rw [h_factor, abs_mul]
 
 theorem compound_het_not_captured_by_dosage
-    (freq_cis interaction_cis interaction_trans : ℝ)
+    (freq_cis interaction_cis interaction_trans pred_cis pred_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
-    (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    (h_phase_gap : interaction_cis ≠ interaction_trans)
+    (h_pred_cis : pred_cis = interaction_cis)
+    (h_pred_trans : pred_trans = interaction_trans) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans pred_cis pred_trans <
+      dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
   rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [h_pred_cis, h_pred_trans]
+  have h_zero : freq_cis * (interaction_cis - interaction_cis) ^ 2 +
+      (1 - freq_cis) * (interaction_trans - interaction_trans) ^ 2 = 0 := by ring
+  rw [h_zero]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -332,11 +343,17 @@ section HaplotypePGS
     strictly positive error whenever both cis and trans states occur and their
     effects differ. -/
 theorem haplotype_pgs_at_least_snp
-    (freq_cis interaction_cis interaction_trans : ℝ)
-    (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    (freq_cis interaction_cis interaction_trans pred_cis pred_trans : ℝ)
+    (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1)
+    (h_pred_cis : pred_cis = interaction_cis)
+    (h_pred_trans : pred_trans = interaction_trans) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans pred_cis pred_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [h_pred_cis, h_pred_trans]
+  have h_zero : freq_cis * (interaction_cis - interaction_cis) ^ 2 +
+      (1 - freq_cis) * (interaction_trans - interaction_trans) ^ 2 = 0 := by ring
+  rw [h_zero]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -347,12 +364,22 @@ theorem haplotype_pgs_at_least_snp
     the target phase-configuration frequency differs from the source. A
     phase-aware haplotype model avoids this bias. -/
 theorem haplotype_pgs_more_portable_for_cis
-    (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
+    (freq_cis_source freq_cis_target interaction_cis interaction_trans pred_cis pred_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
-    (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
-      freq_cis_source freq_cis_target interaction_cis interaction_trans := by
+    (h_phase_gap : interaction_cis ≠ interaction_trans)
+    (h_pred_cis : pred_cis = interaction_cis)
+    (h_pred_trans : pred_trans = interaction_trans) :
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans pred_cis pred_trans <
+      dosageTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans := by
   rw [dosageTransportBias_eq, haplotypeTransportBias]
+  rw [h_pred_cis, h_pred_trans]
+  unfold averagePhaseInteraction
+  have h_zero : |freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans -
+      (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans)| = 0 := by
+    have h_inner : freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans -
+        (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans) = 0 := by ring
+    rw [h_inner, abs_zero]
+  rw [h_zero]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Fixes vacuous specification gaming definitions in `HaplotypeTheory.lean`. The `haplotypePhasePredictionError` and `haplotypeTransportBias` functions were previously hardcoded to return `0` (a trivial witness). They have been rewritten to calculate errors based on predicted vs actual parameter distances. The theorems that rely on them have been updated to explicitly prove these variables evaluate to 0 strictly when the predictive model is hypothetically perfectly accurate. All proofs build and pass successfully.

---
*PR created automatically by Jules for task [2253631853187544547](https://jules.google.com/task/2253631853187544547) started by @SauersML*