### PR TITLE
Fix vacuous specification gaming in HaplotypeTheory

### DIFF
--- a/proofs/Calibrator/HaplotypeTheory.lean
+++ b/proofs/Calibrator/HaplotypeTheory.lean
@@ -245,8 +245,10 @@ noncomputable def dosagePhaseMisspecificationError
 
 /-- A phase-aware haplotype predictor that tracks cis/trans configuration has no
 structural phase-misspecification error. -/
-noncomputable def haplotypePhasePredictionError : ℝ :=
-  0
+noncomputable def haplotypePhasePredictionError
+    (freq_cis interaction_cis interaction_trans pred_cis pred_trans : ℝ) : ℝ :=
+  freq_cis * (interaction_cis - pred_cis) ^ 2 +
+    (1 - freq_cis) * (interaction_trans - pred_trans) ^ 2
 
 /-- Transport bias from carrying a source-trained dosage approximation into a
 target population whose cis/trans configuration frequency differs. -/
@@ -258,8 +260,10 @@ noncomputable def dosageTransportBias
 /-- A phase-aware haplotype model transports without this structural bias when
 the cis/trans effects themselves are portable and only configuration
 frequencies differ. -/
-noncomputable def haplotypeTransportBias : ℝ :=
-  0
+noncomputable def haplotypeTransportBias
+    (freq_cis_target interaction_cis interaction_trans pred_cis pred_trans : ℝ) : ℝ :=
+  |averagePhaseInteraction freq_cis_target interaction_cis interaction_trans -
+    averagePhaseInteraction freq_cis_target pred_cis pred_trans|
 
 /-- The dosage-only phase-misspecification error has the exact variance form
 `f(1-f)(δ_cis - δ_trans)^2`. -/
@@ -288,9 +292,14 @@ theorem compound_het_not_captured_by_dosage
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq : 0 < freq_cis ∧ freq_cis < 1)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypePhasePredictionError < dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans interaction_cis interaction_trans <
+      dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
   rcases h_freq with ⟨h_freq_pos, h_freq_lt_one⟩
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  have h_zero : haplotypePhasePredictionError freq_cis interaction_cis interaction_trans interaction_cis interaction_trans = 0 := by
+    unfold haplotypePhasePredictionError
+    ring
+  rw [h_zero]
   have h_gap_sq : 0 < (interaction_cis - interaction_trans) ^ 2 := by
     exact sq_pos_of_ne_zero (sub_ne_zero.mpr h_phase_gap)
   have h_mix : 0 < freq_cis * (1 - freq_cis) := by
@@ -334,9 +343,13 @@ section HaplotypePGS
 theorem haplotype_pgs_at_least_snp
     (freq_cis interaction_cis interaction_trans : ℝ)
     (h_freq_nonneg : 0 ≤ freq_cis) (h_freq_le_one : freq_cis ≤ 1) :
-    haplotypePhasePredictionError ≤
+    haplotypePhasePredictionError freq_cis interaction_cis interaction_trans interaction_cis interaction_trans ≤
       dosagePhaseMisspecificationError freq_cis interaction_cis interaction_trans := by
-  rw [dosagePhaseMisspecificationError_eq, haplotypePhasePredictionError]
+  rw [dosagePhaseMisspecificationError_eq]
+  have h_zero : haplotypePhasePredictionError freq_cis interaction_cis interaction_trans interaction_cis interaction_trans = 0 := by
+    unfold haplotypePhasePredictionError
+    ring
+  rw [h_zero]
   have h_mix_nonneg : 0 ≤ freq_cis * (1 - freq_cis) := by
     exact mul_nonneg h_freq_nonneg (sub_nonneg.mpr h_freq_le_one)
   exact mul_nonneg h_mix_nonneg (sq_nonneg _)
@@ -350,9 +363,15 @@ theorem haplotype_pgs_more_portable_for_cis
     (freq_cis_source freq_cis_target interaction_cis interaction_trans : ℝ)
     (h_freq_shift : freq_cis_source ≠ freq_cis_target)
     (h_phase_gap : interaction_cis ≠ interaction_trans) :
-    haplotypeTransportBias < dosageTransportBias
-      freq_cis_source freq_cis_target interaction_cis interaction_trans := by
-  rw [dosageTransportBias_eq, haplotypeTransportBias]
+    haplotypeTransportBias freq_cis_target interaction_cis interaction_trans interaction_cis interaction_trans <
+      dosageTransportBias freq_cis_source freq_cis_target interaction_cis interaction_trans := by
+  rw [dosageTransportBias_eq]
+  have h_zero : haplotypeTransportBias freq_cis_target interaction_cis interaction_trans interaction_cis interaction_trans = 0 := by
+    unfold haplotypeTransportBias averagePhaseInteraction
+    have h_inner : freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans -
+      (freq_cis_target * interaction_cis + (1 - freq_cis_target) * interaction_trans) = 0 := sub_self _
+    rw [h_inner, abs_zero]
+  rw [h_zero]
   exact mul_pos
     (abs_pos.mpr (sub_ne_zero.mpr h_freq_shift.symm))
     (abs_pos.mpr (sub_ne_zero.mpr h_phase_gap))


### PR DESCRIPTION
Fix vacuous specification gaming in HaplotypeTheory

The Lean formalizations for `haplotypePhasePredictionError` and `haplotypeTransportBias` previously used "trivial witness" specification gaming by being hardcoded to 0.

This commit updates their definitions to parameterize over cis/trans interaction models correctly, mathematically computing the explicit variance gap and proving that, for correct configuration modeling, the bias/error structurally simplifies to exactly 0 rather than being 0 by fiat.

Downstream theorems `compound_het_not_captured_by_dosage`, `haplotype_pgs_at_least_snp`, and `haplotype_pgs_more_portable_for_cis` were updated to correctly pass the optimal predictions through the new definition parameters to rigorously complete the proofs.

---
*PR created automatically by Jules for task [8434856494162242061](https://jules.google.com/task/8434856494162242061) started by @SauersML*