### PR TITLE
Fix specification gaming and vacuous verification

### DIFF
--- a/proofs/Calibrator/PortabilityBounds.lean
+++ b/proofs/Calibrator/PortabilityBounds.lean
@@ -1,6 +1,7 @@
 import Calibrator.Probability
 import Calibrator.PortabilityDrift
 import Calibrator.OpenQuestions
+import Calibrator.TransportIdentities
 
 namespace Calibrator
 
@@ -148,6 +149,8 @@ has enormous within-group variance. We formalize the exact distribution.
 
 section IndividualErrorDistribution
 
+variable {Ω : Type*}
+
 /-- **Squared prediction error for Gaussian model.**
     If Y = μ(X) + ε, ε ~ N(0, σ²), and Ŷ = μ̂(X), then
     (Y - Ŷ)² = (μ - μ̂ + ε)² = (μ - μ̂)² + 2(μ - μ̂)ε + ε². -/
@@ -158,29 +161,75 @@ theorem squared_error_expansion (μ μ_hat ε : ℝ) :
 /-- **Expected squared error given X = x.**
     E[(Y - Ŷ)² | X = x] = (μ(x) - μ̂(x))² + σ².
     The first term is the squared bias, the second is irreducible noise. -/
-theorem expected_squared_error_given_x (bias σ_sq : ℝ) :
-    bias ^ 2 + σ_sq ≥ σ_sq := by
-  linarith [sq_nonneg bias]
+theorem expected_squared_error_given_x
+    (E : ExpFunctional Ω)
+    (μ μ_hat σ_sq : ℝ) (ε : Ω → ℝ)
+    (h_mean : E ε = 0)
+    (h_var : E (fun ω => (ε ω) ^ 2) = σ_sq) :
+    E (fun ω => (μ + ε ω - μ_hat) ^ 2) = (μ - μ_hat) ^ 2 + σ_sq := by
+  have h_expand : (fun ω => (μ + ε ω - μ_hat) ^ 2) =
+      (fun ω => (μ - μ_hat)^2) + (fun ω => 2*(μ - μ_hat)*ε ω) + (fun ω => (ε ω)^2) := by
+    funext ω
+    dsimp
+    ring
+  rw [h_expand]
+  rw [E.add_eval, E.add_eval]
+  rw [E.eval_const]
+  have h_term2 : E (fun ω => 2 * (μ - μ_hat) * ε ω) = 0 := by
+    have h_c : (fun ω => 2 * (μ - μ_hat) * ε ω) = (2 * (μ - μ_hat)) • ε := by
+      rfl
+    rw [h_c, E.smul_eval, h_mean, mul_zero]
+  rw [h_term2, h_var]
+  ring
 
 /-- **Variance of squared error given X = x.**
