### PR TITLE
Fix vacuous specification gaming in `differential_ascertainment_artifact`

### DIFF
--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -331,10 +331,8 @@ theorem differential_ascertainment_artifact
     (h_target_asc : r2_target_asc < r2_target_pop)
     -- Different ascertainment severity
     (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
-    -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
+    -- Apparent portability drop is smaller than true portability drop
+    r2_source_asc - r2_target_asc < r2_source_pop - r2_target_pop := by
   linarith
 
 end ColliderBias


### PR DESCRIPTION
This PR fixes a vacuous theorem in `StratificationConfounding.lean` to explicitly and rigorously represent the mathematical inequality, rather than trivially asserting that an impossible condition implies `False`. This addresses the specification gaming issue highlighted without deleting any theorems or introducing regressions.

---
*PR created automatically by Jules for task [11829308170101943763](https://jules.google.com/task/11829308170101943763) started by @SauersML*