### PR TITLE
Fix trivial witness specification gaming in critical_sample_size_exists

### DIFF
--- a/proofs/Calibrator/AncestryCalibration.lean
+++ b/proofs/Calibrator/AncestryCalibration.lean
@@ -198,19 +198,45 @@ theorem transfer_beats_target_only
     n_crit depends on the portability ratio and source GWAS power.
     Beyond n_crit, target-only GWAS is sufficient.
 
-    General statement: given any n_lo and n_hi where transfer beats target
-    at n_lo but target beats transfer at n_hi, a crossover point exists
-    in between. -/
-theorem critical_sample_size_exists
-    (mse_transfer mse_target : ℝ → ℝ) (n_lo n_hi : ℝ)
-    (h_transfer_decreasing : ∀ n₁ n₂ : ℝ, 0 < n₁ → n₁ < n₂ → mse_transfer n₂ < mse_transfer n₁)
-    (h_target_decreasing : ∀ n₁ n₂ : ℝ, 0 < n₁ → n₁ < n₂ → mse_target n₂ < mse_target n₁)
-    (h_lo_pos : 0 < n_lo) (h_range : n_lo < n_hi)
-    (h_small_n : mse_transfer n_lo < mse_target n_lo)
-    (h_large_n : mse_target n_hi < mse_transfer n_hi) :
-    -- There exists a crossover point
-    ∃ n_crit : ℝ, n_lo < n_crit ∧ n_crit < n_hi := by
-  exact ⟨(n_lo + n_hi) / 2, by linarith, by linarith⟩
+    We explicitly compute this crossover point based on the error model. -/
+theorem critical_sample_size_crossover
+    (σ_sq bias_sq σ_extra_sq : ℝ)
+    (_h_σ : 0 < σ_sq) (h_bias : 0 < bias_sq)
+    (h_extra : 0 < σ_extra_sq) :
+    let n_crit := σ_extra_sq / bias_sq
+    let mse_transfer := fun (n:ℝ) => σ_sq / n + bias_sq
+    let mse_target := fun (n:ℝ) => (σ_sq + σ_extra_sq) / n
+    (∀ n : ℝ, 0 < n → n < n_crit → mse_transfer n < mse_target n) ∧
+    (∀ n : ℝ, n_crit < n → mse_target n < mse_transfer n) ∧
+    (mse_transfer n_crit = mse_target n_crit) := by
+  intro n_crit mse_transfer mse_target
+  refine ⟨?_, ?_, ?_⟩
+  · intro n hn hlt
+    dsimp [mse_transfer, mse_target, n_crit] at *
+    have h_prod : bias_sq * n < σ_extra_sq := by
+      have h1 : n * bias_sq < σ_extra_sq := (lt_div_iff₀ h_bias).mp hlt
+      linarith
+    have h_key : bias_sq < σ_extra_sq / n := (lt_div_iff₀ hn).mpr h_prod
+    rw [add_div]
+    linarith
+  · intro n hlt
+    have hn : 0 < n := by
+      have hcrit : 0 < n_crit := div_pos h_extra h_bias
+      linarith
+    dsimp [mse_transfer, mse_target, n_crit] at *
+    have h_prod : σ_extra_sq < bias_sq * n := by
+      have h1 : σ_extra_sq < n * bias_sq := (div_lt_iff₀ h_bias).mp hlt
+      linarith
+    have h_key : σ_extra_sq / n < bias_sq := (div_lt_iff₀ hn).mpr h_prod
+    rw [add_div]
+    linarith
+  · dsimp [mse_transfer, mse_target, n_crit]
+    have hcrit : 0 < σ_extra_sq / bias_sq := div_pos h_extra h_bias
+    have hcrit_ne : σ_extra_sq / bias_sq ≠ 0 := ne_of_gt hcrit
+    rw [add_div]
+    have : σ_extra_sq / (σ_extra_sq / bias_sq) = bias_sq := by
+      rw [div_div_eq_mul_div, mul_comm, mul_div_cancel_right₀ _ (ne_of_gt h_extra)]
+    linarith
 
 /-- **Multi-ancestry meta-analysis is optimal.**
     Combining GWAS data from multiple ancestries via inverse-variance


### PR DESCRIPTION
Replaces the vacuous `critical_sample_size_exists` theorem in `proofs/Calibrator/AncestryCalibration.lean` (which previously used a trivial existential witness without enforcing error model properties) with `critical_sample_size_crossover`. The new theorem computes the exact crossover point where transfer learning yields better predictive MSE than target-only models and rigorously proves the bounds using Lean's `linarith`.

---
*PR created automatically by Jules for task [54863379415996026](https://jules.google.com/task/54863379415996026) started by @SauersML*