### PR TITLE
refactor(SelectionArchitecture): resolve vacuous verification in `neutral_expected_shift_zero`

### DIFF
--- a/proofs/Calibrator/SelectionArchitecture.lean
+++ b/proofs/Calibrator/SelectionArchitecture.lean
@@ -475,10 +475,26 @@ noncomputable def polygenicAdaptationShift
 /-- **Under neutral drift, expected shift is zero.**
     E[Δpᵢ] = 0 under drift, so E[Δμ] = 0. -/
 theorem neutral_expected_shift_zero
-    {m : ℕ} (β : Fin m → ℝ) :
-    polygenicAdaptationShift β (fun _ => 0) = 0 := by
+    {Ω : Type*} (E : ExpFunctional Ω)
+    {m : ℕ} (β : Fin m → ℝ) (Δp : Fin m → Ω → ℝ)
+    (h_drift : ∀ i, E (Δp i) = 0) :
+    E (fun ω => polygenicAdaptationShift β (fun i => Δp i ω)) = 0 := by
   unfold polygenicAdaptationShift
-  simp
+  have h_pull : (fun ω => ∑ i, β i * Δp i ω) = (∑ i, fun ω => β i * Δp i ω) := by
+    funext ω
+    simp only [Finset.sum_apply]
+  rw [h_pull]
+  rw [E.eval_sum]
+  have h_zero : ∑ i : Fin m, E (fun ω => β i * Δp i ω) = 0 := by
+    apply Finset.sum_eq_zero
+    intro i _
+    have h1 : (fun ω => β i * Δp i ω) = β i • (Δp i) := by
+      funext ω
+      rfl
+    rw [h1, E.smul_eval]
+    rw [h_drift i]
+    ring
+  exact h_zero
 
 /-- **Under selection, shift is nonzero and directional.**
     If selection favors higher trait values, Δpᵢ > 0 for positive-effect


### PR DESCRIPTION
This PR addresses a vacuous verification in `proofs/Calibrator/SelectionArchitecture.lean`.

The original theorem `neutral_expected_shift_zero` stated that the phenotypic shift under neutral drift is expected to be zero. However, the theorem simply passed a hardcoded `fun _ => 0` into the calculation, side-stepping the mathematical formulation involving expectation over a probability space and trivially solving to `0`. 

I strengthened the theorem by:
1. Introducing an expectation operator `E : ExpFunctional Ω` over a probability space `Ω`.
2. Assuming the expected frequency shift for each individual allele is zero (`h_drift : ∀ i, E (Δp i) = 0`).
3. Proving that the expected value of the overall polygenic shift is zero by utilizing the linearity of the expectation operator (`E.eval_sum` and `E.smul_eval`).

The theorem now provides a rigorously grounded mathematical proof instead of a trivial calculation. All builds pass cleanly.

---
*PR created automatically by Jules for task [9903640962396445272](https://jules.google.com/task/9903640962396445272) started by @SauersML*