### PR TITLE
Eliminate vacuous verification in AncestryCalibration.lean's critical sample size theorem

### DIFF
--- a/proofs/Calibrator/AncestryCalibration.lean
+++ b/proofs/Calibrator/AncestryCalibration.lean
@@ -196,21 +196,24 @@ theorem transfer_beats_target_only
 /-- **Critical sample size for transfer benefit.**
     Transfer learning helps when n_T < n_crit, where
     n_crit depends on the portability ratio and source GWAS power.
-    Beyond n_crit, target-only GWAS is sufficient.
+    Beyond n_crit, target-only GWAS is sufficient. -/
 
-    General statement: given any n_lo and n_hi where transfer beats target
-    at n_lo but target beats transfer at n_hi, a crossover point exists
-    in between. -/
+noncomputable def mse_transfer (σ_sq bias_sq n_T : ℝ) := σ_sq / n_T + bias_sq
+noncomputable def mse_target (σ_sq σ_extra_sq n_T : ℝ) := (σ_sq + σ_extra_sq) / n_T
+
 theorem critical_sample_size_exists
-    (mse_transfer mse_target : ℝ → ℝ) (n_lo n_hi : ℝ)
-    (h_transfer_decreasing : ∀ n₁ n₂ : ℝ, 0 < n₁ → n₁ < n₂ → mse_transfer n₂ < mse_transfer n₁)
-    (h_target_decreasing : ∀ n₁ n₂ : ℝ, 0 < n₁ → n₁ < n₂ → mse_target n₂ < mse_target n₁)
-    (h_lo_pos : 0 < n_lo) (h_range : n_lo < n_hi)
-    (h_small_n : mse_transfer n_lo < mse_target n_lo)
-    (h_large_n : mse_target n_hi < mse_transfer n_hi) :
-    -- There exists a crossover point
-    ∃ n_crit : ℝ, n_lo < n_crit ∧ n_crit < n_hi := by
-  exact ⟨(n_lo + n_hi) / 2, by linarith, by linarith⟩
+    (σ_sq bias_sq σ_extra_sq : ℝ)
+    (_h_σ : 0 < σ_sq) (h_bias : 0 < bias_sq) (h_extra : 0 < σ_extra_sq) :
+    ∃ n_crit : ℝ, 0 < n_crit ∧
+      mse_transfer σ_sq bias_sq n_crit = mse_target σ_sq σ_extra_sq n_crit := by
+  use σ_extra_sq / bias_sq
+  constructor
+  · positivity
+  · unfold mse_transfer mse_target
+    rw [add_div]
+    have h_div : σ_extra_sq / (σ_extra_sq / bias_sq) = bias_sq := by
+      rw [div_div_eq_mul_div, mul_comm, mul_div_cancel_right₀ _ h_extra.ne']
+    linarith
 
 /-- **Multi-ancestry meta-analysis is optimal.**
     Combining GWAS data from multiple ancestries via inverse-variance


### PR DESCRIPTION
Refactored `critical_sample_size_exists` in `proofs/Calibrator/AncestryCalibration.lean` to eliminate vacuous verification (the "trivial witness" problem). Previously, the theorem proved the existence of a crossover point simply by providing the arbitrary midpoint `(n_lo + n_hi) / 2` without utilizing the actual mathematical functions. The patch introduces precise mathematical modeling using variance components (`mse_transfer` and `mse_target`) and calculates the actual rigorous crossover sample size (`n_crit = σ_extra_sq / bias_sq`).

---
*PR created automatically by Jules for task [431419049801946628](https://jules.google.com/task/431419049801946628) started by @SauersML*