### PR TITLE
Fix vacuous verification in differential_ascertainment_artifact

### DIFF
--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -327,14 +327,12 @@ theorem collider_attenuates_association (m : ColliderModel) :
     the apparent portability drop includes an ascertainment component. -/
 theorem differential_ascertainment_artifact
     (r2_source_pop r2_target_pop r2_source_asc r2_target_asc : ℝ)
-    (h_source_asc : r2_source_asc < r2_source_pop)
-    (h_target_asc : r2_target_asc < r2_target_pop)
+    (_h_source_asc : r2_source_asc < r2_source_pop)
+    (_h_target_asc : r2_target_asc < r2_target_pop)
     -- Different ascertainment severity
     (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
-    -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
+    -- True portability drop is larger than apparent portability drop
+    r2_source_pop - r2_target_pop > r2_source_asc - r2_target_asc := by
   linarith
 
 end ColliderBias


### PR DESCRIPTION
Refactor differential_ascertainment_artifact to directly prove inequality rather than using vacuous verification

Strengthened the theorem `differential_ascertainment_artifact` in `proofs/Calibrator/StratificationConfounding.lean` to rigorously state and prove the actual mathematical inequality directly (e.g. `r2_source_pop - r2_target_pop > r2_source_asc - r2_target_asc`), rather than expressing it as a vacuous implication to `False` (where a trivially false assumption implies `False`). Also prefixed unused hypotheses with underscores to suppress linter warnings.

---
*PR created automatically by Jules for task [18321029914233847832](https://jules.google.com/task/18321029914233847832) started by @SauersML*