### PR TITLE
fix: idempotent Rayon global thread-pool init (fixes `gnomon all` SIGABRT)

### DIFF
--- a/cli/all.rs
+++ b/cli/all.rs
@@ -69,6 +69,15 @@ pub fn run(opts: AllOptions) -> Result<(), Box<dyn std::error::Error>> {
     println!("Score path: {}", opts.score.display());
     println!("Projection model: {}", opts.model);
 
+    // Bring up Rayon's global thread pool ONCE, up front, before any phase
+    // touches a parallel primitive. The VCF→PLINK conversion in phase 1
+    // (`convert_genome`) runs `into_par_iter()`, which would otherwise lazily
+    // initialize the global pool with rayon's defaults; the later `score`
+    // phase's explicit `build_global()` would then race that and abort the
+    // process (the historical `gnomon all` SIGABRT). This idempotent helper
+    // configures the pool first and makes every subsequent init a no-op.
+    gnomon::parallel::init_global_thread_pool();
+
     // --- Phase 1: ensure PLINK fileset (single VCF scan, cached for reuse) ---
     let format = detect_input_format(&vcf_path).ok_or_else(|| -> Box<dyn std::error::Error> {
         format!(

--- a/map/main.rs
+++ b/map/main.rs
@@ -541,6 +541,11 @@ fn run_project_inner(
     println!("=== Sample projection into PCA space ===");
     println!("Input genotype location: {}", genotype_path.display());
 
+    // Idempotently ensure Rayon's global pool is up. Harmless if a prior phase
+    // already initialized it (e.g. `gnomon all`); required for the standalone
+    // `gnomon-map` binary, which otherwise relies on lazy initialization.
+    crate::parallel::init_global_thread_pool();
+
     let dataset = open_dataset(genotype_path)?;
     println!(
         "Resolved genotype data file: {}",

--- a/score/main.rs
+++ b/score/main.rs
@@ -32,7 +32,7 @@ use std::fmt::Write as FmtWrite;
 use std::fs::{self, OpenOptions};
 use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Once};
+use std::sync::Arc;
 use std::time::Instant;
 
 // ========================================================================================
@@ -152,15 +152,13 @@ fn fnv1a64_hex8(bytes: &[u8]) -> String {
 // Function removed to eliminate dead code warnings
 
 /// Core implementation that takes args as parameter
-static RAYON_INIT: Once = Once::new();
-
 fn run_gnomon_impl(args: Args) -> Result<(), Box<dyn Error + Send + Sync>> {
     // Initialize the Rayon global thread pool to use all available cores.
-    RAYON_INIT.call_once(|| {
-        rayon::ThreadPoolBuilder::new()
-            .build_global()
-            .expect("failed to initialize Rayon global thread pool");
-    });
+    // Routed through the shared, idempotent helper so that the multi-phase
+    // `gnomon all` driver (where the VCF→PLINK conversion may have already
+    // brought up the global pool lazily) cannot abort on a racing
+    // `build_global()`.
+    gnomon::parallel::init_global_thread_pool();
 
     let overall_start_time = Instant::now();
     let score_arg_str = args.score.to_string_lossy().to_string();

--- a/shared/lib.rs
+++ b/shared/lib.rs
@@ -4,6 +4,12 @@
 #![deny(unused_imports)]
 #![deny(clippy::no_effect_underscore_binding)]
 
+/// Centralized, idempotent Rayon global thread-pool initialization. Used by
+/// every Rayon-using phase (`score`, `project`, `terms`) so that the
+/// multi-phase `gnomon all` driver cannot abort on a racing `build_global()`.
+#[cfg(any(feature = "score", feature = "map", feature = "terms"))]
+pub mod parallel;
+
 #[cfg(any(feature = "score", feature = "map", feature = "terms"))]
 pub mod files;
 

--- a/shared/parallel.rs
+++ b/shared/parallel.rs
@@ -1,0 +1,95 @@
+//! Centralized, idempotent initialization of Rayon's global thread pool.
+//!
+//! # Why this exists
+//!
+//! Rayon exposes a single process-wide *global* thread pool. It can be
+//! configured explicitly exactly once via
+//! [`rayon::ThreadPoolBuilder::build_global`]; a second call — or a call made
+//! *after* the pool has already been brought up — returns
+//! [`rayon::ThreadPoolBuildError`] (`GlobalPoolAlreadyInitialized`).
+//!
+//! Crucially, Rayon also initializes the global pool **lazily** the first time
+//! any parallel primitive runs (`par_iter`, `rayon::scope`, `rayon::join`,
+//! faer's rayon backend, etc.). So by the time an explicit `build_global()`
+//! runs, the pool may already exist even though nobody called `build_global()`
+//! before.
+//!
+//! `gnomon all` is the path that exposes this: it runs the `score`, `project`
+//! and `terms` phases inside a *single* process. Phase 1 (VCF→PLINK conversion
+//! via `convert_genome`) executes `into_par_iter()`, which lazily stands up the
+//! global pool. The later `score` phase then calls `build_global()`, which now
+//! fails because the pool already exists — and the original code `.expect(..)`d
+//! that result, aborting the whole process with SIGABRT (-6).
+//!
+//! The fix is to funnel *every* global-pool initialization through a single
+//! guarded helper that:
+//!   * runs the explicit `build_global()` at most once (via [`Once`]), and
+//!   * treats `GlobalPoolAlreadyInitialized` as success rather than a fatal
+//!     error (the pool exists with sensible defaults, which is all we need).
+
+use std::sync::Once;
+
+static RAYON_GLOBAL_INIT: Once = Once::new();
+
+/// Initialize Rayon's global thread pool exactly once, idempotently.
+///
+/// Safe to call from any phase (`score`, `project`, `terms`, …) and any number
+/// of times. The first call attempts an explicit
+/// [`rayon::ThreadPoolBuilder::build_global`] using all available cores. If the
+/// global pool has *already* been initialized — whether by a prior call here or
+/// lazily by an earlier `par_iter`/faer/etc. — that condition is swallowed:
+/// the pool exists, which is exactly the desired end state.
+///
+/// This makes the multi-phase single-process path (`gnomon all`) safe: no
+/// phase can abort the process by racing a second `build_global()`.
+pub fn init_global_thread_pool() {
+    RAYON_GLOBAL_INIT.call_once(|| {
+        match rayon::ThreadPoolBuilder::new().build_global() {
+            Ok(()) => {}
+            Err(err) => {
+                // The only expected error is that the global pool was already
+                // brought up (e.g. lazily by a prior parallel op in another
+                // phase). That is fine — the pool is live and usable. We log
+                // for observability but do NOT abort: aborting here is exactly
+                // the `gnomon all` SIGABRT bug this helper exists to prevent.
+                eprintln!(
+                    "> Rayon global thread pool already initialized; reusing existing pool ({err})."
+                );
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::init_global_thread_pool;
+    use rayon::prelude::*;
+
+    /// Reproduces the `gnomon all` multi-phase single-process abort scenario:
+    /// an early phase (here: the VCF→PLINK conversion's `into_par_iter`)
+    /// lazily brings up Rayon's global pool, and a LATER phase then tries to
+    /// configure it explicitly. The historical code `.expect()`d
+    /// `build_global()` and aborted with SIGABRT when the pool already existed.
+    ///
+    /// The whole point of `init_global_thread_pool` is that this must NOT
+    /// panic, regardless of which phase touched the pool first.
+    #[test]
+    fn idempotent_init_after_lazy_pool_bringup_does_not_panic() {
+        // Phase-1 stand-in: any parallel primitive lazily initializes the
+        // global pool with rayon's defaults.
+        let lazy_sum: u64 = (0u64..10_000).into_par_iter().sum();
+        assert_eq!(lazy_sum, 49_995_000);
+
+        // Phase-2/3/4 stand-in: explicit init AFTER the pool already exists.
+        // Pre-fix this aborted the process; now it is a swallowed no-op.
+        init_global_thread_pool();
+
+        // And calling it repeatedly (every phase calls it) is still safe.
+        init_global_thread_pool();
+        init_global_thread_pool();
+
+        // The pool remains fully usable afterwards.
+        let post: u64 = (0u64..10_000).into_par_iter().sum();
+        assert_eq!(post, 49_995_000);
+    }
+}


### PR DESCRIPTION
## Root cause

`gnomon all` (cli/all.rs) runs **score → project → terms in one process**. Phase 1 (VCF→PLINK conversion via the external `convert_genome` crate) executes `into_par_iter()`, which **lazily brings up Rayon's global thread pool** with rayon's defaults. The later `score` phase then ran:

```rust
rayon::ThreadPoolBuilder::new().build_global().expect("…");
```

Because the global pool already existed, `build_global()` returned `Err(GlobalPoolAlreadyInitialized)`, and `.expect(..)` aborted the entire process with **SIGABRT (-6)**.

The pre-existing `static RAYON_INIT: Once` guard did **not** help: the conflicting initialization came from rayon's *lazy* global pool (phase 1), not from a second call to that `Once`. Standalone `gnomon score` never hit this because its `build_global()` runs at the very top of `run_gnomon_impl`, before any conversion — only the `all` driver runs a parallel phase first.

## Fix

Funnel **every** global-pool initialization through one guarded helper, `gnomon::parallel::init_global_thread_pool()` (new `shared/parallel.rs`), that:

- runs `build_global()` at most once (via `Once`), and
- treats `GlobalPoolAlreadyInitialized` as **success** (the pool exists with sensible defaults — exactly the desired end state) instead of aborting.

Wired through:
- `score/main.rs` — replaces the local `Once`+`.expect()` init.
- `map/main.rs` (`run_project_inner`) — was relying on lazy init; now explicit + idempotent.
- `cli/all.rs` — inits **up front**, before phase 1, so the pool is configured before `convert_genome` can lazily stand it up, and every later phase is a no-op.

`terms` uses no Rayon primitives directly, so the up-front `all` init covers it.

## Test

`shared/parallel.rs` adds a regression test that reproduces the exact ordering: lazily init the pool via `into_par_iter()` (phase-1 stand-in), then call `init_global_thread_pool()` (later-phase stand-in) and assert **no panic**, then confirm the pool is still usable. Passes:

```
test parallel::tests::idempotent_init_after_lazy_pool_bringup_does_not_panic ... ok
```

`cargo build --release` (full `gnomon` binary) green. No new clippy warnings introduced by this change.

## pgsEngine adoption

- **No CLI change. No model-digest change.** The expected model digest (`7797520466dae…984c0` for `hwe_1kg_hgdp_gsa_v3`) and the cache-sidecar contract are untouched. pgsEngine can bump its gnomon pin to this commit without changing its sidecar.
- This fix is what lets pgsEngine call `gnomon all` (score+project+terms in one process) without the SIGABRT.

## Out of scope (documented, not changed)

- **VCF→PLINK OOM**: the full-genotype-matrix materialization lives in the external `convert_genome` crate, not this repo; a streaming rewrite belongs there.
- **Offline model-cache without sidecar**: the built-in registry only pins each model's `.zst` digest, not its JSON content hash, so there is no built-in JSON digest to validate a sidecar-less cache against. Implementing this cleanly would require adding a `json_sha256` field to every `BuiltinModel` and pinning per-model JSON hashes — a registry-wide change that risks shifting the digest contract pgsEngine pins against. Left as-is per "implement only if clean."
- Pre-existing clippy `panicking_overflow_checks` error at `map/fit.rs:3824` is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)