### PR TITLE
Fix vacuous verification in conditional_expectation_decomposition

### DIFF
--- a/proofs/Calibrator/PowerAnalysis.lean
+++ b/proofs/Calibrator/PowerAnalysis.lean
@@ -329,10 +329,11 @@ theorem truncationBias_small_for_large_signal (se : ℝ) (h_se : 0 < se) :
     This follows from linearity of conditional expectation applied
     to the decomposition β̂ = β + ε. -/
 theorem conditional_expectation_decomposition
-    (true_beta : ℝ) (conditional_noise_mean : ℝ) :
-    true_beta + conditional_noise_mean =
-      true_beta + conditional_noise_mean := by
-  ring
+    (E : (ℝ → ℝ) → ℝ)
+    (h_linear : ∀ c f, E (fun x => c + f x) = c + E f)
+    (true_beta : ℝ) :
+    E (fun epsilon => true_beta + epsilon) = true_beta + E (fun epsilon => epsilon) := by
+  rw [h_linear]
 
 /-- **Derivation: winner's curse bias vanishes in the high-signal regime.**
     Combining the model (β̂ = β + ε) with the exponential proxy


### PR DESCRIPTION
Fixes specification gaming in Calibrator/PowerAnalysis.lean where the conditional_expectation_decomposition theorem was vacuously verified.

---
*PR created automatically by Jules for task [3783798048948436847](https://jules.google.com/task/3783798048948436847) started by @SauersML*