### PR TITLE
Refactor differential_ascertainment_artifact to remove vacuous verification

### DIFF
--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -331,11 +331,11 @@ theorem differential_ascertainment_artifact
     (h_target_asc : r2_target_asc < r2_target_pop)
     -- Different ascertainment severity
     (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
-    -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
-  linarith
+    -- True portability drop is strictly greater than apparent portability drop
+    r2_source_pop - r2_target_pop > r2_source_asc - r2_target_asc := by
+  calc r2_source_pop - r2_target_pop = (r2_source_pop - r2_source_asc) - (r2_target_pop - r2_target_asc) + (r2_source_asc - r2_target_asc) := by ring
+       _ > (r2_target_pop - r2_target_asc) - (r2_target_pop - r2_target_asc) + (r2_source_asc - r2_target_asc) := by linarith
+       _ = r2_source_asc - r2_target_asc := by ring
 
 end ColliderBias
 


### PR DESCRIPTION
Refactor differential_ascertainment_artifact to remove vacuous verification by proving the positive inequality directly using a mathematical calculation.

---
*PR created automatically by Jules for task [5695425651280878602](https://jules.google.com/task/5695425651280878602) started by @SauersML*