### PR TITLE
Refactor AncestryCalibration theorems to fix vacuous verification

### DIFF
--- a/proofs/Calibrator/AncestryCalibration.lean
+++ b/proofs/Calibrator/AncestryCalibration.lean
@@ -175,42 +175,59 @@ theorem more_target_data_reduces_mse
     As n_T → ∞, σ²_extra/n_T → 0, so target-only wins (bias² > 0). -/
 theorem transfer_beats_target_only
     (σ_sq bias_sq σ_extra_sq : ℝ) (n_T : ℝ)
-    (h_σ : 0 < σ_sq) (h_bias : 0 < bias_sq)
-    (h_extra : 0 < σ_extra_sq) (h_n : 0 < n_T)
-    (h_small_n : n_T < σ_extra_sq / bias_sq) :
+    (_h_σ : 0 < σ_sq) (h_bias : 0 < bias_sq)
+    (_h_extra : 0 < σ_extra_sq) (h_n : 0 < n_T) :
     let mse_transfer := σ_sq / n_T + bias_sq
     let mse_target := (σ_sq + σ_extra_sq) / n_T
-    mse_transfer < mse_target := by
-  simp only
-  -- From h_small_n: n_T < σ_extra_sq / bias_sq
-  -- Multiply both sides by bias_sq > 0: n_T * bias_sq < σ_extra_sq
-  -- Divide by n_T > 0: bias_sq < σ_extra_sq / n_T
-  -- Then σ_sq/n_T + bias_sq < σ_sq/n_T + σ_extra_sq/n_T = (σ_sq + σ_extra_sq)/n_T
-  have h_prod : bias_sq * n_T < σ_extra_sq := by
-    rw [mul_comm]
-    exact (lt_div_iff₀ h_bias).mp h_small_n
-  have h_key : bias_sq < σ_extra_sq / n_T := by
-    exact (lt_div_iff₀ h_n).2 h_prod
-  rw [add_div]; linarith
+    (n_T < σ_extra_sq / bias_sq ↔ mse_transfer < mse_target) := by
+  dsimp
+  constructor
+  · intro h_small_n
+    have h_prod : bias_sq * n_T < σ_extra_sq := by
+      rw [mul_comm]
+      exact (lt_div_iff₀ h_bias).mp h_small_n
+    have h_key : bias_sq < σ_extra_sq / n_T := by
+      exact (lt_div_iff₀ h_n).2 h_prod
+    rw [add_div]; linarith
+  · intro h_lt
+    rw [add_div] at h_lt
+    have h_key : bias_sq < σ_extra_sq / n_T := by linarith
+    have h_prod : n_T * bias_sq < σ_extra_sq := by
+      have : bias_sq * n_T < σ_extra_sq := (lt_div_iff₀ h_n).mp h_key
+      rwa [mul_comm] at this
+    exact (lt_div_iff₀ h_bias).mpr h_prod
 
 /-- **Critical sample size for transfer benefit.**
     Transfer learning helps when n_T < n_crit, where
     n_crit depends on the portability ratio and source GWAS power.
-    Beyond n_crit, target-only GWAS is sufficient.
-
-    General statement: given any n_lo and n_hi where transfer beats target
-    at n_lo but target beats transfer at n_hi, a crossover point exists
-    in between. -/
+    Beyond n_crit, target-only GWAS is sufficient. -/
 theorem critical_sample_size_exists
-    (mse_transfer mse_target : ℝ → ℝ) (n_lo n_hi : ℝ)
-    (h_transfer_decreasing : ∀ n₁ n₂ : ℝ, 0 < n₁ → n₁ < n₂ → mse_transfer n₂ < mse_transfer n₁)
-    (h_target_decreasing : ∀ n₁ n₂ : ℝ, 0 < n₁ → n₁ < n₂ → mse_target n₂ < mse_target n₁)
-    (h_lo_pos : 0 < n_lo) (h_range : n_lo < n_hi)
-    (h_small_n : mse_transfer n_lo < mse_target n_lo)
-    (h_large_n : mse_target n_hi < mse_transfer n_hi) :
-    -- There exists a crossover point
-    ∃ n_crit : ℝ, n_lo < n_crit ∧ n_crit < n_hi := by
-  exact ⟨(n_lo + n_hi) / 2, by linarith, by linarith⟩
+    (σ_sq bias_sq σ_extra_sq : ℝ)
+    (_h_σ : 0 < σ_sq) (h_bias : 0 < bias_sq) (h_extra : 0 < σ_extra_sq) :
+    ∃ n_crit : ℝ, 0 < n_crit ∧
+      ∀ n_T : ℝ, 0 < n_T →
+        (let mse_transfer := σ_sq / n_T + bias_sq
+         let mse_target := (σ_sq + σ_extra_sq) / n_T
+         (n_T < n_crit ↔ mse_transfer < mse_target)) := by
+  use σ_extra_sq / bias_sq
+  refine ⟨div_pos h_extra h_bias, ?_⟩
+  intro n_T h_n
+  dsimp
+  constructor
+  · intro h_lt
+    have h1 : n_T * bias_sq < σ_extra_sq := (lt_div_iff₀ h_bias).mp h_lt
+    have h2 : bias_sq < σ_extra_sq / n_T := (lt_div_iff₀ h_n).mpr (by rwa [mul_comm])
+    have h3 : (σ_sq + σ_extra_sq) / n_T = σ_sq / n_T + σ_extra_sq / n_T := add_div _ _ _
+    rw [h3]
+    linarith
+  · intro h_lt
+    have h3 : (σ_sq + σ_extra_sq) / n_T = σ_sq / n_T + σ_extra_sq / n_T := add_div _ _ _
+    rw [h3] at h_lt
+    have h2 : bias_sq < σ_extra_sq / n_T := by linarith
+    have h1 : n_T * bias_sq < σ_extra_sq := by
+      have : bias_sq * n_T < σ_extra_sq := (lt_div_iff₀ h_n).mp h2
+      rwa [mul_comm] at this
+    exact (lt_div_iff₀ h_bias).mpr h1
 
 /-- **Multi-ancestry meta-analysis is optimal.**
     Combining GWAS data from multiple ancestries via inverse-variance


### PR DESCRIPTION
Replaces instances of specification gaming in the `AncestryCalibration.lean` proofs where hardcoded existential witnesses satisfied loose inequalities without computing meaningful constraints. Specifically, it explicitly derives and proves the crossover point for statistical estimators, strengthening the properties to true equivalences.

---
*PR created automatically by Jules for task [3020645563703751087](https://jules.google.com/task/3020645563703751087) started by @SauersML*