### PR TITLE
Refactor haplotype tracking defs to prevent vacuous verification

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -245,8 +245,10 @@ noncomputable def dosagePhaseMisspecificationError
 
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+noncomputable def haplotypePhasePredictionError
+    (freq_cis interaction_cis interaction_trans predicted_cis predicted_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - predicted_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - predicted_trans) ^ 2
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +260,10 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias
+    (freq_cis_target interaction_cis interaction_trans predicted_cis predicted_trans : ℝ) : ℝ :=
+  |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
+    averagePhaseInteraction freq_cis_target predicted_cis predicted_trans|
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -285,12 +289,20 @@ theorem dosageTransportBias_eq
   rw [h_factor, abs_mul]
 
 theorem compound_het_not_captured_by_dosage
-    (freq_cis interaction_cis interaction_trans : ℝ)
+    (freq_cis interaction_cis interaction_trans predicted_cis predicted_trans : ℝ)
+    (h_pred_cis : predicted_cis = interaction_cis)
+    (h_pred_trans : predicted_trans = interaction_trans)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans predicted_cis predicted_trans <
+      dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  have h_zero : haplotypePhasePredictionError freq_cis interaction_cis interaction_trans predicted_cis predicted_trans = 0 := by
+    rw [h_pred_cis, h_pred_trans]
+    unfold haplotypePhasePredictionError
+    ring
+  rw [h_zero]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -332,11 +344,18 @@ section HaplotypePGS
     strictly positive error whenever both cis and trans states occur and their
     effects differ. -/
 theorem haplotype_pgs_at_least_snp
-    (freq_cis interaction_cis interaction_trans : ℝ)
+    (freq_cis interaction_cis interaction_trans predicted_cis predicted_trans : ℝ)
+    (h_pred_cis : predicted_cis = interaction_cis)
+    (h_pred_trans : predicted_trans = interaction_trans)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans predicted_cis predicted_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  have h_zero : haplotypePhasePredictionError freq_cis interaction_cis interaction_trans predicted_cis predicted_trans = 0 := by
+    rw [h_pred_cis, h_pred_trans]
+    unfold haplotypePhasePredictionError
+    ring
+  rw [h_zero]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -347,12 +366,22 @@ theorem haplotype_pgs_at_least_snp
     the target phase-configuration frequency differs from the source. A
     phase-aware haplotype model avoids this bias. -/
 theorem haplotype_pgs_more_portable_for_cis
-    (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
+    (freq_cis_source freq_cis_target interaction_cis interaction_trans predicted_cis predicted_trans : ℝ)
+    (h_pred_cis : predicted_cis = interaction_cis)
+    (h_pred_trans : predicted_trans = interaction_trans)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans predicted_cis predicted_trans < dosageTransportBias
       freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+  rw [dosageTransportBias_eq]
+  have h_zero : haplotypeTransportBias freq_cis_target interaction_cis interaction_trans predicted_cis predicted_trans = 0 := by
+    rw [h_pred_cis, h_pred_trans]
+    unfold haplotypeTransportBias averagePhaseInteraction
+    have h_inner : freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans -
+      (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans) = 0 := by ring
+    rw [h_inner]
+    exact abs_zero
+  rw [h_zero]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
This patch eliminates vacuous verification in `proofs/Calibrator/HaplotypeTheory.lean`. The `haplotypePhasePredictionError` and `haplotypeTransportBias` definitions were previously hardcoded to `0`. They have been refactored to take explicit parameters mirroring the structural mathematical formula of phase interactions and transport biases. Downstream theorems were updated to mathematically prove that under perfect structural knowledge, these values evaluate to 0, ensuring formal mathematical soundness without trivial constants.

---
*PR created automatically by Jules for task [4282838374351519678](https://jules.google.com/task/4282838374351519678) started by @SauersML*