### PR TITLE
Refactor: eliminate vacuous verification in EquityAndImplementation

### DIFF
--- a/proofs/Calibrator/EquityAndImplementation.lean
+++ b/proofs/Calibrator/EquityAndImplementation.lean
@@ -34,30 +34,65 @@ benefit across ancestry groups.
 
 section HealthDisparity
 
+/-- **Two Population Portability Model**
+    Formalizes the structural relationships governing PGS performance across two populations
+    (source and target). Resolves previous ex post facto theorems by ensuring the
+    performance gap rigorously arises from the structural `fst` distance mechanism. -/
+structure TwoPopModel where
+  r2_source : ℝ
+  r2_target : ℝ
+  fst : ℝ
+  α : ℝ
+  γ : ℝ
+  d₀ : ℝ
+  h_r2_source_pos : 0 < r2_source
+  h_fst_pos : 0 < fst
+  h_fst_lt : fst < 1
+  h_α_pos : 0 < α
+  h_γ_pos : 0 < γ
+  h_d₀_nonneg : 0 ≤ d₀
+  h_r2_target_eq : r2_target = r2_source * (1 - fst) ^ 2
+
+namespace TwoPopModel
+
+lemma r2_target_pos (m : TwoPopModel) : 0 < m.r2_target := by
+  rw [m.h_r2_target_eq]
+  have h1 : 0 < 1 - m.fst := by linarith [m.h_fst_lt]
+  have h3 : 0 < (1 - m.fst) ^ 2 := by positivity
+  exact mul_pos m.h_r2_source_pos h3
+
+lemma r2_target_lt_r2_source (m : TwoPopModel) : m.r2_target < m.r2_source := by
+  rw [m.h_r2_target_eq]
+  have h1 : 0 < 1 - m.fst := by linarith [m.h_fst_lt]
+  have h2 : 1 - m.fst < 1 := by linarith [m.h_fst_pos]
+  have h3 : (1 - m.fst) ^ 2 < 1 := by
+    nlinarith [h1, h2]
+  have h4 : m.r2_source * (1 - m.fst) ^ 2 < m.r2_source * 1 := by
+    exact mul_lt_mul_of_pos_left h3 m.h_r2_source_pos
+  linarith
+
+end TwoPopModel
+
 /-- **Clinical utility depends on PGS R².**
     The net clinical benefit from PGS-guided care is monotonically
     increasing in R². We model benefit = α × R² for a positive
-    proportionality constant α (benefit per unit R²). When
-    R²₁ < R²₂, the benefit in population 1 is strictly less. -/
+    proportionality constant α (benefit per unit R²).
+    Now structurally linked to the `TwoPopModel`. -/
 theorem clinical_benefit_increases_with_r2
-    (α r2₁ r2₂ : ℝ)
-    (h_α : 0 < α)
-    (h_r2 : r2₁ < r2₂) :
-    α * r2₁ < α * r2₂ := by
-  exact mul_lt_mul_of_pos_left h_r2 h_α
+    (m : TwoPopModel) :
+    m.α * m.r2_target < m.α * m.r2_source := by
+  have h_r2 : m.r2_target < m.r2_source := m.r2_target_lt_r2_source
+  exact mul_lt_mul_of_pos_left h_r2 m.h_α_pos
 
 /-- **Portability gap creates benefit gap.**
-    If R²_EUR > R²_AFR and benefit = α × R² with α > 0, then
-    clinical benefit for EUR patients exceeds that for AFR patients.
-    The benefit gap α × (R²_EUR - R²_AFR) > 0 follows from the R² gap. -/
+    Clinical benefit for the source population exceeds that for the target population.
+    The benefit gap α × (R²_source - R²_target) > 0 follows rigorously from
+    the model's structural Fst-driven R² gap, avoiding previous vacuous verification. -/
 theorem portability_creates_benefit_gap
-    (α r2_eur r2_afr : ℝ)
-    (h_α : 0 < α)
-    (h_r2_gap : r2_afr < r2_eur)
-    (h_nn : 0 ≤ r2_afr) :
-    0 < α * r2_eur - α * r2_afr := by
-  have : r2_eur - r2_afr > 0 := by linarith
-  nlinarith
+    (m : TwoPopModel) :
+    0 < m.α * m.r2_source - m.α * m.r2_target := by
+  have : m.r2_source - m.r2_target > 0 := by linarith [m.r2_target_lt_r2_source]
+  nlinarith [m.h_α_pos]
 
 /-- **Disparity increases with Fst from discovery population.**
     Populations most genetically distant from the discovery
@@ -65,15 +100,17 @@ theorem portability_creates_benefit_gap
     (1 - Fst)², so disparity = R²_source - R²_target grows
     with Fst. For Fst₂ > Fst₁ > 0, the R² loss is larger. -/
 theorem disparity_increases_with_distance
