### PR TITLE
Fix Vacuous Definitions in HaplotypeTheory

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -245,8 +245,10 @@ noncomputable def dosagePhaseMisspecificationError
 
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+noncomputable def haplotypePhasePredictionError
+    (freq_cis interaction_cis interaction_trans pred_cis pred_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - pred_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - pred_trans) ^ 2
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +260,9 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias
+    (freq_cis_target interaction_cis interaction_trans pred_interaction : ℝ) : ℝ :=
+  |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans - pred_interaction|
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -288,9 +291,13 @@ theorem compound_het_not_captured_by_dosage
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans interaction_cis interaction_trans < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  have h_hap : haplotypePhasePredictionError freq_cis interaction_cis interaction_trans interaction_cis interaction_trans = 0 := by
+    unfold haplotypePhasePredictionError
+    ring
+  rw [h_hap]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -334,9 +341,13 @@ section HaplotypePGS
 theorem haplotype_pgs_at_least_snp
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans interaction_cis interaction_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  have h_hap : haplotypePhasePredictionError freq_cis interaction_cis interaction_trans interaction_cis interaction_trans = 0 := by
+    unfold haplotypePhasePredictionError
+    ring
+  rw [h_hap]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -350,9 +361,14 @@ theorem haplotype_pgs_more_portable_for_cis
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans (averagePhaseInteraction freq_cis_target interaction_cis interaction_trans) < dosageTransportBias
       freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+  rw [dosageTransportBias_eq]
+  have h_hap : haplotypeTransportBias freq_cis_target interaction_cis interaction_trans (averagePhaseInteraction freq_cis_target interaction_cis interaction_trans) = 0 := by
+    unfold haplotypeTransportBias
+    have h_inner : averagePhaseInteraction freq_cis_target interaction_cis interaction_trans - averagePhaseInteraction freq_cis_target interaction_cis interaction_trans = 0 := sub_self _
+    rw [h_inner, abs_zero]
+  rw [h_hap]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Refactored vacuous zero definitions in `HaplotypeTheory.lean` to correct specification gaming.

- Modified `haplotypePhasePredictionError` to structurally evaluate generic `pred_cis` and `pred_trans` predictors.
- Modified `haplotypeTransportBias` to structurally evaluate an abstract `pred_interaction`.
- Updated all theorems relying on these definitions (`compound_het_not_captured_by_dosage`, `haplotype_pgs_at_least_snp`, `haplotype_pgs_more_portable_for_cis`) to pass true values as the prediction arguments, naturally demonstrating structural zero error.

---
*PR created automatically by Jules for task [2032652375033827232](https://jules.google.com/task/2032652375033827232) started by @SauersML*