### PR TITLE
Fix vacuous verification in differential_ascertainment_artifact

### DIFF
--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -327,14 +327,12 @@ theorem collider_attenuates_association (m : ColliderModel) :
     the apparent portability drop includes an ascertainment component. -/
 theorem differential_ascertainment_artifact
     (r2_source_pop r2_target_pop r2_source_asc r2_target_asc : ℝ)
-    (h_source_asc : r2_source_asc < r2_source_pop)
-    (h_target_asc : r2_target_asc < r2_target_pop)
+    (_h_source_asc : r2_source_asc < r2_source_pop)
+    (_h_target_asc : r2_target_asc < r2_target_pop)
     -- Different ascertainment severity
-    (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
+    (h_diff_severity : r2_source_pop - r2_source_asc < r2_target_pop - r2_target_asc) :
     -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
+    r2_source_pop - r2_target_pop < r2_source_asc - r2_target_asc := by
   linarith
 
 end ColliderBias


### PR DESCRIPTION
Refactored the `differential_ascertainment_artifact` theorem in `Calibrator/StratificationConfounding.lean` to eliminate specification gaming (vacuous verification). The previous implementation indirectly implied `False` from a contradicted hypothesis. The new version directly and rigorously proves the affirmative mathematical relationship `r2_source_pop - r2_target_pop < r2_source_asc - r2_target_asc`. It also correctly silences the unused variable linter for unused hypotheses. All proofs compile successfully.

---
*PR created automatically by Jules for task [435462354028389908](https://jules.google.com/task/435462354028389908) started by @SauersML*