### PR TITLE
Fix specification gaming in theorems

### DIFF
--- a/proofs/Calibrator/ScoreDistribution.lean
+++ b/proofs/Calibrator/ScoreDistribution.lean
@@ -472,11 +472,17 @@ theorem external_vs_internal_differ
 theorem percentile_invariant_to_standardization
     (μ σ : ℝ) (h_σ : 0 < σ) :
     -- Standardization is strictly increasing → preserves order
-    ∀ pgs₁ pgs₂ : ℝ, pgs₁ < pgs₂ →
+    ∀ pgs₁ pgs₂ : ℝ, pgs₁ < pgs₂ ↔
       externallyStandardized pgs₁ μ σ < externallyStandardized pgs₂ μ σ := by
-  intro pgs₁ pgs₂ h
+  intro pgs₁ pgs₂
   unfold externallyStandardized
-  exact div_lt_div_of_pos_right (by linarith) h_σ
+  constructor
+  · intro h
+    exact div_lt_div_of_pos_right (sub_lt_sub_right h μ) h_σ
+  · intro h
+    have h_mul := mul_lt_mul_of_pos_right h h_σ
+    rw [div_mul_cancel₀ _ (ne_of_gt h_σ), div_mul_cancel₀ _ (ne_of_gt h_σ)] at h_mul
+    exact sub_lt_sub_iff_right μ |>.mp h_mul
 
 end Standardization
 

--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -327,14 +327,12 @@ theorem collider_attenuates_association (m : ColliderModel) :
     the apparent portability drop includes an ascertainment component. -/
 theorem differential_ascertainment_artifact
     (r2_source_pop r2_target_pop r2_source_asc r2_target_asc : ℝ)
-    (h_source_asc : r2_source_asc < r2_source_pop)
-    (h_target_asc : r2_target_asc < r2_target_pop)
+    (_h_source_asc : r2_source_asc < r2_source_pop)
+    (_h_target_asc : r2_target_asc < r2_target_pop)
     -- Different ascertainment severity
-    (h_diff_severity : r2_target_pop - r2_target_asc < r2_source_pop - r2_source_asc) :
+    (h_diff_severity : r2_source_pop - r2_source_asc < r2_target_pop - r2_target_asc) :
     -- Apparent portability drop is larger than true portability drop
-    r2_source_asc - r2_target_asc > r2_source_pop - r2_target_pop →
-      False := by
-  intro h
+    (r2_source_pop - r2_target_pop) < (r2_source_asc - r2_target_asc) := by
   linarith
 
 end ColliderBias


### PR DESCRIPTION
Fixes specification gaming/vacuous verification in two theorems.

In `ScoreDistribution.lean`, `percentile_invariant_to_standardization` was strengthened from a one-way implication to a biconditional equivalence. 
In `StratificationConfounding.lean`, `differential_ascertainment_artifact` was refactored. The old version vacuously assumed the exact opposite of its conclusion to trivially prove `False`. The new version states the actual rigorous algebraic relationship natively.

---
*PR created automatically by Jules for task [6707062809424289597](https://jules.google.com/task/6707062809424289597) started by @SauersML*