### PR TITLE
Fix vacuous verification in `neutral_expected_shift_zero` theorem

### DIFF
--- a/proofs/Calibrator/SelectionArchitecture.lean
+++ b/proofs/Calibrator/SelectionArchitecture.lean
@@ -475,10 +475,21 @@ noncomputable def polygenicAdaptationShift
 /-- **Under neutral drift, expected shift is zero.**
     E[Δpᵢ] = 0 under drift, so E[Δμ] = 0. -/
 theorem neutral_expected_shift_zero
-    {m : ℕ} (β : Fin m → ℝ) :
-    polygenicAdaptationShift β (fun _ => 0) = 0 := by
+    {Ω : Type*} {m : ℕ} (E : ExpFunctional Ω) (β : Fin m → ℝ) (Δp : Fin m → Ω → ℝ)
+    (h_drift : ∀ i, E (Δp i) = 0) :
+    E (fun ω => polygenicAdaptationShift β (fun i => Δp i ω)) = 0 := by
   unfold polygenicAdaptationShift
-  simp
+  have h_inner : (fun ω => ∑ i, β i * Δp i ω) = ∑ i, (β i) • (Δp i) := by
+    ext ω
+    simp
+  rw [h_inner]
+  rw [ExpFunctional.eval_sum]
+  have h_zero : ∑ i : Fin m, E (β i • Δp i) = 0 := by
+    apply Finset.sum_eq_zero
+    intro i _
+    rw [E.smul_eval, h_drift i]
+    ring
+  exact h_zero
 
 /-- **Under selection, shift is nonzero and directional.**
     If selection favors higher trait values, Δpᵢ > 0 for positive-effect


### PR DESCRIPTION
This PR addresses a specification gaming issue in `proofs/Calibrator/SelectionArchitecture.lean`.

Previously, the `neutral_expected_shift_zero` theorem trivially demonstrated that the expected shift is zero by passing a hardcoded zero function (`fun _ => 0`) directly into the hypothesis. This vacuous verification bypassed the mathematical complexity of expectation over random variables.

The fix introduces the `ExpFunctional` operator to explicitly model `Δp` as a random variable (`Fin m → Ω → ℝ`), assuming only that the *expectation* of drift is zero (`E (Δp i) = 0`). It then mathematically proves that the overall expected shift is zero using the linearity of the expectation functional (`ExpFunctional.eval_sum` and `smul_eval`). This strengthens the codebase by replacing a tautological statement with a robust proof. All tests and builds pass successfully.

---
*PR created automatically by Jules for task [2168581003442339971](https://jules.google.com/task/2168581003442339971) started by @SauersML*