### PR TITLE
fix: Remove vacuous verification from differential_ascertainment_artifact

### DIFF
--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -327,14 +327,12 @@ theorem collider_attenuates_association (m : ColliderModel) :
     the apparent portability drop includes an ascertainment component. -/
 theorem differential_ascertainment_artifact
     (r2_source_pop r2_target_pop r2_source_asc r2_target_asc : ℝ)
-    (h_source_asc : r2_source_asc < r2_source_pop)
-    (h_target_asc : r2_target_asc < r2_target_pop)
+    (_h_source_asc : r2_source_asc < r2_source_pop)
+    (_h_target_asc : r2_target_asc < r2_target_pop)
     -- Different ascertainment severity
-    (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
+    (h_diff_severity : r2_source_pop - r2_source_asc < r2_target_pop - r2_target_asc) :
     -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
+    r2_source_pop - r2_target_pop < r2_source_asc - r2_target_asc := by
   linarith
 
 end ColliderBias


### PR DESCRIPTION
Refactored the `differential_ascertainment_artifact` theorem to remove specification gaming where an impossible condition led to `False`. The proof now cleanly verifies the actual inequality relationship directly, silencing 'unused variable' warnings as well. Code compiles cleanly.

---
*PR created automatically by Jules for task [1214646575613546874](https://jules.google.com/task/1214646575613546874) started by @SauersML*