### PR TITLE
Fix vacuous verification in conditional_expectation_decomposition

### DIFF
--- a/proofs/Calibrator/PowerAnalysis.lean
+++ b/proofs/Calibrator/PowerAnalysis.lean
@@ -329,10 +329,12 @@ theorem truncationBias_small_for_large_signal (se : ℝ) (h_se : 0 < se) :
     This follows from linearity of conditional expectation applied
     to the decomposition β̂ = β + ε. -/
 theorem conditional_expectation_decomposition
-    (true_beta : ℝ) (conditional_noise_mean : ℝ) :
-    true_beta + conditional_noise_mean =
-      true_beta + conditional_noise_mean := by
-  ring
+    (m : GWASObservationModel)
+    (E : (ℝ → ℝ) → ℝ)
+    (h_linear : ∀ c f, E (fun x => c + f x) = c + E f) :
+    E (fun ε => m.observedBeta ε) = m.true_beta + E (fun ε => ε) := by
+  unfold GWASObservationModel.observedBeta
+  rw [h_linear m.true_beta (fun ε => ε)]
 
 /-- **Derivation: winner's curse bias vanishes in the high-signal regime.**
     Combining the model (β̂ = β + ε) with the exponential proxy


### PR DESCRIPTION
Fix vacuous verification in conditional_expectation_decomposition

Replaced a trivial tautology (`true_beta + conditional_noise_mean = true_beta + conditional_noise_mean`) with a rigorous mathematical formulation using an explicit abstract expectation operator and linearity of expectation.

This accurately models the definition and meaning behind the GWASObservationModel decomposition and effectively removes the specification gaming in Calibrator/PowerAnalysis.lean.

---
*PR created automatically by Jules for task [6415306169512698996](https://jules.google.com/task/6415306169512698996) started by @SauersML*