-    Var((Y - Ŷ)² | X = x) ≈ 4·bias²·σ² + 2·σ⁴.
-    This is large even for moderate σ², explaining why individual-level
-    accuracy has high variance. -/
-theorem variance_of_squared_error_lower_bound (σ_sq : ℝ) (hσ : 0 < σ_sq) :
-    0 < 2 * σ_sq ^ 2 := by positivity
+    For Gaussian noise, E[ε³] = 0 and E[ε⁴] = 3σ⁴.
+    Var((Y - Ŷ)² | X = x) = 4·bias²·σ² + 2·σ⁴. -/
+theorem variance_of_squared_error_lower_bound
+    (E : ExpFunctional Ω)
+    (bias σ_sq : ℝ) (ε : Ω → ℝ)
+    (h_mean : E ε = 0)
+    (h_var : E (fun ω => (ε ω) ^ 2) = σ_sq)
+    (h_skew : E (fun ω => (ε ω) ^ 3) = 0)
+    (h_kurtosis : E (fun ω => (ε ω) ^ 4) = 3 * σ_sq ^ 2) :
+    variance E (fun ω => (bias + ε ω) ^ 2) = 4 * bias ^ 2 * σ_sq + 2 * σ_sq ^ 2 := by
+  rw [variance_eq_expect_sq_sub_sq_mean]
+  have h_sq : (fun ω => (bias + ε ω) ^ 2) =
+      (fun ω => bias^2) + (fun ω => 2*bias*ε ω) + (fun ω => (ε ω)^2) := by
+    funext ω
+    dsimp
+    ring
+  have h_mean_sq : E (fun ω => (bias + ε ω) ^ 2) = bias^2 + σ_sq := by
+    rw [h_sq]
+    rw [E.add_eval, E.add_eval, E.eval_const]
+    have hc : (fun ω => 2 * bias * ε ω) = (2 * bias) • ε := rfl
+    rw [hc, E.smul_eval, h_mean, mul_zero, add_zero, h_var]
+  have h_sq_sq : (fun ω => ((bias + ε ω) ^ 2) ^ 2) =
+      (fun ω => bias^4) + (fun ω => 4*bias^3*ε ω) + (fun ω => 6*bias^2*(ε ω)^2) + (fun ω => 4*bias*(ε ω)^3) + (fun ω => (ε ω)^4) := by
+    funext ω
+    dsimp
+    ring
+  have h_mean_sq_sq : E (fun ω => ((bias + ε ω) ^ 2) ^ 2) = bias^4 + 6 * bias^2 * σ_sq + 3 * σ_sq^2 := by
+    rw [h_sq_sq]
+    rw [E.add_eval, E.add_eval, E.add_eval, E.add_eval]
+    rw [E.eval_const]
+    have hc1 : (fun ω => 4 * bias^3 * ε ω) = (4 * bias^3) • ε := rfl
+    rw [hc1, E.smul_eval, h_mean, mul_zero, add_zero]
+    have hc2 : (fun ω => 6 * bias^2 * (ε ω)^2) = (6 * bias^2) • (fun ω => (ε ω)^2) := rfl
+    rw [hc2, E.smul_eval, h_var]
+    have hc3 : (fun ω => 4 * bias * (ε ω)^3) = (4 * bias) • (fun ω => (ε ω)^3) := rfl
+    rw [hc3, E.smul_eval, h_skew, mul_zero, add_zero]
+    rw [h_kurtosis]
+  rw [h_mean_sq, h_mean_sq_sq]
+  ring
 
-/-- **Conditional variance is large relative to conditional mean squared.**
-    For ε ~ N(0, σ²), we have E[ε²] = σ² and Var(ε²) = 2σ⁴.
-    Therefore CV² = Var(ε²)/E[ε²]² = 2σ⁴/σ⁴ = 2.
-    Adding squared bias b² to the mean only reduces CV² (denominator grows faster),
-    but the variance term 2σ⁴ provides a lower bound on conditional-squared-error
-    variance regardless of bias.
-
-    We derive: Var(squared error) / E[squared error]² ≥ 2σ⁴/(b² + σ²)²,
-    and the conditional variance 4b²σ² + 2σ⁴ ≥ 2σ⁴ always. -/
-theorem high_cv_inevitable (σ_sq bias_sq : ℝ) (hσ : 0 < σ_sq) (hb : 0 ≤ bias_sq) :
-    -- Variance of squared error (4b²σ² + 2σ⁴) ≥ irreducible noise variance (2σ⁴)
-    4 * bias_sq * σ_sq + 2 * σ_sq ^ 2 ≥ 2 * σ_sq ^ 2 := by
+theorem high_cv_inevitable
+    (E : ExpFunctional Ω)
+    (bias σ_sq : ℝ) (ε : Ω → ℝ)
+    (h_var_sq_err : variance E (fun ω => (bias + ε ω) ^ 2) = 4 * bias ^ 2 * σ_sq + 2 * σ_sq ^ 2)
+    (hσ : 0 < σ_sq) (hb : 0 ≤ bias ^ 2) :
+    variance E (fun ω => (bias + ε ω) ^ 2) ≥ 2 * σ_sq ^ 2 := by
+  rw [h_var_sq_err]
   nlinarith [mul_nonneg hb (le_of_lt hσ)]
 
 /-- **Spline fit R² bounded above by noise-to-signal ratio.**

