### PR TITLE
Strengthen `differential_ascertainment_artifact` by removing vacuous verification.

### DIFF
--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -327,14 +327,12 @@ theorem collider_attenuates_association (m : ColliderModel) :
     the apparent portability drop includes an ascertainment component. -/
 theorem differential_ascertainment_artifact
     (r2_source_pop r2_target_pop r2_source_asc r2_target_asc : ℝ)
-    (h_source_asc : r2_source_asc < r2_source_pop)
-    (h_target_asc : r2_target_asc < r2_target_pop)
+    (_h_source_asc : r2_source_asc < r2_source_pop)
+    (_h_target_asc : r2_target_asc < r2_target_pop)
     -- Different ascertainment severity
     (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
     -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
+    r2_source_asc - r2_target_asc < r2_source_pop - r2_target_pop := by
   linarith
 
 end ColliderBias


### PR DESCRIPTION
Strengthen `differential_ascertainment_artifact` by removing vacuous verification.

Refactored the theorem `differential_ascertainment_artifact` in `proofs/Calibrator/StratificationConfounding.lean` to eliminate specification gaming. Previously, it vacuously proved `False` by assuming an impossible constraint (`r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop`). It has been strengthened to formally prove the actual mathematically sound inequality (`r2_source_asc - r2_target_asc < r2_source_pop - r2_target_pop`) directly using the given assumptions and the `linarith` tactic. Unused variables in the signature were prefixed with underscores to clear linter warnings.

---
*PR created automatically by Jules for task [6421726357343846073](https://jules.google.com/task/6421726357343846073) started by @SauersML*