### PR TITLE
Fix vacuous verification in HaplotypeTheory

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -245,8 +245,10 @@ noncomputable def dosagePhaseMisspecificationError
 
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+noncomputable def haplotypePhasePredictionError
+    (freq_cis interaction_cis interaction_trans pred_cis pred_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - pred_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - pred_trans) ^ 2
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +260,10 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias
+    (freq_cis_target interaction_cis interaction_trans pred_cis pred_trans : ℝ) : ℝ :=
+  |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
+    averagePhaseInteraction freq_cis_target pred_cis pred_trans|
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -285,12 +289,19 @@ theorem dosageTransportBias_eq
   rw [h_factor, abs_mul]
 
 theorem compound_het_not_captured_by_dosage
-    (freq_cis interaction_cis interaction_trans : ℝ)
+    (freq_cis interaction_cis interaction_trans pred_cis pred_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
-    (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    (h_phase_gap : interaction_cis ≠ interaction_trans)
+    (h_pred_cis : pred_cis = interaction_cis)
+    (h_pred_trans : pred_trans = interaction_trans) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans pred_cis pred_trans < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  have h_zero : haplotypePhasePredictionError freq_cis interaction_cis interaction_trans pred_cis pred_trans = 0 := by
+    rw [h_pred_cis, h_pred_trans]
+    unfold haplotypePhasePredictionError
+    ring
+  rw [h_zero]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -332,14 +343,22 @@ section HaplotypePGS
     strictly positive error whenever both cis and trans states occur and their
     effects differ. -/
 theorem haplotype_pgs_at_least_snp
-    (freq_cis interaction_cis interaction_trans : ℝ)
-    (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    (freq_cis interaction_cis interaction_trans pred_cis pred_trans : ℝ)
+    (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1)
+    (h_pred_cis : pred_cis = interaction_cis)
+    (h_pred_trans : pred_trans = interaction_trans) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans pred_cis pred_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  have h_zero : haplotypePhasePredictionError freq_cis interaction_cis interaction_trans pred_cis pred_trans = 0 := by
+    rw [h_pred_cis, h_pred_trans]
+    unfold haplotypePhasePredictionError
+    ring
+  rw [h_zero]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
+
 
 /-- **Haplotype PGS portability can be better.**
     If the causal mechanism acts through cis/trans haplotype configuration,
@@ -347,12 +366,21 @@ theorem haplotype_pgs_at_least_snp
     the target phase-configuration frequency differs from the source. A
     phase-aware haplotype model avoids this bias. -/
 theorem haplotype_pgs_more_portable_for_cis
-    (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
+    (freq_cis_source freq_cis_target interaction_cis interaction_trans pred_cis pred_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
-    (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
-      freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+    (h_phase_gap : interaction_cis ≠ interaction_trans)
+    (h_pred_cis : pred_cis = interaction_cis)
+    (h_pred_trans : pred_trans = interaction_trans) :
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans pred_cis pred_trans < dosageTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans := by
+  rw [dosageTransportBias_eq]
+  have h_zero : haplotypeTransportBias freq_cis_target interaction_cis interaction_trans pred_cis pred_trans = 0 := by
+    rw [h_pred_cis, h_pred_trans]
+    unfold haplotypeTransportBias averagePhaseInteraction
+    have h_inner : freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans - (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans) = 0 := sub_self _
+    rw [h_inner]
+    have h_abs : |(0 : ℝ)| = 0 := abs_zero
+    rw [h_abs]
+  rw [h_zero]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))
@@ -449,7 +477,7 @@ end PhasingErrors
 
 
 /-!
-## Local Ancestry Haplotype Effects
+## Local Ancestry Haplotypes
 
 In admixed populations, the haplotype effect depends on the
 local ancestry of the genomic segment.


### PR DESCRIPTION
Fix specification gaming with 0 assignments and reparameterize upstream definitions to accept proper predictions.

---
*PR created automatically by Jules for task [10015730007980464342](https://jules.google.com/task/10015730007980464342) started by @SauersML*