### PR TITLE
Fix trivial witness in critical_sample_size_exists

### DIFF
--- a/proofs/Calibrator/AncestryCalibration.lean
+++ b/proofs/Calibrator/AncestryCalibration.lean
@@ -198,19 +198,33 @@ theorem transfer_beats_target_only
     n_crit depends on the portability ratio and source GWAS power.
     Beyond n_crit, target-only GWAS is sufficient.
 
-    General statement: given any n_lo and n_hi where transfer beats target
-    at n_lo but target beats transfer at n_hi, a crossover point exists
-    in between. -/
+    This replaces the previous trivial witness with an explicit
+    derivation of the exact crossover point in the MSE model. -/
 theorem critical_sample_size_exists
-    (mse_transfer mse_target : ℝ → ℝ) (n_lo n_hi : ℝ)
-    (h_transfer_decreasing : ∀ n₁ n₂ : ℝ, 0 < n₁ → n₁ < n₂ → mse_transfer n₂ < mse_transfer n₁)
-    (h_target_decreasing : ∀ n₁ n₂ : ℝ, 0 < n₁ → n₁ < n₂ → mse_target n₂ < mse_target n₁)
-    (h_lo_pos : 0 < n_lo) (h_range : n_lo < n_hi)
-    (h_small_n : mse_transfer n_lo < mse_target n_lo)
-    (h_large_n : mse_target n_hi < mse_transfer n_hi) :
-    -- There exists a crossover point
-    ∃ n_crit : ℝ, n_lo < n_crit ∧ n_crit < n_hi := by
-  exact ⟨(n_lo + n_hi) / 2, by linarith, by linarith⟩
+    (σ_sq bias_sq σ_extra_sq : ℝ)
+    (_h_σ : 0 < σ_sq) (h_bias : 0 < bias_sq)
+    (h_extra : 0 < σ_extra_sq) :
+    ∃ n_crit : ℝ, 0 < n_crit ∧
+      (∀ n_T : ℝ, 0 < n_T → n_T < n_crit →
+        (σ_sq / n_T + bias_sq) < ((σ_sq + σ_extra_sq) / n_T)) ∧
+      (∀ n_T : ℝ, 0 < n_T → n_crit < n_T →
+        ((σ_sq + σ_extra_sq) / n_T) < (σ_sq / n_T + bias_sq)) := by
+  use σ_extra_sq / bias_sq
+  refine ⟨div_pos h_extra h_bias, ?_, ?_⟩
+  · intro n_T h_nT h_lt
+    have h_prod : n_T * bias_sq < σ_extra_sq := (lt_div_iff₀ h_bias).mp h_lt
+    have h_prod2 : bias_sq * n_T < σ_extra_sq := by rwa [mul_comm]
+    have h_key : bias_sq < σ_extra_sq / n_T := (lt_div_iff₀ h_nT).mpr h_prod2
+    calc
+      σ_sq / n_T + bias_sq < σ_sq / n_T + σ_extra_sq / n_T := add_lt_add_left h_key _
+      _ = (σ_sq + σ_extra_sq) / n_T := by rw [add_div]
+  · intro n_T h_nT h_gt
+    have h_prod : σ_extra_sq < n_T * bias_sq := (div_lt_iff₀ h_bias).mp h_gt
+    have h_prod2 : σ_extra_sq < bias_sq * n_T := by rwa [mul_comm]
+    have h_key : σ_extra_sq / n_T < bias_sq := (div_lt_iff₀ h_nT).mpr h_prod2
+    calc
+      (σ_sq + σ_extra_sq) / n_T = σ_sq / n_T + σ_extra_sq / n_T := by rw [add_div]
+      _ < σ_sq / n_T + bias_sq := add_lt_add_left h_key _
 
 /-- **Multi-ancestry meta-analysis is optimal.**
     Combining GWAS data from multiple ancestries via inverse-variance


### PR DESCRIPTION
Fix trivial witness in critical_sample_size_exists

Replaced the trivial witness for `critical_sample_size_exists` in `proofs/Calibrator/AncestryCalibration.lean` with an explicit and rigorous derivation of the crossover point in the MSE model (`σ_extra_sq / bias_sq`). This resolves the issue of "specification gaming" where the theorem previously satisfied the loosely stated bound simply by averaging the interval rather than calculating the actual target value mathematically.

---
*PR created automatically by Jules for task [583663643854489822](https://jules.google.com/task/583663643854489822) started by @SauersML*