### PR TITLE
Fix vacuous verification in `differential_ascertainment_artifact`

### DIFF
--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -327,14 +327,10 @@ theorem collider_attenuates_association (m : ColliderModel) :
     the apparent portability drop includes an ascertainment component. -/
 theorem differential_ascertainment_artifact
     (r2_source_pop r2_target_pop r2_source_asc r2_target_asc : ℝ)
-    (h_source_asc : r2_source_asc < r2_source_pop)
-    (h_target_asc : r2_target_asc < r2_target_pop)
     -- Different ascertainment severity
-    (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
-    -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
+    (h_diff_severity : r2_source_pop - r2_source_asc > r2_target_pop - r2_target_asc) :
+    -- Apparent portability drop is less than true portability drop
+    r2_source_asc - r2_target_asc < r2_source_pop - r2_target_pop := by
   linarith
 
 end ColliderBias


### PR DESCRIPTION
This submission refactors the `differential_ascertainment_artifact` theorem in `proofs/Calibrator/StratificationConfounding.lean`. 

The original theorem exhibited "vacuous verification" by assuming `r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop` and trivially returning `False` when the preceding hypothesis mandated the inverse. Furthermore, it utilized unused, irrelevant hypotheses (`h_source_asc` and `h_target_asc`) which created the illusion of a complex relationship where a simple mathematical inequality was at play. 

The update removes the `False` contradiction framework and the extraneous hypotheses, explicitly proving the mathematically accurate outcome: `r2_source_asc - r2_target_asc < r2_source_pop - r2_target_pop` using `linarith`. The codebase has been verified to build successfully following this change.

---
*PR created automatically by Jules for task [11233848202975346514](https://jules.google.com/task/11233848202975346514) started by @SauersML*