### PR TITLE
fix(calibrator): remove vacuous specification gaming in conditional expectation decomposition

### DIFF
--- a/proofs/Calibrator/PowerAnalysis.lean
+++ b/proofs/Calibrator/PowerAnalysis.lean
@@ -329,10 +329,11 @@ theorem truncationBias_small_for_large_signal (se : ℝ) (h_se : 0 < se) :
     This follows from linearity of conditional expectation applied
     to the decomposition β̂ = β + ε. -/
 theorem conditional_expectation_decomposition
-    (true_beta : ℝ) (conditional_noise_mean : ℝ) :
-    true_beta + conditional_noise_mean =
-      true_beta + conditional_noise_mean := by
-  ring
+    (m : GWASObservationModel) (E : (ℝ → ℝ) → ℝ)
+    (h_linear : ∀ c f, E (fun x => c + f x) = c + E f) :
+    E (fun epsilon => m.observedBeta epsilon) = m.true_beta + E (fun epsilon => epsilon) := by
+  unfold GWASObservationModel.observedBeta
+  rw [h_linear]
 
 /-- **Derivation: winner's curse bias vanishes in the high-signal regime.**
     Combining the model (β̂ = β + ε) with the exponential proxy


### PR DESCRIPTION
Addresses a "begging the question" specification gaming instance in `proofs/Calibrator/PowerAnalysis.lean`.

The previous implementation of `conditional_expectation_decomposition` proved a vacuous statement:
```lean
theorem conditional_expectation_decomposition
    (true_beta : ℝ) (conditional_noise_mean : ℝ) :
    true_beta + conditional_noise_mean =
      true_beta + conditional_noise_mean := by
  ring
```

This patch rigorously constructs the model by introducing an abstract expectation operator `E` and a linearity hypothesis, mathematically mapping the `GWASObservationModel` true beta and noise to the expected observed beta without relying on tautology.

---
*PR created automatically by Jules for task [2377242063869393325](https://jules.google.com/task/2377242063869393325) started by @SauersML*