--- a/proofs/Calibrator/SelectionArchitecture.lean
+++ b/proofs/Calibrator/SelectionArchitecture.lean
@@ -472,13 +472,34 @@ noncomputable def polygenicAdaptationShift
     {m : ℕ} (β : Fin m → ℝ) (Δp : Fin m → ℝ) : ℝ :=
   ∑ i, β i * Δp i
 
-/-- **Under neutral drift, expected shift is zero.**
-    E[Δpᵢ] = 0 under drift, so E[Δμ] = 0. -/
-theorem neutral_expected_shift_zero
-    {m : ℕ} (β : Fin m → ℝ) :
+@[simp]
+theorem polygenicAdaptationShift_zero {m : ℕ} (β : Fin m → ℝ) :
     polygenicAdaptationShift β (fun _ => 0) = 0 := by
   unfold polygenicAdaptationShift
   simp
+
+variable {Ω : Type*}
+
+/-- **Under neutral drift, expected shift is zero.**
+    E[Δpᵢ] = 0 under drift, so E[Δμ] = 0. -/
+theorem neutral_expected_shift_zero
+    (E : ExpFunctional Ω)
+    {m : ℕ} (β : Fin m → ℝ) (Δp : Ω → Fin m → ℝ)
+    (h_neutral : ∀ i, E (fun ω => Δp ω i) = 0) :
+    E (fun ω => polygenicAdaptationShift β (Δp ω)) = 0 := by
+  unfold polygenicAdaptationShift
+  have h_expand :
+      (fun ω => ∑ i, β i * Δp ω i)
+        = ∑ i, (β i) • (fun ω => Δp ω i) := by
+    funext ω
+    simp [smul_eq_mul]
+  rw [h_expand, ExpFunctional.eval_sum]
+  have h_zero : ∑ i : Fin m, E ((β i) • (fun ω => Δp ω i)) = 0 := by
+    apply Finset.sum_eq_zero
+    intro i _
+    rw [E.smul_eval, h_neutral i]
+    ring
+  exact h_zero
 
 /-- **Under selection, shift is nonzero and directional.**
     If selection favors higher trait values, Δpᵢ > 0 for positive-effect

--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -331,10 +331,8 @@ theorem differential_ascertainment_artifact
     (h_target_asc : r2_target_asc < r2_target_pop)
     -- Different ascertainment severity
     (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
-    -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
+    -- Apparent portability drop is smaller than true portability drop
+    r2_source_asc - r2_target_asc < r2_source_pop - r2_target_pop := by
   linarith
 
 end ColliderBias


### PR DESCRIPTION
Fixed theorems that "begged the question" or used trivial/constant witnesses:
- `PortabilityBounds.lean`: Implemented strict bounds using expectation and variance on `ExpFunctional Ω` for `expected_squared_error_given_x`, `variance_of_squared_error_lower_bound`, and `high_cv_inevitable`, rather than trivial variable comparisons. Preserved `squared_error_expansion` to avoid compilation breakages.
- `SelectionArchitecture.lean`: Updated `neutral_expected_shift_zero` to take an actual expectation `E` over random variables rather than trivially applying a zero-function `fun _ => 0`. Extracted the zero-function evaluation into a `@[simp]` lemma.
- `StratificationConfounding.lean`: Rewrote `differential_ascertainment_artifact` to establish the proper rigorous inequality relating apparent and true portability drops rather than proving `False` from impossible preconditions.

---
*PR created automatically by Jules for task [11668214500004288712](https://jules.google.com/task/11668214500004288712) started by @SauersML*