### PR TITLE
Refactor `differential_ascertainment_artifact` to eliminate vacuous verification

### DIFF
--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -322,20 +322,33 @@ theorem collider_attenuates_association (m : ColliderModel) :
       < m.β_G * 1 := by exact mul_lt_mul_of_pos_left h_ratio_lt_one m.β_G_pos
     _ = m.β_G := by ring
 
+structure DifferentialAscertainmentModel where
+  source : ColliderModel
+  target : ColliderModel
+  same_beta : source.β_G = target.β_G
+  same_var : source.σ2_G = target.σ2_G
+  diff_env : source.σ2_E < target.σ2_E
+
 /-- **Differential ascertainment creates portability artifact.**
     If source and target cohorts have different ascertainment patterns,
     the apparent portability drop includes an ascertainment component. -/
 theorem differential_ascertainment_artifact
-    (r2_source_pop r2_target_pop r2_source_asc r2_target_asc : ℝ)
-    (h_source_asc : r2_source_asc < r2_source_pop)
-    (h_target_asc : r2_target_asc < r2_target_pop)
-    -- Different ascertainment severity
-    (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
-    -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
-  linarith
+    (m : DifferentialAscertainmentModel) :
+    m.target.β_selected < m.source.β_selected := by
+  unfold ColliderModel.β_selected
+  rw [← m.same_beta, ← m.same_var]
+  have h_denom_source : 0 < m.source.σ2_G + m.source.σ2_E := by
+    linarith [m.source.σ2_G_pos, m.source.σ2_E_pos]
+  have h_denom_target : 0 < m.source.σ2_G + m.target.σ2_E := by
+    linarith [m.source.σ2_G_pos, m.target.σ2_E_pos]
+  apply mul_lt_mul_of_pos_left
+  · rw [div_lt_div_iff₀ h_denom_target h_denom_source]
+    have h_diff : m.source.σ2_G * (m.source.σ2_G + m.source.σ2_E) < m.source.σ2_G * (m.source.σ2_G + m.target.σ2_E) := by
+      apply mul_lt_mul_of_pos_left
+      · linarith [m.diff_env]
+      · exact m.source.σ2_G_pos
+    exact h_diff
+  · exact m.source.β_G_pos
 
 end ColliderBias
 


### PR DESCRIPTION
This PR addresses the issue of "specification gaming" (vacuous verification) within `proofs/Calibrator/StratificationConfounding.lean`. 

The original theorem `differential_ascertainment_artifact` was written with an impossible set of premises. Due to a contradiction between `h_diff_severity` and the final implication, the theorem essentially boiled down to proving `False` via `linarith`, sidestepping any real mathematical rigor or causality related to differential ascertainment.

To fix this:
1. Introduced a `DifferentialAscertainmentModel` structure to formally link a `source` and `target` `ColliderModel` with identical underlying genetic parameters but varying environmental (ascertainment) thresholds (`diff_env : source.σ2_E < target.σ2_E`).
2. Refactored the `differential_ascertainment_artifact` theorem to utilize this structure.
3. Proved the true underlying relationship: that a population subject to stronger ascertainment selection demonstrates a lower apparent genetic effect (`m.target.β_selected < m.source.β_selected`) than the population with weaker ascertainment.

The code now provides a genuine proof relying on mathematical bounds rather than tautologies, thereby strengthening the formalization of collider bias in PGS. All changes compiled successfully.

---
*PR created automatically by Jules for task [16352698653635809263](https://jules.google.com/task/16352698653635809263) started by @SauersML*