-    (R2_source fst₁ fst₂ : ℝ)
-    (h_R2 : 0 < R2_source)
-    (h_fst₁_pos : 0 < fst₁) (h_fst₁_lt : fst₁ < 1)
-    (h_fst₂_pos : 0 < fst₂) (h_fst₂_lt : fst₂ < 1)
-    (h_fst : fst₁ < fst₂) :
-    -- R² loss at fst₁ < R² loss at fst₂
-    R2_source * (1 - (1 - fst₁) ^ 2) < R2_source * (1 - (1 - fst₂) ^ 2) := by
+    (m₁ m₂ : TwoPopModel)
+    (h_same_source : m₁.r2_source = m₂.r2_source)
+    (h_fst : m₁.fst < m₂.fst) :
+    m₁.r2_source - m₁.r2_target < m₂.r2_source - m₂.r2_target := by
+  rw [m₁.h_r2_target_eq, m₂.h_r2_target_eq, h_same_source]
+  have h_R2 : 0 < m₂.r2_source := m₂.h_r2_source_pos
+  have h_fst₁_lt : m₁.fst < 1 := m₁.h_fst_lt
+  have h_fst₂_lt : m₂.fst < 1 := m₂.h_fst_lt
+  apply sub_lt_sub_left
   apply mul_lt_mul_of_pos_left _ h_R2
-  have h1 : (1 - fst₂) ^ 2 < (1 - fst₁) ^ 2 := by nlinarith
+  have h1 : (1 - m₂.fst) ^ 2 < (1 - m₁.fst) ^ 2 := by nlinarith
   linarith
 
 /-- **Existing health disparities may be amplified.**
@@ -82,22 +119,19 @@ theorem disparity_increases_with_distance
     gets no PGS benefit, so the pre-existing disparity d₀ ≥ 0 grows
     to d₀ + α × R²_eur. -/
 theorem deployment_amplifies_disparity
-    (d₀ α r2_eur : ℝ)
-    (h_nn : 0 ≤ d₀)
-    (h_α : 0 < α) (h_r2 : 0 < r2_eur) :
-    d₀ < d₀ + α * r2_eur := by
-  linarith [mul_pos h_α h_r2]
+    (m : TwoPopModel) :
+    m.d₀ < m.d₀ + m.α * m.r2_source := by
+  linarith [mul_pos m.h_α_pos m.h_r2_source_pos]
 
 /-- **QALY gap from portability.**
     QALYs gained = γ × R² for a positive constant γ (QALYs per unit R²).
-    The QALY gap between two populations is γ × (R²₁ - R²₂), which is
-    positive when R²₁ > R²₂. Derived from the model, not assumed. -/
+    The QALY gap between two populations is strictly derived from the
+    structural Fst model. -/
 theorem qaly_gap_proportional_to_r2_gap
-    (γ r2₁ r2₂ : ℝ)
-    (h_γ : 0 < γ) (h_gap : r2₂ < r2₁) :
-    0 < γ * r2₁ - γ * r2₂ := by
-  have : r2₁ - r2₂ > 0 := by linarith
-  nlinarith
+    (m : TwoPopModel) :
+    0 < m.γ * m.r2_source - m.γ * m.r2_target := by
+  have : m.r2_source - m.r2_target > 0 := by linarith [m.r2_target_lt_r2_source]
+  nlinarith [m.h_γ_pos]
 
 end HealthDisparity
 


### PR DESCRIPTION
I have implemented a fix for the "specification gaming" present in the `proofs/Calibrator/EquityAndImplementation.lean` file, specifically where theorems were "begging the question" by defining their hypotheses based directly on their target conclusion.

Previously, theorems like `portability_creates_benefit_gap` operated on raw unstructured parameters (`r2_eur` and `r2_afr`) and explicitly included the hypothesis `r2_afr < r2_eur`. The proof then simply restated this hypothesis algebraically to demonstrate a gap in clinical benefit. This is vacuous verification: the model was not proving that a gap exists under mathematical genetics theory; it was simply assuming a gap exists and then restating it.

To resolve this, I introduced a new formal structure, `TwoPopModel`:
```lean
structure TwoPopModel where
  r2_source : ℝ
  r2_target : ℝ
  fst : ℝ
  -- ...
  h_r2_target_eq : r2_target = r2_source * (1 - fst) ^ 2
```

This ensures that the target $R^2$ is strictly bound to the source $R^2$ by the evolutionary genetics drift scalar $(1 - F_{st})^2$, which originates fundamentally from population distance. I then formally proved the structural lemma `r2_target_lt_r2_source` demonstrating that the gap naturally arises from this system because $(1 - F_{st})^2 < 1$.

Finally, I refactored the downstream parity theorems (`clinical_benefit_increases_with_r2`, `portability_creates_benefit_gap`, `disparity_increases_with_distance`, `deployment_amplifies_disparity`, and `qaly_gap_proportional_to_r2_gap`) to accept instances of `TwoPopModel`. Instead of relying on trivial hypotheses, they now unpack the rigorous geometric bound to establish their mathematical truth.

The codebase successfully compiles (`lake build`) and all modified theorems are fully and robustly proved without the use of axioms or sorry tactics.

---
*PR created automatically by Jules for task [9424634595482483445](https://jules.google.com/task/9424634595482483445) started by @SauersML*