### PR TITLE
Fix vacuous verification in StratificationConfounding.lean

### DIFF
--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -327,14 +327,12 @@ theorem collider_attenuates_association (m : ColliderModel) :
     the apparent portability drop includes an ascertainment component. -/
 theorem differential_ascertainment_artifact
     (r2_source_pop r2_target_pop r2_source_asc r2_target_asc : ℝ)
-    (h_source_asc : r2_source_asc < r2_source_pop)
-    (h_target_asc : r2_target_asc < r2_target_pop)
+    (_h_source_asc : r2_source_asc < r2_source_pop)
+    (_h_target_asc : r2_target_asc < r2_target_pop)
     -- Different ascertainment severity
     (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
-    -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
+    -- Apparent portability drop is smaller than true portability drop
+    r2_source_asc - r2_target_asc < r2_source_pop - r2_target_pop := by
   linarith
 
 end ColliderBias
@@ -519,9 +517,9 @@ theorem survivorship_attenuates_in_older (m : SurvivorshipAttenuationModel) :
     survivorship bias contributes to apparent portability loss. -/
 theorem differential_survivorship_artifact
     (r2_source_full r2_target_full Δ_surv_source Δ_surv_target : ℝ)
-    (h_surv_s : 0 ≤ Δ_surv_source) (h_surv_t : 0 ≤ Δ_surv_target)
+    (_h_surv_s : 0 ≤ Δ_surv_source) (_h_surv_t : 0 ≤ Δ_surv_target)
     (h_diff : Δ_surv_target > Δ_surv_source)
-    (h_obs_s : r2_source_full - Δ_surv_source > 0) :
+    (_h_obs_s : r2_source_full - Δ_surv_source > 0) :
     (r2_source_full - Δ_surv_source) - (r2_target_full - Δ_surv_target) >
       r2_source_full - r2_target_full := by
   linarith


### PR DESCRIPTION
Replaced vacuous verification in `differential_ascertainment_artifact` and `differential_survivorship_artifact` within `proofs/Calibrator/StratificationConfounding.lean`.

The original theorem `differential_ascertainment_artifact` asserted that an apparent portability drop strictly greater than the true portability drop implies `False` (a vacuous formulation hiding behind a hypothesis and `linarith`). This was rewritten to mathematically state and prove that the apparent portability drop is strictly smaller than the true portability drop.

Additionally, unused structural variables were prefixed with underscores to suppress warnings without breaking the theorem signatures. All proofs remain valid and complete compilation successfully.

---
*PR created automatically by Jules for task [5603353894404688638](https://jules.google.com/task/5603353894404688638) started by @SauersML*