### PR TITLE
Refactor vacuous definitions in HaplotypeTheory.lean

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -245,8 +245,10 @@ noncomputable def dosagePhaseMisspecificationError
 
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+noncomputable def haplotypePhasePredictionError
+    (freq_cis interaction_cis interaction_trans pred_cis pred_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - pred_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - pred_trans) ^ 2
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +260,12 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias
+    (freq_cis_source freq_cis_target interaction_cis interaction_trans pred_cis pred_trans : ℝ) : ℝ :=
+  |(freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans) -
+   (freq_cis_target * pred_cis + (1 - freq_cis_target) * pred_trans) -
+   ((freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans) -
+    (freq_cis_source * pred_cis + (1 - freq_cis_source) * pred_trans))|
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -285,12 +291,19 @@ theorem dosageTransportBias_eq
   rw [h_factor, abs_mul]
 
 theorem compound_het_not_captured_by_dosage
-    (freq_cis interaction_cis interaction_trans : ℝ)
+    (freq_cis interaction_cis interaction_trans pred_cis pred_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
-    (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    (h_phase_gap : interaction_cis ≠ interaction_trans)
+    (h_pred_cis : pred_cis = interaction_cis)
+    (h_pred_trans : pred_trans = interaction_trans) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans pred_cis pred_trans < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  have h_hap_zero : haplotypePhasePredictionError freq_cis interaction_cis interaction_trans pred_cis pred_trans = 0 := by
+    rw [h_pred_cis, h_pred_trans]
+    unfold haplotypePhasePredictionError
+    ring
+  rw [h_hap_zero]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -332,11 +345,18 @@ section HaplotypePGS
     strictly positive error whenever both cis and trans states occur and their
     effects differ. -/
 theorem haplotype_pgs_at_least_snp
-    (freq_cis interaction_cis interaction_trans : ℝ)
-    (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    (freq_cis interaction_cis interaction_trans pred_cis pred_trans : ℝ)
+    (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1)
+    (h_pred_cis : pred_cis = interaction_cis)
+    (h_pred_trans : pred_trans = interaction_trans) :
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans pred_cis pred_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  have h_hap_zero : haplotypePhasePredictionError freq_cis interaction_cis interaction_trans pred_cis pred_trans = 0 := by
+    rw [h_pred_cis, h_pred_trans]
+    unfold haplotypePhasePredictionError
+    ring
+  rw [h_hap_zero]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -347,12 +367,23 @@ theorem haplotype_pgs_at_least_snp
     the target phase-configuration frequency differs from the source. A
     phase-aware haplotype model avoids this bias. -/
 theorem haplotype_pgs_more_portable_for_cis
-    (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
+    (freq_cis_source freq_cis_target interaction_cis interaction_trans pred_cis pred_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
-    (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
+    (h_phase_gap : interaction_cis ≠ interaction_trans)
+    (h_pred_cis : pred_cis = interaction_cis)
+    (h_pred_trans : pred_trans = interaction_trans) :
+    haplotypeTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans pred_cis pred_trans < dosageTransportBias
       freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+  rw [dosageTransportBias_eq]
+  have h_hap_zero : haplotypeTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans pred_cis pred_trans = 0 := by
+    rw [h_pred_cis, h_pred_trans]
+    unfold haplotypeTransportBias
+    have h_inner : (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans) -
+      (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans) -
+      ((freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans) -
+      (freq_cis_source * interaction_cis + (1 - freq_cis_source) * interaction_trans)) = 0 := by ring
+    rw [h_inner, abs_zero]
+  rw [h_hap_zero]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
This PR addresses specification gaming in `proofs/Calibrator/HaplotypeTheory.lean`.

1. Replaced the vacuous definition `haplotypePhasePredictionError := 0` with an explicit formula quantifying the structural phase-misspecification error `freq_cis * (interaction_cis - pred_cis)^2 + (1 - freq_cis) * (interaction_trans - pred_trans)^2`.
2. Updated the definition `haplotypeTransportBias := 0` to use a parameterized structural formula tracking the difference between populations over the explicit prediction targets.
3. Updated the proof bodies of downstream dependent theorems `compound_het_not_captured_by_dosage`, `haplotype_pgs_at_least_snp`, and `haplotype_pgs_more_portable_for_cis` to explicitly define constraints bounding the predictors to accurately replace the `0` constants using pure algebraic manipulation (`ring`).

These changes convert vacuous "ex post facto" tautologies into robust, parameterized algebraic theorems showing under what conditions error evaluates to `0`.

---
*PR created automatically by Jules for task [11208291964988539284](https://jules.google.com/task/11208291964988539284) started by @SauersML*