### PR TITLE
Fix specification gaming in StratificationConfounding and CovarianceStructure

### DIFF
--- a/proofs/Calibrator/CovarianceStructure.lean
+++ b/proofs/Calibrator/CovarianceStructure.lean
@@ -350,21 +350,25 @@ theorem ldsr_increases_with_ell (N h2 M ell₁ ell₂ a : ℝ)
   have : 0 < N * h2 / M := div_pos (mul_pos h_N h_h2) h_M
   nlinarith
 
+/-- Cross-ancestry LDSR estimate. -/
+noncomputable def crossAncestryLDSREstimate (h2_true ell_discovery ell_reference : ℝ) : ℝ :=
+  h2_true * ell_discovery / ell_reference
+
 /-- **Cross-ancestry LDSR.**
     Using LD scores from population A to analyze GWAS from B
     produces biased h² estimates. The bias direction depends on
     whether LD_A > LD_B or LD_A < LD_B. -/
 theorem cross_ancestry_ldsr_biased
-    (h2_true h2_estimated ell_discovery ell_reference : ℝ)
-    (h_formula : h2_estimated = h2_true * ell_discovery / ell_reference)
+    (h2_true ell_discovery ell_reference : ℝ)
     (h_mismatch : ell_discovery ≠ ell_reference)
     (h_true : 0 < h2_true) (h_ref : 0 < ell_reference) :
-    h2_estimated ≠ h2_true := by
-  rw [h_formula]
+    crossAncestryLDSREstimate h2_true ell_discovery ell_reference ≠ h2_true := by
+  unfold crossAncestryLDSREstimate
   intro h
   apply h_mismatch
   have h_ne : h2_true ≠ 0 := h_true.ne'
-  field_simp at h
+  have href_ne : ell_reference ≠ 0 := h_ref.ne'
+  rw [div_eq_iff href_ne] at h
   nlinarith
 
 end LDScore

--- a/proofs/Calibrator/StratificationConfounding.lean
+++ b/proofs/Calibrator/StratificationConfounding.lean
@@ -775,15 +775,15 @@ theorem larger_sample_more_power
 
     Worked example: Wang et al.'s finding of R² ≈ 0.5% for
     distance-on-error illustrates this. -/
+noncomputable def requiredSampleSize (r2 : ℝ) : ℝ := 1 / r2
+
 theorem small_effect_needs_large_n
-    (r2_effect n_required ub : ℝ)
-    (h_small : r2_effect ≤ ub) (h_ub_pos : 0 < ub)
-    (h_formula : n_required ≥ 1 / r2_effect)
+    (r2_effect ub : ℝ)
+    (h_small : r2_effect ≤ ub) (_h_ub_pos : 0 < ub)
     (h_effect_pos : 0 < r2_effect) :
-    n_required ≥ 1 / ub := by
-  calc n_required ≥ 1 / r2_effect := h_formula
-    _ ≥ 1 / ub := by
-        exact div_le_div_of_nonneg_left (le_of_lt one_pos) h_effect_pos h_small
+    requiredSampleSize ub ≤ requiredSampleSize r2_effect := by
+  unfold requiredSampleSize
+  exact div_le_div_of_nonneg_left (le_of_lt zero_lt_one) h_effect_pos h_small
 
 end PowerAnalysis
 


### PR DESCRIPTION
Fixes specification gaming by eliminating 'begging the question' in two core theorems.

---
*PR created automatically by Jules for task [14753030584072314584](https://jules.google.com/task/14753030584072314584) started by @SauersML*